### PR TITLE
[S0-AUDIT] KB entries from Sprint 0 audit

### DIFF
--- a/kb/patterns/playwright-local-server.md
+++ b/kb/patterns/playwright-local-server.md
@@ -1,0 +1,25 @@
+# Playwright Local Server Pattern
+
+**Source:** Sprint 0 (Patch, S0-001)
+
+## Pattern
+Use Playwright's built-in `webServer` config to auto-start a local server for tests, rather than requiring manual server setup or testing against live URLs.
+
+## Implementation
+```js
+// playwright.config.js
+webServer: {
+  command: 'npx serve -l 8080 -s _site',
+  port: 8080,
+  reuseExistingServer: true,
+  timeout: 10000,
+}
+```
+
+## Why
+- Tests are reproducible (not dependent on deploy state)
+- CI doesn't need a separate server step
+- `reuseExistingServer: true` allows running tests locally while dev server is up
+
+## Anti-pattern
+Testing against live URLs (e.g., `github.io`) in the verify stage couples verification to prior deployment. Use local server for verify; live URL tests are post-deploy smoke tests only.

--- a/kb/troubleshooting/godot-web-export.md
+++ b/kb/troubleshooting/godot-web-export.md
@@ -1,0 +1,15 @@
+# Godot Web Export Requirements
+
+**Source:** Sprint 0 (Patch, S0-001)
+
+## Problem
+Godot web exports fail or produce broken builds if the renderer isn't set correctly.
+
+## Solution
+- Use `gl_compatibility` renderer in `project.godot` (`renderer/rendering_method="gl_compatibility"`)
+- Vulkan (default) does NOT work for HTML5/web exports
+- Export preset must target "Web" platform with `variant/thread_support=false` for broadest browser compatibility
+
+## Also
+- Headless browsers (CI) lack WebGL — Godot stays in loading state. This is expected, not a bug.
+- Godot's HTML shell hides `<body>` until WASM engine loads. Test for canvas presence in DOM, not body visibility.


### PR DESCRIPTION
## KB Entries from Sprint 0 Audit

Two knowledge base entries extracted from agent transcripts:

1. **kb/troubleshooting/godot-web-export.md** — Godot web export renderer requirements, headless browser limitations
2. **kb/patterns/playwright-local-server.md** — Using Playwright webServer config for reproducible testing

**Source:** Specc Sprint 0 audit, learning extraction from Patch (S0-001) and Optic (S0-002) sessions.