### PR TITLE
[S3-AUDIT] KB entries from Sprint 3 audit

### DIFF
--- a/kb/troubleshooting/godot-web-export.md
+++ b/kb/troubleshooting/godot-web-export.md
@@ -10,6 +10,10 @@ Godot web exports fail or produce broken builds if the renderer isn't set correc
 - Vulkan (default) does NOT work for HTML5/web exports
 - Export preset must target "Web" platform with `variant/thread_support=false` for broadest browser compatibility
 
+## Entry Point
+- `run/main_scene` in `project.godot` determines what the web export loads. If you add a new main scene (e.g., `game_main.tscn` replacing `main.tscn`), update this setting or the deployed game will show the old scene.
+- **Source:** Sprint 3 — web export showed Sprint 1 arena demo until entry point was updated.
+
 ## Also
 - Headless browsers (CI) lack WebGL — Godot stays in loading state. This is expected, not a bug.
 - Godot's HTML shell hides `<body>` until WASM engine loads. Test for canvas presence in DOM, not body visibility.


### PR DESCRIPTION
Adds entry point section to `kb/troubleshooting/godot-web-export.md`.

Sprint 3 revealed that changing the main scene without updating `project.godot` `run/main_scene` causes the web export to show the old scene. This was the root cause of Sprint 2's P4 finding (web export drift).

No new KB files — the existing entry was the right place for this info.