### PR TITLE
[S4-005] Pacing v3 — 1.5x HP, 90s timeout

### DIFF
--- a/godot/combat/combat_sim.gd
+++ b/godot/combat/combat_sim.gd
@@ -9,7 +9,7 @@ const MAX_ENERGY: float = 100.0
 const ENERGY_REGEN_PER_TICK: float = 5.0 / 10.0
 const CRIT_CHANCE: float = 0.05
 const CRIT_MULT: float = 1.5
-const MATCH_TIMEOUT_TICKS: int = 120 * 10
+const MATCH_TIMEOUT_TICKS: int = 90 * 10
 const BOT_HITBOX_RADIUS: float = 12.0
 const TILE_SIZE: float = 32.0
 

--- a/godot/data/chassis_data.gd
+++ b/godot/data/chassis_data.gd
@@ -1,4 +1,4 @@
-## Static chassis definitions — Sprint 4: HP doubled for pacing
+## Static chassis definitions — Sprint 4: 1.5x HP for pacing (v3)
 class_name ChassisData
 extends RefCounted
 
@@ -7,7 +7,7 @@ enum ChassisType { SCOUT, BRAWLER, FORTRESS }
 const CHASSIS := {
 	ChassisType.SCOUT: {
 		"name": "Scout",
-		"hp": 200,
+		"hp": 150,
 		"speed": 220.0, # px/s
 		"weight_cap": 30,
 		"weapon_slots": 2,
@@ -17,7 +17,7 @@ const CHASSIS := {
 	},
 	ChassisType.BRAWLER: {
 		"name": "Brawler",
-		"hp": 300,
+		"hp": 225,
 		"speed": 120.0,
 		"weight_cap": 55,
 		"weapon_slots": 2,
@@ -27,7 +27,7 @@ const CHASSIS := {
 	},
 	ChassisType.FORTRESS: {
 		"name": "Fortress",
-		"hp": 360,
+		"hp": 270,
 		"speed": 60.0,
 		"weight_cap": 80,
 		"weapon_slots": 2,

--- a/godot/tests/test_sprint4.gd
+++ b/godot/tests/test_sprint4.gd
@@ -10,9 +10,9 @@ func _init() -> void:
 	print("=== BattleBrotts Sprint 4 Test Suite ===\n")
 	
 	# --- PACING TESTS ---
-	_test_scout_hp_tripled()
-	_test_brawler_hp_tripled()
-	_test_fortress_hp_tripled()
+	_test_scout_hp_1_5x()
+	_test_brawler_hp_1_5x()
+	_test_fortress_hp_1_5x()
 	_test_tick_rate_halved()
 	_test_match_timeout_ticks()
 	_test_energy_regen_per_tick()
@@ -83,20 +83,20 @@ func assert_near(a: float, b: float, eps: float, msg: String) -> void:
 
 # ============= PACING =============
 
-func _test_scout_hp_tripled() -> void:
-	print("test_scout_hp_tripled")
+func _test_scout_hp_1_5x() -> void:
+	print("test_scout_hp_1_5x")
 	var ch := ChassisData.get_chassis(ChassisData.ChassisType.SCOUT)
-	assert_eq(ch["hp"], 200, "Scout HP = 200")
+	assert_eq(ch["hp"], 150, "Scout HP = 150 (1.5x base)")
 
-func _test_brawler_hp_tripled() -> void:
-	print("test_brawler_hp_tripled")
+func _test_brawler_hp_1_5x() -> void:
+	print("test_brawler_hp_1_5x")
 	var ch := ChassisData.get_chassis(ChassisData.ChassisType.BRAWLER)
-	assert_eq(ch["hp"], 300, "Brawler HP = 300")
+	assert_eq(ch["hp"], 225, "Brawler HP = 225 (1.5x base)")
 
-func _test_fortress_hp_tripled() -> void:
-	print("test_fortress_hp_tripled")
+func _test_fortress_hp_1_5x() -> void:
+	print("test_fortress_hp_1_5x")
 	var ch := ChassisData.get_chassis(ChassisData.ChassisType.FORTRESS)
-	assert_eq(ch["hp"], 360, "Fortress HP = 360")
+	assert_eq(ch["hp"], 270, "Fortress HP = 270 (1.5x base)")
 
 func _test_tick_rate_halved() -> void:
 	print("test_tick_rate_halved")
@@ -104,7 +104,7 @@ func _test_tick_rate_halved() -> void:
 
 func _test_match_timeout_ticks() -> void:
 	print("test_match_timeout_ticks")
-	assert_eq(CombatSim.MATCH_TIMEOUT_TICKS, 1200, "MATCH_TIMEOUT = 120 * 10 = 1200")
+	assert_eq(CombatSim.MATCH_TIMEOUT_TICKS, 900, "MATCH_TIMEOUT = 90 * 10 = 900")
 
 func _test_energy_regen_per_tick() -> void:
 	print("test_energy_regen_per_tick")
@@ -265,8 +265,8 @@ func _test_brott_setup_uses_tripled_hp() -> void:
 	b.chassis_type = ChassisData.ChassisType.SCOUT
 	b.weapon_types = [WeaponData.WeaponType.MINIGUN]
 	b.setup()
-	assert_eq(b.max_hp, 200, "Scout BrottState max_hp = 200")
-	assert_near(b.hp, 200.0, 0.01, "Scout BrottState hp = 200")
+	assert_eq(b.max_hp, 150, "Scout BrottState max_hp = 150")
+	assert_near(b.hp, 150.0, 0.01, "Scout BrottState hp = 150")
 
 func _test_combat_sim_ticks_per_sec() -> void:
 	print("test_combat_sim_ticks_per_sec")
@@ -276,7 +276,7 @@ func _test_combat_sim_ticks_per_sec() -> void:
 func _test_combat_match_timeout() -> void:
 	print("test_combat_match_timeout")
 	var sim := CombatSim.new(42)
-	assert_eq(sim.MATCH_TIMEOUT_TICKS, 1200, "Match timeout = 1200 ticks")
+	assert_eq(sim.MATCH_TIMEOUT_TICKS, 900, "Match timeout = 900 ticks")
 
 func _test_death_sets_death_timer() -> void:
 	print("test_death_sets_death_timer")


### PR DESCRIPTION
## Pacing Fix v3

Previous attempts:
- **v1 (3x HP):** 70s avg match — too slow
- **v2 (2x HP):** 57s avg match — still slow

Tick rate halving (20→10 TPS) amplifies HP changes, so smaller multiplier needed.

### Changes
- **Scout:** 100 → 150 HP (1.5x base)
- **Brawler:** 150 → 225 HP (1.5x base)
- **Fortress:** 180 → 270 HP (1.5x base)
- **Match timeout:** 120s → 90s (caps worst case)
- Updated test assertions in test_sprint4.gd

### Files Changed
- `godot/data/chassis_data.gd`
- `godot/combat/combat_sim.gd`
- `godot/tests/test_sprint4.gd`