### PR TITLE
[S4-006] Add overtime aggression — fix 27% timeout rate

### DIFF
--- a/docs/gdd.md
+++ b/docs/gdd.md
@@ -350,6 +350,7 @@ Example: Any Brott → 20 🔩 repair on win, 50 🔩 on loss, regardless of equ
 - **Win condition**: Reduce all enemy Brotts' HP to 0
 - **Loss condition**: All your Brotts reach 0 HP
 - **Draw condition**: If neither side is eliminated after **120 seconds**, the side with higher total remaining HP% wins. If tied, it's a draw (counts as a loss for progression, but awards 40 🔩).
+- **Overtime Aggression** (60s): If the match timer exceeds 60 seconds, both Brotts enter **Overtime** — their stance is forced to 🔥 "Go Get 'Em!" (overriding BrottBrain), movement speed increases by 20%, and an "OVERTIME!" banner appears on screen. This mechanic prevents stalemates from defensive/kiting builds orbiting outside weapon range and guarantees decisive outcomes. Target: <5% timeout rate.
 - **Target match length**: 30–60 seconds for 1v1, 45–90 seconds for 2v2/3v3. 120 sec timeout prevents stalemate builds.
 
 ---

--- a/godot/arena/arena_renderer.gd
+++ b/godot/arena/arena_renderer.gd
@@ -46,6 +46,11 @@ var death_zoom_timer: float = 0.0
 var death_slow_mo_timer: float = 0.0
 var death_debris: Array = []
 
+# Overtime visual state
+var overtime_flash_timer: float = 0.0
+var overtime_banner_alpha: float = 0.0
+var overtime_triggered: bool = false
+
 # Hit flash tracking (max 1 flash per 3 frames)
 var last_flash_frame: Dictionary = {}  # brott -> last flash frame
 var frame_count: int = 0
@@ -356,6 +361,16 @@ func tick_visuals() -> void:
 	if death_slow_mo_timer > 0:
 		death_slow_mo_timer -= 1.0
 	
+	# Update overtime banner
+	if sim.overtime_active and not overtime_triggered:
+		overtime_triggered = true
+		overtime_flash_timer = 60.0  # 1 sec flash
+		overtime_banner_alpha = 1.0
+	if overtime_flash_timer > 0:
+		overtime_flash_timer -= 1.0
+	if overtime_triggered:
+		overtime_banner_alpha = maxf(0.4, overtime_banner_alpha - 0.01)  # fade to persistent 0.4
+
 	# Update brott visual state
 	for b: BrottState in sim.brotts:
 		if b.flash_timer > 0:
@@ -438,6 +453,10 @@ func _draw() -> void:
 	# Match result
 	if sim.match_over:
 		_draw_match_result(draw_offset)
+	
+	# Overtime banner
+	if overtime_triggered:
+		_draw_overtime_banner(draw_offset)
 
 func _draw_brott(b: BrottState, draw_offset: Vector2) -> void:
 	var pos: Vector2 = b.position + draw_offset
@@ -515,3 +534,16 @@ func _draw_match_result(draw_offset: Vector2) -> void:
 		col = Color.RED
 	var center: Vector2 = draw_offset + Vector2(ARENA_PX / 2.0, ARENA_PX / 2.0)
 	draw_string(ThemeDB.fallback_font, center - Vector2(60, 0), text, HORIZONTAL_ALIGNMENT_CENTER, 120, 32, col)
+
+func _draw_overtime_banner(draw_offset: Vector2) -> void:
+	var center: Vector2 = draw_offset + Vector2(ARENA_PX / 2.0, 40.0)
+	var alpha: float = overtime_banner_alpha
+	# Pulsing effect when flash is active
+	if overtime_flash_timer > 0:
+		alpha = clampf(sin(overtime_flash_timer * 0.3) * 0.5 + 1.0, 0.5, 1.0)
+	var col := Color(1.0, 0.3, 0.1, alpha)
+	# Outline
+	var outline_col := Color(0, 0, 0, alpha * 0.8)
+	for off in [Vector2(-1, 0), Vector2(1, 0), Vector2(0, -1), Vector2(0, 1)]:
+		draw_string(ThemeDB.fallback_font, center - Vector2(60, 0) + off, "OVERTIME!", HORIZONTAL_ALIGNMENT_CENTER, 120, 20, outline_col)
+	draw_string(ThemeDB.fallback_font, center - Vector2(60, 0), "OVERTIME!", HORIZONTAL_ALIGNMENT_CENTER, 120, 20, col)

--- a/godot/combat/brott_state.gd
+++ b/godot/combat/brott_state.gd
@@ -51,6 +51,7 @@ var stance: int = 0  # 0=aggressive, 1=defensive, 2=kiting, 3=ambush
 # BrottBrain
 var brain: RefCounted = null  # BrottBrain instance
 var _pending_gadget: String = ""  # Set by brain, consumed by combat_sim
+var overtime: bool = false  # Set by CombatSim when overtime triggers
 
 # Target
 var target: BrottState = null

--- a/godot/combat/combat_sim.gd
+++ b/godot/combat/combat_sim.gd
@@ -10,6 +10,8 @@ const ENERGY_REGEN_PER_TICK: float = 5.0 / 10.0
 const CRIT_CHANCE: float = 0.05
 const CRIT_MULT: float = 1.5
 const MATCH_TIMEOUT_TICKS: int = 90 * 10
+const OVERTIME_TICKS: int = 60 * 10  # 600 ticks = 60s — triggers overtime aggression
+const OVERTIME_SPEED_MULT: float = 1.2  # +20% movement speed in overtime
 const BOT_HITBOX_RADIUS: float = 12.0
 const TILE_SIZE: float = 32.0
 
@@ -19,6 +21,7 @@ var rng: RandomNumberGenerator
 var tick_count: int = 0
 var match_over: bool = false
 var winner_team: int = -1
+var overtime_active: bool = false
 
 signal on_damage(target: BrottState, amount: float, is_crit: bool, pos: Vector2)
 signal on_projectile_spawned(proj: Projectile)
@@ -38,6 +41,14 @@ func simulate_tick() -> void:
 		return
 	tick_count += 1
 	
+	# Check overtime trigger
+	if not overtime_active and tick_count >= OVERTIME_TICKS:
+		overtime_active = true
+		for b in brotts:
+			if b.alive:
+				b.stance = 0  # Force Aggressive
+				b.overtime = true
+
 	for b in brotts:
 		if not b.alive:
 			continue
@@ -85,6 +96,10 @@ func _evaluate_brain(b: BrottState) -> void:
 		if b._pending_gadget != "":
 			_activate_gadget_by_name(b, b._pending_gadget)
 			b._pending_gadget = ""
+	
+	# Overtime: force aggressive stance (overrides BrottBrain)
+	if overtime_active:
+		b.stance = 0
 
 func _find_target(b: BrottState) -> BrottState:
 	var best: BrottState = null
@@ -212,6 +227,8 @@ func _move_brott(b: BrottState) -> void:
 	if b.target == null:
 		return
 	var spd: float = b.get_effective_speed() * TICK_DELTA
+	if overtime_active:
+		spd *= OVERTIME_SPEED_MULT
 	
 	# Check movement override from brain
 	var move_override: String = ""

--- a/godot/tests/test_sprint4.gd
+++ b/godot/tests/test_sprint4.gd
@@ -50,6 +50,13 @@ func _init() -> void:
 	_test_death_sets_death_timer()
 	_test_flash_timer_on_damage()
 	
+	# --- OVERTIME AGGRESSION TESTS ---
+	_test_overtime_ticks_constant()
+	_test_overtime_triggers_at_60s()
+	_test_overtime_forces_aggressive_stance()
+	_test_overtime_speed_boost()
+	_test_no_overtime_before_60s()
+	
 	print("\n=== Results: %d passed, %d failed, %d total ===" % [pass_count, fail_count, test_count])
 	
 	if fail_count > 0:
@@ -320,6 +327,71 @@ func _test_flash_timer_on_damage() -> void:
 	# Flash timer should have been set at some point (3.0 per hit)
 	# We can't check exact value since it decrements, but it proves damage pathway works
 	assert_true(true, "Damage pathway exercised without crash")
+
+# ============= OVERTIME AGGRESSION =============
+
+func _test_overtime_ticks_constant() -> void:
+	print("test_overtime_ticks_constant")
+	assert_eq(CombatSim.OVERTIME_TICKS, 600, "OVERTIME_TICKS = 60 * 10 = 600")
+
+func _test_overtime_triggers_at_60s() -> void:
+	print("test_overtime_triggers_at_60s")
+	var sim := CombatSim.new(42)
+	var b := _make_brott(0, ChassisData.ChassisType.BRAWLER)
+	b.stance = 1  # Defensive
+	b.setup()
+	var enemy := _make_brott(1, ChassisData.ChassisType.BRAWLER)
+	enemy.stance = 1  # Defensive
+	enemy.position = Vector2(12 * 32.0, 8 * 32.0)  # Far apart to avoid kills
+	enemy.setup()
+	sim.add_brott(b)
+	sim.add_brott(enemy)
+	# Simulate to tick 600
+	for _i in range(600):
+		sim.simulate_tick()
+	assert_true(sim.overtime_active, "Overtime active at tick 600")
+
+func _test_overtime_forces_aggressive_stance() -> void:
+	print("test_overtime_forces_aggressive_stance")
+	var sim := CombatSim.new(42)
+	var b := _make_brott(0, ChassisData.ChassisType.SCOUT)
+	b.stance = 2  # Kiting
+	b.setup()
+	var enemy := _make_brott(1, ChassisData.ChassisType.FORTRESS)
+	enemy.stance = 1  # Defensive
+	enemy.position = Vector2(14 * 32.0, 8 * 32.0)
+	enemy.setup()
+	sim.add_brott(b)
+	sim.add_brott(enemy)
+	for _i in range(601):
+		sim.simulate_tick()
+	# Both should be forced to aggressive (0)
+	if b.alive:
+		assert_eq(b.stance, 0, "Player forced to Aggressive in overtime")
+	else:
+		assert_true(true, "Brott died before overtime check — skip")
+	if enemy.alive:
+		assert_eq(enemy.stance, 0, "Enemy forced to Aggressive in overtime")
+	else:
+		assert_true(true, "Enemy died before overtime check — skip")
+
+func _test_overtime_speed_boost() -> void:
+	print("test_overtime_speed_boost")
+	assert_near(CombatSim.OVERTIME_SPEED_MULT, 1.2, 0.001, "Overtime speed multiplier = 1.2")
+
+func _test_no_overtime_before_60s() -> void:
+	print("test_no_overtime_before_60s")
+	var sim := CombatSim.new(42)
+	var b := _make_brott(0, ChassisData.ChassisType.BRAWLER)
+	b.setup()
+	var enemy := _make_brott(1, ChassisData.ChassisType.BRAWLER)
+	enemy.position = Vector2(14 * 32.0, 8 * 32.0)
+	enemy.setup()
+	sim.add_brott(b)
+	sim.add_brott(enemy)
+	for _i in range(599):
+		sim.simulate_tick()
+	assert_true(not sim.overtime_active, "Overtime NOT active at tick 599")
 
 # ============= HELPERS =============
 


### PR DESCRIPTION
## Problem
Optic found 27.5% of matches timeout because bots orbit outside weapon range (defensive/kiting stances). Matches that DO finish are 15-20s — perfect pacing. The problem is movement AI, not HP.

## Solution: Overtime Aggression Mechanic
When match timer exceeds 60s (600 ticks at 10 TPS):
1. **Both bots forced to Aggressive stance** (overrides BrottBrain)
2. **Movement speed +20%**
3. **"OVERTIME!" visual banner** on screen with pulse/fade effect

This forces engagement and guarantees decisive outcomes.

## Changes
- `combat_sim.gd`: Added `OVERTIME_TICKS`, `OVERTIME_SPEED_MULT` constants, `overtime_active` flag, stance override in `_evaluate_brain`, speed boost in `_move_brott`
- `brott_state.gd`: Added `overtime` bool flag
- `arena_renderer.gd`: Overtime banner with pulsing flash and persistent display
- `docs/gdd.md`: Documented Overtime Aggression as a designed mechanic in Match Format section
- `test_sprint4.gd`: 5 new tests (constant value, trigger timing, stance override, speed boost, no early trigger)

**Target: <5% timeout rate**