### PR TITLE
[S5-AUDIT] KB entries from Sprint 5 audit

### DIFF
--- a/kb/patterns/shrinking-arena-pacing.md
+++ b/kb/patterns/shrinking-arena-pacing.md
@@ -1,0 +1,32 @@
+# Shrinking Arena as Pacing Forcing Function
+
+**Source:** Sprint 4-5 (S4-008, verified in S5-002)
+
+## Problem
+Defensive/kiting bot builds cause matches to time out. Adjusting HP, damage, and aggression mechanics reduced but didn't eliminate the problem. The root cause is *disengagement* — bots stay out of weapon range.
+
+## Key Insight
+**Long matches ≠ too much HP.** If matches that finish are correctly paced (15-20s) but many time out, the problem is engagement, not durability. Don't keep tuning HP when bots aren't fighting.
+
+## Solution: Shrinking Arena
+At overtime (60s), the arena boundary contracts at 0.5 tiles/sec toward center. Bots outside the boundary take 10 damage/sec (ignores armor). By 80s the safe area is zero — bots MUST fight.
+
+Combined with damage amplification (1.5× at 60s, 2× at 75s), this brought timeout rate from 30.4% → 1.8%.
+
+## Why It Works
+1. **Addresses root cause** (disengagement) not symptom (long matches)
+2. **Non-destructive to normal pacing** — only activates at 60s, most matches finish by 40s
+3. **Creates urgency without randomness** — deterministic, predictable, counterplayable
+4. **Visualizable** — red danger zone overlay gives clear feedback to player
+
+## Anti-Pattern: HP Tuning Loop
+Sprint 4 burned 3 iterations tuning HP (3× → 2× → 1.5×) before realizing HP wasn't the problem. The verification data showed this clearly after round 1, but it took 2 more rounds to pivot. **Always read the verification data before choosing a fix.**
+
+## Iteration History
+| Round | Fix | Timeout Rate |
+|-------|-----|-------------|
+| 1 | 3× HP, 10 TPS | 30.4% |
+| 2 | 2× HP | ~25% (est) |
+| 3 | 1.5× HP, 90s timeout | ~27% |
+| 4 | Overtime aggression + damage amp | ~20% |
+| 5 | Shrinking arena | 1.8% ✅ |

--- a/kb/troubleshooting/godot-web-export.md
+++ b/kb/troubleshooting/godot-web-export.md
@@ -14,6 +14,27 @@ Godot web exports fail or produce broken builds if the renderer isn't set correc
 - `run/main_scene` in `project.godot` determines what the web export loads. If you add a new main scene (e.g., `game_main.tscn` replacing `main.tscn`), update this setting or the deployed game will show the old scene.
 - **Source:** Sprint 3 — web export showed Sprint 1 arena demo until entry point was updated.
 
+## set_script() Fails in Web Exports
+
+**Source:** Sprint 5 (S5-001)
+
+**Problem:** `Node2D.new()` followed by `set_script(load("res://script.gd"))` does NOT register virtual method overrides (`_draw()`, `_process()`, etc.) in Godot web exports. The node loads but virtual methods never fire — result is a blank/invisible node.
+
+**Fix:** Preload the script and instantiate directly:
+```gdscript
+# WRONG (breaks in web export):
+var node = Node2D.new()
+node.set_script(load("res://my_script.gd"))
+
+# RIGHT:
+var MyScript = preload("res://my_script.gd")
+var node = MyScript.new()
+```
+
+**Why:** In web exports, `set_script()` on an already-constructed bare node doesn't re-register virtual method overrides. The node's vtable is fixed at construction time. `preload().new()` constructs with the script already attached, so overrides register correctly.
+
+**Rule:** Never use `set_script()` for nodes that rely on virtual methods. Always use `preload().new()`.
+
 ## Also
 - Headless browsers (CI) lack WebGL — Godot stays in loading state. This is expected, not a bug.
 - Godot's HTML shell hides `<body>` until WASM engine loads. Test for canvas presence in DOM, not body visibility.


### PR DESCRIPTION
## KB Updates from Sprint 5 Audit

### Updated: `kb/troubleshooting/godot-web-export.md`
- Added `set_script()` web export gotcha (Sprint 5 blank battle root cause)

### New: `kb/patterns/shrinking-arena-pacing.md`
- Shrinking arena as pacing forcing function
- Documents the Sprint 4→5 iteration anti-pattern (HP tuning loop)
- Key insight: long matches ≠ too much HP; diagnose engagement vs durability