### PR TITLE
[S7-001] Bug fixes — brottbrain type error, KB cleanup, test fixes

### DIFF
--- a/godot/ui/brottbrain_screen.gd
+++ b/godot/ui/brottbrain_screen.gd
@@ -136,7 +136,7 @@ func _build_ui() -> void:
 	add_child(move_down)
 	
 	# Available cards tray
-	var tray_y := max(y + 15, 380)
+	var tray_y: int = maxi(y + 15, 380)
 	var tray_hdr := Label.new()
 	tray_hdr.text = "── Available Cards ──"
 	tray_hdr.add_theme_font_size_override("font_size", 14)

--- a/kb/troubleshooting/godot-web-export.md
+++ b/kb/troubleshooting/godot-web-export.md
@@ -16,24 +16,28 @@ Godot web exports fail or produce broken builds if the renderer isn't set correc
 
 ## set_script() Fails in Web Exports
 
-**Source:** Sprint 5 (S5-001)
+**Source:** Sprint 5 (S5-001), updated Sprint 7
 
 **Problem:** `Node2D.new()` followed by `set_script(load("res://script.gd"))` does NOT register virtual method overrides (`_draw()`, `_process()`, etc.) in Godot web exports. The node loads but virtual methods never fire — result is a blank/invisible node.
 
-**Fix:** Preload the script and instantiate directly:
+**Fix:** Use scene instantiation — create a `.tscn` scene with the script attached, then preload and instantiate it:
 ```gdscript
 # WRONG (breaks in web export):
 var node = Node2D.new()
 node.set_script(load("res://my_script.gd"))
 
-# RIGHT:
+# ALSO WRONG (Script.new() is unreliable in web exports):
 var MyScript = preload("res://my_script.gd")
 var node = MyScript.new()
+
+# RIGHT — scene instantiation:
+var scene = preload("res://my_node.tscn")
+var node = scene.instantiate()
 ```
 
-**Why:** In web exports, `set_script()` on an already-constructed bare node doesn't re-register virtual method overrides. The node's vtable is fixed at construction time. `preload().new()` constructs with the script already attached, so overrides register correctly.
+**Why:** In web exports, both `set_script()` and `Script.new()` can fail to properly register virtual method overrides. Scene instantiation (`preload().instantiate()`) is the only reliable method because Godot fully constructs the node with its script and overrides during scene loading.
 
-**Rule:** Never use `set_script()` for nodes that rely on virtual methods. Always use `preload().new()`.
+**Rule:** Never use `set_script()` or bare `Script.new()` for nodes that rely on virtual methods in web exports. Always use scene instantiation (`preload("res://scene.tscn").instantiate()`).
 
 ## Also
 - Headless browsers (CI) lack WebGL — Godot stays in loading state. This is expected, not a bug.


### PR DESCRIPTION
## Changes

### Fix 1: brottbrain_screen.gd Variant inference error
- Line 139: `max(y + 15, 380)` returns `Variant`, which cant be inferred by `:=`
- Fixed by using `maxi()` (integer-specific) with explicit `int` type annotation

### Fix 2: KB cleanup — godot-web-export.md
- Removed contradictory Sprint 5 advice that said `preload().new()` was the fix
- Updated to reflect the correct fix: scene instantiation (`preload(scene.tscn).instantiate()`)
- Clearly marked `Script.new()` as also unreliable in web exports

### Fix 3: Test verification
- Ran full test suite: 65 passed, 6 failed, 71 total
- All 6 failures are **pre-existing on main** (HP values, energy regen, tick count, repair nanites)
- No new failures introduced by these changes