### PR TITLE
feat(kb): [S8-AUDIT] KB entries — Godot CI import + hub-and-spoke orchestration

### DIFF
--- a/kb/patterns/openclaw-hub-and-spoke.md
+++ b/kb/patterns/openclaw-hub-and-spoke.md
@@ -1,0 +1,28 @@
+# OpenClaw Subagents Cannot Spawn Subagents
+
+**Source:** Sprint 8 — agent chaining prototype failed
+**Date:** 2026-04-16
+
+## Constraint
+
+OpenClaw subagents do not have `sessions_spawn` in their toolset. Only the main agent can spawn subagents.
+
+## Implication
+
+Multi-agent chains (A → B → C → D) where each agent spawns the next are **structurally impossible**. The pipeline must use **hub-and-spoke** orchestration:
+
+```
+Main Agent (The Bott)
+  ├── spawns → Nutts (build)
+  ├── spawns → Boltz (review)
+  ├── spawns → Optic (verify)
+  └── spawns → Specc (audit)
+```
+
+Each agent runs independently and reports back to The Bott. The Bott decides when to spawn the next stage.
+
+## Why This Matters
+
+- Don't design pipelines that assume agent-to-agent spawning
+- Don't try to work around this with cron jobs or message triggers (creates fragile, compliance-reliant processes)
+- If OpenClaw adds subagent spawning in the future, revisit the chain architecture then

--- a/kb/troubleshooting/godot-ci-project-import.md
+++ b/kb/troubleshooting/godot-ci-project-import.md
@@ -1,0 +1,36 @@
+# Godot CI: Project Import Required Before Tests
+
+**Source:** Sprint 8 audit — Godot unit test CI job fails on first run
+**Date:** 2026-04-16
+
+## Problem
+
+Running `godot --headless --path godot/ --script res://tests/test_runner.gd` in CI fails with:
+
+```
+SCRIPT ERROR: Parse Error: Could not find type "ChassisData" in the current scope.
+```
+
+All autoloads (`ChassisData`, `WeaponData`, `CombatSim`, etc.) are unresolved.
+
+## Cause
+
+Godot must import the project before autoloads are registered. A local Godot install has the project already imported (cached in `.godot/`), but a fresh CI environment does not.
+
+## Fix
+
+Add an import step before running tests:
+
+```yaml
+- name: Import Godot project
+  run: godot --headless --path godot/ --import
+
+- name: Run Godot tests
+  run: godot --headless --path godot/ --script res://tests/test_runner.gd
+```
+
+Alternative: `godot --headless --path godot/ --editor --quit` also triggers import.
+
+## Key Insight
+
+Tests passing locally but failing in CI is almost always a missing import. The `.godot/` directory (which contains imported resources and autoload registrations) is gitignored and must be regenerated in CI.


### PR DESCRIPTION
## KB Entries from Sprint 8 Audit

### 1. `kb/troubleshooting/godot-ci-project-import.md`
Godot CI jobs fail if project isn't imported first. Autoloads unresolved without `.godot/`. Fix: add `godot --headless --import` step.

### 2. `kb/patterns/openclaw-hub-and-spoke.md`
OpenClaw subagents can't spawn other subagents. Pipeline must use hub-and-spoke orchestration from main agent.

Both from Sprint 8 audit findings.