### PR TITLE
[S9-001] Fix CI/CD + require status checks

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -18,6 +18,9 @@ jobs:
           chmod +x Godot_v4.4.1-stable_linux.x86_64
           sudo mv Godot_v4.4.1-stable_linux.x86_64 /usr/local/bin/godot
 
+      - name: Import Godot resources
+        run: godot --headless --path godot/ --import 2>&1 || true
+
       - name: Run Godot tests
         run: godot --headless --path godot/ --script res://tests/test_runner.gd
 


### PR DESCRIPTION
## What changed
- Added `godot --import` step before running Godot tests in `verify.yml`
- This generates `.import` files needed by the test runner

## Why
Without the import step, Godot tests fail because resources/assets are not imported and `.import` files are missing. The `--import` flag tells Godot to process all resources before exiting.

## How to verify
- CI should pass on this PR
- The Godot Unit Tests job now runs import before test execution