### PR TITLE
[S10.1] fix: bot separation, battle sim tests, varied stances, shop scroll

### DIFF
--- a/godot/combat/combat_sim.gd
+++ b/godot/combat/combat_sim.gd
@@ -315,6 +315,20 @@ func _move_brott(b: BrottState) -> void:
 			3:  # Ambush
 				pass
 	
+	# Bot-bot separation force — prevent overlapping
+	var min_sep: float = BOT_HITBOX_RADIUS * 2.5  # 30px minimum separation
+	for other in brotts:
+		if other == b or not other.alive:
+			continue
+		var sep: Vector2 = b.position - other.position
+		var sep_dist: float = sep.length()
+		if sep_dist < min_sep and sep_dist > 0.01:
+			var push: float = (min_sep - sep_dist) * 0.5
+			b.position += sep.normalized() * push
+		elif sep_dist <= 0.01:
+			# Perfectly overlapping — push in arbitrary direction
+			b.position += Vector2(BOT_HITBOX_RADIUS, 0)
+	
 	var arena_px: float = 16.0 * TILE_SIZE
 	b.position.x = clampf(b.position.x, BOT_HITBOX_RADIUS, arena_px - BOT_HITBOX_RADIUS)
 	b.position.y = clampf(b.position.y, BOT_HITBOX_RADIUS, arena_px - BOT_HITBOX_RADIUS)

--- a/godot/game/opponent_data.gd
+++ b/godot/game/opponent_data.gd
@@ -30,7 +30,7 @@ static func get_league_opponents(league: String) -> Array:
 					"weapons": [WeaponData.WeaponType.PLASMA_CUTTER],
 					"armor": ArmorData.ArmorType.PLATING,
 					"modules": [],
-					"stance": 0,
+					"stance": 1,  # Defensive
 					"brain": null,
 				},
 				{
@@ -40,7 +40,7 @@ static func get_league_opponents(league: String) -> Array:
 					"weapons": [WeaponData.WeaponType.PLASMA_CUTTER, WeaponData.WeaponType.SHOTGUN],
 					"armor": ArmorData.ArmorType.NONE,
 					"modules": [],
-					"stance": 0,
+					"stance": 2,  # Kiting
 					"brain": null,
 				},
 			]

--- a/godot/tests/test_runner.gd
+++ b/godot/tests/test_runner.gd
@@ -14,6 +14,7 @@ func _init() -> void:
 	_run_combat_tests()
 	_run_module_tests()
 	_run_movement_tests()
+	_run_sprint10_tests()
 	
 	print("\n=== Results: %d passed, %d failed, %d total ===" % [pass_count, fail_count, test_count])
 	
@@ -371,3 +372,27 @@ func _make_brott(team: int, chassis: ChassisData.ChassisType) -> BrottState:
 	b.position = Vector2(128, 128)
 	b.setup()
 	return b
+
+func _run_sprint10_tests() -> void:
+	print("\n--- Sprint 10 Tests ---")
+	# Stalemate detection: 300-tick sim, bots should move
+	var sim := CombatSim.new()
+	sim.rng_seed = 42
+	var bd := {"name": "TestBot", "hp": 100, "max_hp": 100, "armor_dr": 0, "speed": 3.0,
+		"weapons": [{"type": "plasma_cutter", "damage": 10, "cooldown": 5, "range": 80.0, "projectile_speed": 200.0}],
+		"stance": 0, "team": 0, "modules": [], "chassis": "standard"}
+	var bd2 := bd.duplicate(true)
+	bd2["team"] = 1
+	sim.setup([bd], [bd2])
+	var positions: Array[Vector2] = []
+	for tick in range(300):
+		sim.tick()
+		if tick % 50 == 0 and sim.brotts.size() > 0 and sim.brotts[0].alive:
+			positions.append(sim.brotts[0].position)
+	var moved := false
+	if positions.size() >= 2:
+		for i in range(1, positions.size()):
+			if positions[i].distance_to(positions[0]) > 1.0:
+				moved = true
+				break
+	assert_true(moved, "Sprint10: Bots moved during 300-tick sim")

--- a/godot/tests/test_sprint10.gd
+++ b/godot/tests/test_sprint10.gd
@@ -1,0 +1,118 @@
+## Sprint 10 test suite — Bot separation, battle sim validation
+## Usage: godot --headless --script tests/test_sprint10.gd
+extends SceneTree
+
+var pass_count := 0
+var fail_count := 0
+var test_count := 0
+var _hit_count := 0
+
+const CombatSim = preload("res://combat/combat_sim.gd")
+const BrottData = preload("res://combat/brott_data.gd")
+
+func _init() -> void:
+	print("=== BattleBrotts Sprint 10 Test Suite ===\n")
+
+	test_stalemate_detection()
+	test_bot_separation()
+	test_hit_rate()
+	test_match_resolution()
+
+	print("\n--- Results ---")
+	print("%d passed, %d failed out of %d" % [pass_count, fail_count, test_count])
+	quit(1 if fail_count > 0 else 0)
+
+func _assert(cond: bool, msg: String) -> void:
+	test_count += 1
+	if cond:
+		pass_count += 1
+		print("  PASS: %s" % msg)
+	else:
+		fail_count += 1
+		print("  FAIL: %s" % msg)
+
+func _make_aggressive_bot(team: int) -> Dictionary:
+	return {
+		"name": "TestBot%d" % team,
+		"hp": 100,
+		"max_hp": 100,
+		"armor_dr": 0,
+		"speed": 3.0,
+		"weapons": [{"type": "plasma_cutter", "damage": 10, "cooldown": 5, "range": 80.0, "projectile_speed": 200.0}],
+		"stance": 0,  # Aggressive
+		"team": team,
+		"modules": [],
+		"chassis": "standard"
+	}
+
+func _create_sim(seed_val: int = 0) -> Object:
+	var sim = CombatSim.new()
+	sim.rng_seed = seed_val
+	sim.setup([_make_aggressive_bot(0)], [_make_aggressive_bot(1)])
+	return sim
+
+func test_stalemate_detection() -> void:
+	print("\n-- Stalemate Detection --")
+	var sim = _create_sim(42)
+	var positions: Array[Vector2] = []
+	for tick in range(300):
+		sim.tick()
+		if tick % 50 == 0:
+			if sim.brotts.size() > 0 and sim.brotts[0].alive:
+				positions.append(sim.brotts[0].position)
+	# Check position variance — bots should have moved
+	if positions.size() >= 2:
+		var moved := false
+		for i in range(1, positions.size()):
+			if positions[i].distance_to(positions[0]) > 1.0:
+				moved = true
+				break
+		_assert(moved, "Bots moved during 300-tick sim (not stuck)")
+	else:
+		_assert(false, "Not enough position samples collected")
+
+func test_bot_separation() -> void:
+	print("\n-- Bot Separation --")
+	var sim = _create_sim(42)
+	var min_dist := 99999.0
+	for tick in range(300):
+		sim.tick()
+		# Check all living bot pairs
+		for i in range(sim.brotts.size()):
+			if not sim.brotts[i].alive:
+				continue
+			for j in range(i + 1, sim.brotts.size()):
+				if not sim.brotts[j].alive:
+					continue
+				var d := sim.brotts[i].position.distance_to(sim.brotts[j].position)
+				if d < min_dist:
+					min_dist = d
+	_assert(min_dist >= 12.0, "Min bot distance %.1f >= BOT_HITBOX_RADIUS (12.0)" % min_dist)
+
+func _on_damage(_a, _b, _c, _d) -> void:
+	_hit_count += 1
+
+func test_hit_rate() -> void:
+	print("\n-- Hit Rate --")
+	var sim = _create_sim(42)
+	_hit_count = 0
+	if sim.has_signal("on_damage"):
+		sim.on_damage.connect(_on_damage)
+	for tick in range(300):
+		sim.tick()
+	_assert(_hit_count > 0, "Hits occurred during 300-tick sim (%d hits)" % _hit_count)
+
+func test_match_resolution() -> void:
+	print("\n-- Match Resolution --")
+	var resolved := 0
+	for seed_val in range(10):
+		var sim = _create_sim(seed_val)
+		var finished := false
+		for tick in range(900):
+			sim.tick()
+			if sim.is_match_over():
+				finished = true
+				break
+		if finished:
+			resolved += 1
+	_assert(resolved >= 5, "Match resolution: %d/10 resolved before 900 ticks (need >= 5)" % resolved)

--- a/godot/ui/shop_screen.gd
+++ b/godot/ui/shop_screen.gd
@@ -7,6 +7,7 @@ signal continue_pressed
 
 var game_state: GameState
 var details_expanded: Dictionary = {}  # track which items have stats expanded
+var _item_container: Control  # scroll content container for shop items
 
 func setup(state: GameState) -> void:
 	game_state = state
@@ -25,7 +26,18 @@ func _build_ui() -> void:
 	header.size = Vector2(600, 40)
 	add_child(header)
 	
-	var y_offset := 60
+	# ScrollContainer for shop items
+	var scroll := ScrollContainer.new()
+	scroll.position = Vector2(0, 60)
+	scroll.size = Vector2(1280, 580)  # Leave room for header and continue button
+	scroll.horizontal_scroll_mode = ScrollContainer.SCROLL_MODE_DISABLED
+	add_child(scroll)
+	
+	var scroll_content := Control.new()
+	scroll.add_child(scroll_content)
+	_item_container = scroll_content
+	
+	var y_offset := 0
 	
 	# Weapons section
 	y_offset = _add_section("WEAPONS", y_offset)
@@ -59,6 +71,9 @@ func _build_ui() -> void:
 		var owned: bool = mt in game_state.owned_modules
 		y_offset = _add_shop_item_v2(md, price, owned, "module", mt, y_offset)
 	
+	# Set scroll content height so ScrollContainer knows the full extent
+	scroll_content.custom_minimum_size.y = y_offset
+	
 	# Continue button
 	var btn := Button.new()
 	btn.text = "Continue →"
@@ -74,7 +89,7 @@ func _add_section(title: String, y: int) -> int:
 	lbl.add_theme_font_size_override("font_size", 18)
 	lbl.position = Vector2(20, y)
 	lbl.size = Vector2(300, 30)
-	add_child(lbl)
+	_item_container.add_child(lbl)
 	return y + 30
 
 func _add_shop_item_v2(data: Dictionary, price: int, owned: bool, category: String, type: int, y: int) -> int:
@@ -118,7 +133,7 @@ func _add_shop_item_v2(data: Dictionary, price: int, owned: bool, category: Stri
 	)
 	hbox.add_child(det_btn)
 	
-	add_child(hbox)
+	_item_container.add_child(hbox)
 	y += 30
 	
 	# Description line
@@ -129,7 +144,7 @@ func _add_shop_item_v2(data: Dictionary, price: int, owned: bool, category: Stri
 		desc_lbl.add_theme_color_override("font_color", Color(0.7, 0.7, 0.7))
 		desc_lbl.position = Vector2(60, y)
 		desc_lbl.size = Vector2(600, 20)
-		add_child(desc_lbl)
+		_item_container.add_child(desc_lbl)
 		y += 20
 	
 	# Expanded stats
@@ -143,7 +158,7 @@ func _add_shop_item_v2(data: Dictionary, price: int, owned: bool, category: Stri
 			stat_lbl.add_theme_color_override("font_color", Color(0.5, 0.5, 0.5))
 			stat_lbl.position = Vector2(70, y)
 			stat_lbl.size = Vector2(500, 16)
-			add_child(stat_lbl)
+			_item_container.add_child(stat_lbl)
 			y += 16
 	
 	return y
@@ -171,7 +186,7 @@ func _add_shop_item(item_name: String, price: int, owned: bool, category: String
 		btn.pressed.connect(_on_buy.bind(category, type))
 		hbox.add_child(btn)
 	
-	add_child(hbox)
+	_item_container.add_child(hbox)
 	return y + 30
 
 func _on_buy(category: String, type: int) -> void:


### PR DESCRIPTION
## Sprint 10.1

### Task A: Bot Separation Force (P0)
Added bot-bot separation force in `_move_brott()` to prevent overlapping. Bots now push apart when within 2.5x hitbox radius.

### Task B: Battle Simulation Unit Tests (P0)
New `test_sprint10.gd` with 4 tests: stalemate detection, separation validation, hit rate, and match resolution. Also integrated into `test_runner.gd`.

### Task C: Vary Scrapyard Stances (P1)
Tincan → Defensive (stance 1), Crusher → Kiting (stance 2). Rusty stays Aggressive.

### Task D: Shop Scrolling (P1)
Wrapped shop items in ScrollContainer so items below viewport are accessible via scrolling.