### PR TITLE
[S11.2] fix: cap away juke retreat + add combat instrumentation

### DIFF
--- a/godot/combat/combat_sim.gd
+++ b/godot/combat/combat_sim.gd
@@ -31,6 +31,12 @@ var overtime_active: bool = false
 var sudden_death_active: bool = false
 var arena_boundary_tiles: float = 8.0  # half-size in tiles from center (starts at 8 = full 16x16)
 
+# --- Instrumentation (S11.2) ---
+var shots_fired: Dictionary = {}   # weapon_name -> int
+var shots_hit: Dictionary = {}     # weapon_name -> int
+var first_engagement_tick: int = -1
+var kill_ticks: Dictionary = {}    # bot_name -> tick when killed
+
 signal on_damage(target: BrottState, amount: float, is_crit: bool, pos: Vector2)
 signal on_projectile_spawned(proj: Projectile)
 signal on_death(brott: BrottState)
@@ -434,7 +440,12 @@ func _do_combat_movement(b: BrottState, base_spd: float) -> void:
 				if dist > TILE_SIZE * 0.5:
 					b.position += to_target.normalized() * juke_spd
 			"away":
-				b.position -= to_target.normalized() * juke_spd
+				if b.backup_distance < TILE_SIZE:
+					var step: float = minf(juke_spd, TILE_SIZE - b.backup_distance)
+					b.position -= to_target.normalized() * step
+					b.backup_distance += step
+					if b.backup_distance >= TILE_SIZE:
+						b.juke_active_timer = 0.0  # End juke early — cap reached
 		if b.juke_active_timer <= 0:
 			if b.juke_type == "lateral":
 				b.orbit_direction *= -1
@@ -530,6 +541,12 @@ func _fire_weapons(b: BrottState) -> void:
 		var fire_rate: float = float(wd["fire_rate"]) * b.get_fire_rate_multiplier()
 		b.weapon_cooldowns[i] = float(TICKS_PER_SEC) / fire_rate
 		
+		# Instrumentation: track shots fired
+		var wname: String = str(wd.get("name", str(wt)))
+		shots_fired[wname] = shots_fired.get(wname, 0) + 1
+		if first_engagement_tick < 0:
+			first_engagement_tick = tick_count
+		
 		var pellets: int = int(wd["pellets"])
 		for _p in range(pellets):
 			var is_crit: bool = rng.randf() < CRIT_CHANCE
@@ -610,6 +627,13 @@ func _apply_damage(target: BrottState, base_dmg: float, is_crit: bool, source: B
 		target.hp -= effective
 		target.flash_timer = 3.0
 		on_damage.emit(target, effective, is_crit, hit_pos)
+		# Instrumentation: track shots hit (by source weapon)
+		if source != null:
+			for wt_idx in range(source.weapon_types.size()):
+				var wd_instr: Dictionary = WeaponData.get_weapon(source.weapon_types[wt_idx])
+				var wn: String = str(wd_instr.get("name", str(source.weapon_types[wt_idx])))
+				shots_hit[wn] = shots_hit.get(wn, 0) + 1
+				break  # attribute to first weapon (projectile doesn't track index)
 	
 	var armor_data: Dictionary = ArmorData.get_armor(target.armor_type)
 	if str(armor_data["special"]) == "reflect" and source.alive:
@@ -624,6 +648,9 @@ func _kill_brott(b: BrottState) -> void:
 	b.alive = false
 	b.hp = 0.0
 	b.death_timer = 20.0
+	# Instrumentation: record kill tick
+	if not kill_ticks.has(b.bot_name):
+		kill_ticks[b.bot_name] = tick_count
 	on_death.emit(b)
 
 func _check_match_end() -> void:
@@ -662,6 +689,67 @@ func _check_match_end() -> void:
 
 func get_arena_boundary_tiles() -> float:
 	return arena_boundary_tiles
+
+## --- Instrumentation API (S11.2) ---
+
+func get_hit_rates() -> Dictionary:
+	## Returns {weapon_name: hit_rate_float} for each weapon that fired
+	var result: Dictionary = {}
+	for wname in shots_fired:
+		var fired: int = shots_fired[wname]
+		var hit: int = shots_hit.get(wname, 0)
+		result[wname] = float(hit) / float(fired) if fired > 0 else 0.0
+	return result
+
+func get_ttk_seconds() -> Dictionary:
+	## Returns {bot_name: ttk_seconds} for each bot that died
+	var result: Dictionary = {}
+	var engage_tick: int = first_engagement_tick if first_engagement_tick >= 0 else 0
+	for bname in kill_ticks:
+		var death_tick: int = kill_ticks[bname]
+		result[bname] = float(death_tick - engage_tick) / float(TICKS_PER_SEC)
+	return result
+
+func get_regression_summary() -> Dictionary:
+	## Returns summary stats for regression comparison
+	return {
+		"winner_team": winner_team,
+		"ticks": tick_count,
+		"duration_sec": float(tick_count) / float(TICKS_PER_SEC),
+		"hit_rates": get_hit_rates(),
+		"ttk": get_ttk_seconds(),
+		"overtime": overtime_active,
+		"sudden_death": sudden_death_active,
+	}
+
+static func batch_regression_summary(results: Array[Dictionary]) -> Dictionary:
+	## Aggregate multiple sim summaries into a regression baseline
+	var wins: Dictionary = {}
+	var ttk_list: Array[float] = []
+	var hit_rate_sums: Dictionary = {}
+	var hit_rate_counts: Dictionary = {}
+	for r in results:
+		var w: int = r["winner_team"]
+		wins[w] = wins.get(w, 0) + 1
+		for bname in r["ttk"]:
+			ttk_list.append(r["ttk"][bname])
+		for wname in r["hit_rates"]:
+			hit_rate_sums[wname] = hit_rate_sums.get(wname, 0.0) + r["hit_rates"][wname]
+			hit_rate_counts[wname] = hit_rate_counts.get(wname, 0) + 1
+	var avg_hit_rates: Dictionary = {}
+	for wname in hit_rate_sums:
+		avg_hit_rates[wname] = hit_rate_sums[wname] / float(hit_rate_counts[wname])
+	var avg_ttk: float = 0.0
+	if ttk_list.size() > 0:
+		for t in ttk_list:
+			avg_ttk += t
+		avg_ttk /= float(ttk_list.size())
+	return {
+		"total_sims": results.size(),
+		"win_rates": wins,
+		"avg_ttk_sec": avg_ttk,
+		"avg_hit_rates": avg_hit_rates,
+	}
 
 func _team_hp_pct(team: int) -> float:
 	var total_hp: float = 0.0

--- a/godot/tests/test_sprint11_2.gd
+++ b/godot/tests/test_sprint11_2.gd
@@ -1,0 +1,182 @@
+## Sprint 11.2 test suite — Juke bugfix + Combat Instrumentation
+extends SceneTree
+
+var pass_count := 0
+var fail_count := 0
+var test_count := 0
+
+func _init() -> void:
+	print("=== BattleBrotts Sprint 11.2 Test Suite ===")
+	print("=== Juke Bugfix + Instrumentation ===\n")
+
+	test_away_juke_capped_at_one_tile()
+	test_away_juke_cap_across_seeds()
+	test_hit_rate_instrumentation()
+	test_ttk_instrumentation()
+	test_regression_summary()
+
+	print("\n--- Results ---")
+	print("%d passed, %d failed out of %d" % [pass_count, fail_count, test_count])
+	quit(1 if fail_count > 0 else 0)
+
+func _assert(cond: bool, msg: String) -> void:
+	test_count += 1
+	if cond:
+		pass_count += 1
+		print("  PASS: %s" % msg)
+	else:
+		fail_count += 1
+		print("  FAIL: %s" % msg)
+
+func _make_scout(team: int, stance: int = 0) -> BrottState:
+	var b := BrottState.new()
+	b.team = team
+	b.bot_name = "Scout_%d" % team
+	b.chassis_type = ChassisData.ChassisType.SCOUT
+	b.weapon_types = [WeaponData.WeaponType.PLASMA_CUTTER]
+	b.armor_type = ArmorData.ArmorType.NONE
+	b.module_types = []
+	b.stance = stance
+	b.setup()
+	return b
+
+## Test 1: Away juke retreat never exceeds 1 tile (32px)
+## The bug allowed Scout to retreat 3.3 tiles in a single away juke.
+func test_away_juke_capped_at_one_tile() -> void:
+	print("\n-- Away Juke Cap (direct test) --")
+	var b0 := _make_scout(0)
+	var b1 := _make_scout(1)
+	var sim := CombatSim.new(123)
+	b0.position = Vector2(200, 256)
+	b1.position = Vector2(220, 256)
+	sim.add_brott(b0)
+	sim.add_brott(b1)
+
+	# Force b0 into combat movement with an "away" juke
+	b0.in_combat_movement = true
+	b0.target = b1
+	b0.juke_active_timer = 8.0  # 8 ticks — old bug duration
+	b0.juke_type = "away"
+	b0.backup_distance = 0.0
+
+	var start_pos := b0.position
+	for _t in range(20):
+		sim.simulate_tick()
+
+	var retreat_dist: float = start_pos.distance_to(b0.position)
+	# Allow small margin for separation force but retreat component should be ≤32px
+	_assert(b0.backup_distance <= 32.0 + 0.1, "backup_distance capped: %.1f px (max 32)" % b0.backup_distance)
+
+## Test 2: Across many seeds, no bot retreats >1 tile in a single away juke sequence
+func test_away_juke_cap_across_seeds() -> void:
+	print("\n-- Away Juke Cap (100 seeds) --")
+	var violations := 0
+	for seed_val in range(100):
+		var b0 := _make_scout(0)
+		var b1 := _make_scout(1)
+		var sim := CombatSim.new(seed_val)
+		b0.position = Vector2(200, 256)
+		b1.position = Vector2(220, 256)
+		sim.add_brott(b0)
+		sim.add_brott(b1)
+
+		var prev_pos := b0.position
+		var backup_run := 0.0
+
+		for _t in range(300):
+			if sim.match_over:
+				break
+			sim.simulate_tick()
+			if b0.alive and b0.target != null:
+				var to_target: Vector2 = b0.target.position - b0.position
+				var movement: Vector2 = b0.position - prev_pos
+				if to_target.length() > 0.1 and movement.length() > 0.1:
+					var dot: float = movement.normalized().dot(to_target.normalized())
+					if dot < -0.7:
+						backup_run += movement.length()
+					else:
+						backup_run = 0.0
+				prev_pos = b0.position
+				if backup_run > 32.0 * 1.2:
+					violations += 1
+					break
+
+	_assert(violations == 0, "No moonwalk violations (%d/100)" % violations)
+
+## Test 3: Hit rate instrumentation returns valid data
+func test_hit_rate_instrumentation() -> void:
+	print("\n-- Hit Rate Instrumentation --")
+	var b0 := _make_scout(0)
+	var b1 := _make_scout(1)
+	var sim := CombatSim.new(42)
+	b0.position = Vector2(64, 256)
+	b1.position = Vector2(448, 256)
+	sim.add_brott(b0)
+	sim.add_brott(b1)
+	for _t in range(600):
+		if sim.match_over:
+			break
+		sim.simulate_tick()
+
+	var hit_rates: Dictionary = sim.get_hit_rates()
+	_assert(hit_rates.size() > 0, "Hit rates recorded for %d weapon(s)" % hit_rates.size())
+	for wname in hit_rates:
+		var rate: float = hit_rates[wname]
+		_assert(rate >= 0.0 and rate <= 1.0, "Hit rate for %s: %.2f (valid range)" % [wname, rate])
+
+	# Verify raw counts exist
+	var total_fired := 0
+	for wname in sim.shots_fired:
+		total_fired += sim.shots_fired[wname]
+	_assert(total_fired > 0, "Total shots fired: %d (>0)" % total_fired)
+
+## Test 4: TTK instrumentation returns valid data
+func test_ttk_instrumentation() -> void:
+	print("\n-- TTK Instrumentation --")
+	var b0 := _make_scout(0)
+	var b1 := _make_scout(1)
+	var sim := CombatSim.new(42)
+	b0.position = Vector2(64, 256)
+	b1.position = Vector2(448, 256)
+	sim.add_brott(b0)
+	sim.add_brott(b1)
+	for _t in range(900):  # Run long enough for a kill
+		if sim.match_over:
+			break
+		sim.simulate_tick()
+
+	_assert(sim.first_engagement_tick >= 0, "First engagement tick recorded: %d" % sim.first_engagement_tick)
+
+	var ttk: Dictionary = sim.get_ttk_seconds()
+	if sim.match_over and sim.winner_team != 2:
+		_assert(ttk.size() > 0, "TTK recorded for %d bot(s)" % ttk.size())
+		for bname in ttk:
+			var t: float = ttk[bname]
+			_assert(t >= 0.0, "TTK for %s: %.1fs (non-negative)" % [bname, t])
+	else:
+		_assert(true, "Match was draw/timeout — TTK may be empty (OK)")
+
+## Test 5: Regression summary batch aggregation
+func test_regression_summary() -> void:
+	print("\n-- Regression Summary --")
+	var summaries: Array[Dictionary] = []
+	for seed_val in range(20):
+		var b0 := _make_scout(0)
+		var b1 := _make_scout(1)
+		var sim := CombatSim.new(seed_val)
+		b0.position = Vector2(64, 256)
+		b1.position = Vector2(448, 256)
+		sim.add_brott(b0)
+		sim.add_brott(b1)
+		for _t in range(900):
+			if sim.match_over:
+				break
+			sim.simulate_tick()
+		summaries.append(sim.get_regression_summary())
+
+	var batch: Dictionary = CombatSim.batch_regression_summary(summaries)
+	_assert(batch["total_sims"] == 20, "Batch has 20 sims")
+	_assert(batch.has("win_rates"), "Batch has win_rates")
+	_assert(batch.has("avg_ttk_sec"), "Batch has avg_ttk_sec: %.1fs" % batch["avg_ttk_sec"])
+	_assert(batch.has("avg_hit_rates"), "Batch has avg_hit_rates")
+	print("  Regression baseline: %s" % str(batch))


### PR DESCRIPTION
## Summary

### Task 1: Fix away juke moonwalk bug
The "away" juke type in `_do_combat_movement()` moved bots backward at 120% speed for up to 8 ticks without checking `backup_distance`. Scout could retreat 3.3 tiles in a single juke (spec says max 1 tile / 32px).

**Fix:** Away juke now tracks `backup_distance` and caps cumulative retreat at 32px (1 tile). Juke ends early when cap is reached.

### Task 2: Combat instrumentation
Added to `CombatSim`:
- **Hit rate tracking** — `shots_fired` / `shots_hit` dictionaries, per-weapon. `get_hit_rates()` returns hit rate floats.
- **TTK measurement** — `first_engagement_tick` + `kill_ticks` dictionary. `get_ttk_seconds()` returns TTK per bot.
- **Regression baseline** — `get_regression_summary()` per sim, `batch_regression_summary()` static method aggregates across sims (win rates, avg TTK, avg hit rates).

### Tests (`test_sprint11_2.gd`)
1. **Away juke cap (direct)** — Forces an away juke and verifies backup_distance ≤ 32px
2. **Away juke cap (100 seeds)** — Runs 100 sims checking no bot retreats >1.2 tiles straight back
3. **Hit rate instrumentation** — Verifies hit rates are recorded and in [0, 1] range
4. **TTK instrumentation** — Verifies engagement tick and TTK values are recorded
5. **Regression summary** — Runs 20-sim batch and verifies aggregated baseline output

### Task 3: Skipped
PR #45 merge is Boltz's responsibility.

## How to verify
```bash
godot --headless --script tests/test_sprint11_2.gd
```