### PR TITLE
[S12.1] feat: movement physics + plasma cutter range + overtime tuning

### DIFF
--- a/docs/design/stalemate-fix.md
+++ b/docs/design/stalemate-fix.md
@@ -1,0 +1,263 @@
+# Design Spec: Combat Stalemate Fix
+
+**Author:** Gizmo (Game Designer)
+**Date:** 2026-04-16
+**Sprint:** TBD (for Nutts)
+**Status:** DESIGN READY
+
+---
+
+## Problem Statement
+
+CD playtested Scrapyard and observed: both bots rush center, collide within ~1 second, get stuck overlapping/adjacent, then stand still shooting and mostly missing for the remaining 60+ seconds. Only 1 hit landed in a full minute. This violates the core player fantasy ("holding your breath watching if the next shots will hit") and makes the game look broken on first impression.
+
+**Root cause chain:**
+1. Scrapyard bots both use Aggressive stance ("close to within shortest weapon range")
+2. Both have Plasma Cutter (1.5 tile range) → target distance = 1.5 tiles → effectively 0 after collision
+3. Collision system says "slide along the surface" but provides no separation force → bots get stuck touching
+4. At 0 distance, bots may be inside each other's hitbox or at angles where hit detection fails
+5. No behavior exists to separate, reposition, or circle — just "move toward enemy" forever
+
+---
+
+## Options Analysis
+
+### Option 1: Minimum Engagement Distance
+
+**Description:** Aggressive stance targets `weapon_range × 0.7` instead of `0`. Bot approaches to optimal distance, then holds position. If closer than `weapon_range × 0.4`, bot backs away.
+
+**Pros:**
+- Simple to implement (modify stance movement target)
+- Immediately fixes the rush-and-stick problem
+- Creates natural standoff distance that looks like a firefight
+
+**Cons:**
+- Two bots with the same weapon settle at the same distance and stand still → still boring (just further apart)
+- Doesn't create dynamic movement during combat
+- Backing-away logic can look weird (robots moonwalking)
+
+**Player experience:** Better than current, but still mostly static. 5/10.
+
+---
+
+### Option 2: Separation Force (Physics Repulsion)
+
+**Description:** When two bots' hitboxes overlap or are within 0.5 tiles of each other, apply a repulsion vector that pushes them apart at 50% of their move speed.
+
+**Pros:**
+- Prevents the stuck-together state entirely
+- Simple physics, easy to implement
+- Works regardless of stance or weapon
+
+**Cons:**
+- Only fixes the overlap symptom, not the "rush to center and stand still" behavior
+- Bots still converge to the same spot — they just vibrate near each other
+- Feels like a band-aid, not a real behavior improvement
+
+**Player experience:** Fixes the worst case but doesn't make fights interesting. 4/10.
+
+---
+
+### Option 3: Weapon Minimum Range
+
+**Description:** Weapons have a minimum effective range (e.g., Plasma Cutter: 0.5 tiles, Shotgun: 1 tile). Inside minimum range, weapon cannot fire or deals 50% damage.
+
+**Pros:**
+- Creates mechanical reason to maintain distance
+- Adds a new balance lever per weapon
+- Could create interesting close-range vs. long-range dynamics
+
+**Cons:**
+- Doesn't help if bots have no behavior to respond to "can't fire" — they'll just stand there NOT shooting, which is worse
+- Adds complexity to weapon table
+- Unintuitive for players ("why isn't my gun working?")
+
+**Player experience:** Worse without matching AI improvements. 3/10.
+
+---
+
+### Option 4: Smarter Aggressive Stance (Optimal Range Targeting)
+
+**Description:** Redefine Aggressive to seek `weapon_range × 0.6` (the "sweet spot") instead of minimum range. Add micro-repositioning: when at target distance ±0.5 tiles, bot strafes laterally instead of standing still.
+
+**Pros:**
+- Directly fixes the "rush to zero" behavior
+- Strafing at optimal range looks like actual combat
+- Works within existing system, no new mechanics
+
+**Cons:**
+- Only affects Aggressive stance — other stances could have similar issues
+- Strafing pattern is predictable if always the same direction
+- Doesn't address what happens when bots DO end up touching
+
+**Player experience:** Good — bots fight at range and move laterally. 7/10.
+
+---
+
+### Option 5: Combat Choreography System
+
+**Description:** Add a movement sub-system that runs alongside stances. When a bot is within its engagement range and has line of sight, it enters "combat movement" mode:
+- **Orbit:** Bot circles the target at current distance (direction randomized per engagement, flips on wall collision)
+- **Juke:** Every 1.5–3s (randomized), bot briefly moves toward or away from target by 1–2 tiles, then returns to orbit
+- **Separation:** If within 1 tile of any bot, immediately move perpendicular to the line between them until at 1.5+ tiles
+
+**Pros:**
+- Fights look dynamic and exciting — bots actually MOVE during combat
+- Randomized timing creates tension ("will this shot land?")
+- Works for ALL stances (each stance modifies the orbit distance and juke frequency)
+- Separation prevents the stuck-together state
+- Scales well to 2v2 and 3v3
+
+**Cons:**
+- Most complex to implement
+- Needs tuning to not look erratic
+- Juking could accidentally dodge INTO danger
+
+**Player experience:** Excellent — this is the "two robots actually fighting" fantasy. 9/10.
+
+---
+
+### Option 6: Engagement Distance Per Stance (Hybrid)
+
+**Description:** Each stance defines an `engagement_range_factor` applied to the bot's shortest weapon range. When in engagement range, bot uses combat movement (orbit + juke). Add a hard separation threshold.
+
+| Stance | Engagement Factor | Orbit Speed | Juke Frequency | Juke Distance |
+|--------|------------------|-------------|----------------|---------------|
+| Aggressive | 0.7× weapon range | 80% move speed | Every 2s | 1.5 tiles |
+| Defensive | 1.0× weapon range | 60% move speed | Every 3s | 1 tile |
+| Kiting | 0.8× weapon range | 100% move speed | Every 1.5s | 2 tiles |
+| Ambush | N/A (stationary) | 0 | N/A | N/A |
+
+**Pros:** Combines best of Options 4 and 5. Each stance feels distinct in combat.
+**Cons:** Same complexity concerns as Option 5.
+
+**Player experience:** 9/10.
+
+---
+
+## Recommendation: Option 5 + 2 (Combat Choreography + Separation Force)
+
+### The Full Design
+
+#### A. Separation Force (Safety Net)
+
+When two bots' centers are within **1.0 tile** (32 px) of each other:
+- Apply repulsion vector away from the other bot
+- Repulsion speed: **60% of bot's base move speed**
+- This is a physics-level guarantee — no bot should ever be stuck overlapping another
+
+**Numbers:**
+- Separation threshold: 1.0 tile (32 px center-to-center)
+- Repulsion speed: `base_speed × 0.6`
+- Scout repulsion: 132 px/s, Brawler: 72 px/s, Fortress: 36 px/s
+
+#### B. Combat Movement System
+
+When a bot has a target in LoS and is within weapon range, it enters **Combat Movement** mode. This replaces the current "move toward target and stop" behavior.
+
+**B1. Engagement Distance**
+
+Each stance now defines an **ideal engagement distance** (not "close to zero"):
+
+| Stance | Ideal Distance | Tolerance Band |
+|--------|---------------|----------------|
+| Aggressive | `shortest_weapon_range × 0.65` | ±0.5 tiles |
+| Defensive | `longest_weapon_range × 0.85` | ±1.0 tiles |
+| Kiting | `longest_weapon_range × 0.70` | ±1.0 tiles |
+| Ambush | N/A (hold position) | N/A |
+
+For Scrapyard bots (Scout + Plasma Cutter, range 1.5 tiles, Aggressive):
+- Ideal distance = 1.5 × 0.65 = **~1.0 tile**
+- Tolerance = 0.5–1.5 tiles
+
+For a Brawler + Shotgun (range 3, Aggressive):
+- Ideal distance = 3 × 0.65 = **~2.0 tiles**
+
+**Approach behavior:** If further than ideal + tolerance, move toward target. If closer than ideal − tolerance, back away. If within tolerance band → orbit.
+
+**B2. Orbit**
+
+When within the tolerance band:
+- Bot moves **perpendicular** to the vector between itself and target
+- Direction: randomized (CW or CCW) at start of each engagement, flips when hitting a wall or arena boundary
+- Orbit speed: **70% of base move speed**
+- This creates the "circling" look of two fighters sizing each other up
+
+**Numbers:**
+- Scout orbit: 154 px/s
+- Brawler orbit: 84 px/s
+- Fortress orbit: 42 px/s
+
+**B3. Juking**
+
+While in combat movement, bots periodically **juke** — a brief burst toward or away from the target:
+- Juke interval: randomized between **1.5–3.0 seconds** (uniform distribution)
+- Juke type: 60% chance lateral (perpendicular, flip orbit direction), 30% close (toward target by 1 tile), 10% retreat (away by 1 tile)
+- Juke duration: **0.4 seconds** (8 ticks)
+- Juke speed: **120% of base move speed**
+- After juke ends, resume orbit
+
+This creates the unpredictability that makes watching fights exciting. "Is this juke going to move them into that railgun shot?"
+
+**B4. Re-engagement**
+
+If target breaks LoS (moves behind cover):
+- Bot exits combat movement
+- Resumes stance-based pathfinding to reacquire target
+- Re-enters combat movement when LoS reestablished and within range
+
+#### C. Scrapyard-Specific Impact
+
+With these changes, a Scrapyard match (two Scouts, Plasma Cutters, Aggressive) plays out like:
+
+1. **0–2s:** Both bots rush toward each other (unchanged)
+2. **~2s:** They reach engagement distance (~1 tile apart). Combat movement activates.
+3. **2–60s:** Bots orbit each other, juking unpredictably. Plasma Cutters fire 3×/sec at 1-tile range. Some shots connect during stable orbit, some miss during jukes. Damage accumulates steadily.
+4. **Expected TTK:** With 14 damage/hit, 0° spread at 1 tile, ~70% hit rate during orbiting, ~40% during jukes → avg ~8 damage/sec after armor → Scout (100 HP, Plating 20% reduction) dies in ~16 seconds.
+
+This is right in the Scrapyard TTK target of 15–30s. ✓
+
+#### D. What This Changes in Code
+
+1. **New: `separation_force`** — Applied in Movement phase (tick step 4). If any bot center within 1.0 tile, apply repulsion vector.
+2. **Modified: Stance movement logic** — Replace "move to target" with engagement distance + tolerance band system.
+3. **New: `CombatMovement` state** — Orbit + juke sub-behaviors. Activated when in engagement range with LoS.
+4. **Modified: Aggressive stance definition** — "Close to within shortest weapon range" → "Close to 65% of shortest weapon range, then orbit."
+
+#### E. GDD Text Update (Section 4.3)
+
+Replace the Aggressive stance row:
+
+| Stance | Friendly Name | Movement Behavior | Engagement Behavior |
+|---|---|---|---|
+| **Aggressive** | 🔥 "Go Get 'Em!" | Move toward nearest enemy. Enter combat movement at 65% of shortest weapon range (orbit + juke). | Fire all weapons as soon as in range. Prioritize DPS uptime. |
+
+Add new subsection after 5.3:
+
+> ### 5.3.1 Combat Movement
+> When a Brott has LoS to its target and is within weapon range, it enters combat movement. The Brott orbits its target at its stance's ideal engagement distance, periodically juking laterally, forward, or backward. This creates dynamic, watchable fights where positioning matters.
+>
+> **Separation force:** If two Brotts' centers are within 1.0 tile, a repulsion force pushes them apart at 60% of their base speed. This prevents Brotts from getting stuck overlapping.
+
+---
+
+## Acceptance Criteria (for Optic)
+
+1. **No overlap stalemate:** In 1,000 Scrapyard simulations (Scout vs Scout, Aggressive, Plasma Cutter), 0% of matches should have bots stuck within 0.5 tiles for more than 2 consecutive seconds.
+2. **Movement during combat:** Average distance traveled per bot after first engagement should be >5 tiles per match (currently ~0).
+3. **Hit rate:** Plasma Cutter at 1-tile orbit distance should land 60–80% of shots (not 0%, not 100%).
+4. **TTK in Scrapyard:** 15–30 seconds for Scout vs Scout.
+5. **Match pacing:** At least 1 position change (juke or orbit direction flip) every 3 seconds during combat.
+6. **No moonwalking:** Bots should never back up in a straight line for more than 1 tile. Backing away should transition into orbit.
+7. **Existing stances preserved:** Kiting circle-strafe behavior should still work (it's already an orbit — just ensure it integrates with the new system rather than conflicting). Defensive and Ambush stances should not orbit.
+8. **Regression:** All existing balance metrics (chassis WR, weapon usage, economy flow) should remain within ±5% of current values.
+
+---
+
+## Priority
+
+**HIGH.** This is the first thing a new player sees. If Scrapyard looks broken, they close the game. This should ship before any new content.
+
+---
+
+*Gizmo out. Make 'em dance, Nutts.* 🤖💃

--- a/docs/sprint12-design-spec.md
+++ b/docs/sprint12-design-spec.md
@@ -1,0 +1,260 @@
+# Sprint 12 — Design Spec: Charm & Polish Pass
+
+**Author:** Gizmo (Game Designer)
+**Date:** 2026-04-16
+**Creative Direction:** "Wall-E style robots — mechanical, weighty, slightly clumsy."
+
+---
+
+## 1. Robot Movement Physics
+
+**Player Fantasy:** "My bot is a real machine with weight and momentum — not a cursor sliding on ice."
+
+### Spec
+
+Each chassis gets acceleration, deceleration, and turn-speed values. Movement is no longer instant — bots ramp up and ramp down.
+
+| Chassis | Max Speed (px/s) | Accel (px/s²) | Decel (px/s²) | Turn Speed (°/s) | Turn Accel (°/s²) |
+|---------|------------------|---------------|---------------|-------------------|--------------------|
+| **Scout** | 220 | 660 | 880 | 360 | 720 |
+| **Brawler** | 120 | 240 | 360 | 240 | 480 |
+| **Fortress** | 60 | 90 | 150 | 150 | 300 |
+
+**Derived feel:**
+- **Scout:** 0→max in ~0.33s. Zippy but still has perceptible ramp. Stops in ~0.25s.
+- **Brawler:** 0→max in ~0.50s. Noticeable momentum. Stops in ~0.33s.
+- **Fortress:** 0→max in ~0.67s. Heavy, deliberate. Stops in ~0.40s. You FEEL the weight.
+
+**Turn speed** is how fast the bot can change its facing direction. Bots must turn toward their movement target — they don't snap. This is purely visual; movement direction changes are governed by acceleration (the bot can begin moving in a new direction immediately, but the sprite rotates at turn speed). This creates the "chunky mechanical" feel without impacting gameplay fairness.
+
+**Afterburner interaction:** During Afterburner boost, acceleration is also multiplied by 1.8× (not just max speed). Deceleration remains unchanged — the bot overshoots when the boost ends. This creates a satisfying "rocket brake" moment.
+
+**Combat movement interaction:** Orbit speed (70% of base) and juke bursts (120% of base) are still subject to acceleration curves. Jukes feel punchier on lighter bots and more lumbering on heavy ones.
+
+### Acceptance Criteria
+- [ ] Each chassis accelerates at its specified rate (measure px/s² in sim)
+- [ ] Each chassis decelerates at its specified rate when stopping or reversing
+- [ ] Bot sprites rotate at turn speed (not instant snap)
+- [ ] Fortress takes visibly longer to reach full speed than Scout
+- [ ] Afterburner multiplies acceleration by 1.8× during boost
+- [ ] Combat orbit/juke still functions correctly with acceleration curves
+- [ ] Run 1,000 sims: no stuck bots, no oscillation bugs from accel/decel fighting
+
+---
+
+## 2. Visual Loadout (Bot Preview)
+
+**Player Fantasy:** "I'm in the garage building my robot. I see every piece go on."
+
+### Spec
+
+The bot preview in the loadout screen is a larger version of the in-game bot sprite (96×96 px, 4× scale) that dynamically reflects equipped items.
+
+**Visual layers (bottom to top):**
+1. **Chassis base** — the core body shape (differs per chassis type)
+2. **Armor overlay** — wraps around the chassis. Each armor type has a distinct silhouette:
+   - Plating: thick angular plates on front and sides
+   - Reactive Mesh: glowing wire-frame mesh pattern
+   - Ablative Shell: bulky rounded shell encasing the whole bot
+3. **Weapon mounts** — weapons appear at fixed mount points:
+   - Slot 1: right side of chassis
+   - Slot 2: left side of chassis
+   - Each weapon has a recognizable silhouette (Minigun = barrel cluster, Railgun = long barrel, Shotgun = wide barrel, etc.)
+4. **Module indicators** — small icons/lights on the chassis body:
+   - Each equipped module adds a small glowing element (color-coded)
+   - Overclock: orange light, Repair Nanites: green light, Shield Projector: blue light, Sensor Array: yellow light, Afterburner: red light, EMP Charge: purple light
+
+**Animation:** When an item is equipped, it slides/snaps onto the bot with a brief mechanical animation (0.3s tween + 2-frame "clunk" shake). When removed, it detaches and fades (0.2s).
+
+**In-game:** The in-game 24×24 sprite also reflects equipped weapons (simplified — just the weapon silhouette on the side of the bot). Armor changes the bot's outline/color slightly. Modules are NOT visible in-game (too small).
+
+### Acceptance Criteria
+- [ ] Bot preview updates in real-time when any item is equipped/unequipped
+- [ ] All 7 weapons have distinct silhouettes visible on the preview
+- [ ] All 3 armor types change the bot's appearance visibly
+- [ ] All 6 modules show as colored indicator lights on the preview
+- [ ] Equip animation plays (0.3s snap + shake)
+- [ ] Unequip animation plays (0.2s detach + fade)
+- [ ] In-game sprites show weapon silhouettes and armor outline changes
+- [ ] Preview works correctly for all 3 chassis types
+
+---
+
+## 3. Clear Equipped State (Loadout UI)
+
+**Player Fantasy:** "I can see at a glance what's on my bot and what's in my inventory."
+
+### Spec
+
+**Equipped items:**
+- Card background: **bright blue** (#4A90D9) with a subtle glow border
+- A small **checkmark badge** (✓) in the top-right corner of the card
+- Card is **slightly elevated** (2px drop shadow) to pop off the list
+- Item name rendered in **bold white**
+
+**Unequipped (inventory) items:**
+- Card background: **dark grey** (#3A3A3A), no border glow
+- No badge
+- Flat (no shadow)
+- Item name in **regular grey** text
+
+**Slot indicators on the bot preview:**
+- Empty weapon/module slots show as **dashed outline rectangles** with a "+" icon
+- Filled slots show the item (per section 2)
+
+**Weight budget bar:**
+- Positioned below the bot preview
+- Shows current weight / max weight
+- Color: green (0-70%), yellow (70-90%), red (90-100%)
+- Overweight: bar turns red and flashes, equip button disabled
+
+### Acceptance Criteria
+- [ ] Equipped cards are visually distinct from unequipped at a glance (color + badge + shadow)
+- [ ] Empty slots are clearly indicated with dashed outlines and "+" icon
+- [ ] Weight budget bar updates in real-time when items are equipped/unequipped
+- [ ] Weight bar changes color at 70% and 90% thresholds
+- [ ] Overweight state prevents equipping and shows visual feedback
+- [ ] Screen-reader accessible: equipped state is reflected in item label text
+
+---
+
+## 4. Plasma Cutter Range Buff
+
+**Player Fantasy:** "Close-range brawler weapon that rewards aggressive positioning."
+
+### Spec
+
+| Stat | Before | After | Rationale |
+|------|--------|-------|-----------|
+| Range | 1.5 tiles | 2.5 tiles | At 1.5, bots almost never close enough to fire. 2.5 puts it in the "melee range band" (0-2 tiles) with some breathing room. |
+| Damage | 14 | 14 | No change — DPS is already good IF it fires. |
+| Fire Rate | 3 shots/s | 3 shots/s | No change. |
+| Energy/Shot | 4 | 4 | No change. |
+| Weight | 8 kg | 8 kg | No change. |
+
+**Design intent:** Plasma Cutter is the close-range DPS king. At 2.5 tiles and 42 DPS (14 × 3), it out-damages everything at melee range. The trade-off is the player MUST design a BrottBrain that closes distance. It rewards Aggressive stance and Afterburner combos.
+
+**Interaction with combat movement:** With 2.5 tile range, an Aggressive Brott's ideal engagement distance is 2.5 × 0.65 = 1.625 tiles. This keeps the bot very close while orbiting — visually exciting, high-risk gameplay.
+
+### Acceptance Criteria
+- [ ] Plasma Cutter fires at targets up to 2.5 tiles away
+- [ ] Plasma Cutter does NOT fire beyond 2.5 tiles
+- [ ] Run 1,000 sims with Plasma Cutter builds: fire rate > 0 in at least 80% of matches (was ~10% at 1.5 range)
+- [ ] "Roach" example build (Scout + Plasma Cutter + Ambush) is still viable
+- [ ] Plasma Cutter DPS in practice lands between Shotgun and Minigun for close-range matchups
+
+---
+
+## 5. Overtime Threshold: 60s → 45s
+
+**Player Fantasy:** "Matches have urgency. The clock is always ticking."
+
+### Spec
+
+| Parameter | Before | After |
+|-----------|--------|-------|
+| Overtime trigger | 60s | 45s |
+| Sudden Death trigger | 75s | 60s |
+| Match timeout | 120s | 100s |
+| Arena shrink rate | 0.5 tiles/s | 0.5 tiles/s (unchanged) |
+
+**Reasoning:** CD feedback says overtime feels too late. At 45s, even an evenly-matched fight will feel the pressure before the 1-minute mark. Sudden Death at 60s means the climax hits right at the "target match length" center (45s for 1v1). Timeout shortened proportionally.
+
+**2v2/3v3 adjustment:** Overtime at 60s, Sudden Death at 75s, Timeout at 120s (unchanged for team modes — more bots need more time).
+
+| Mode | Overtime | Sudden Death | Timeout |
+|------|----------|--------------|---------|
+| 1v1 | 45s | 60s | 100s |
+| 2v2 | 60s | 75s | 120s |
+| 3v3 | 60s | 75s | 120s |
+
+**Target match length updated:**
+- 1v1: 25–50s (was 30–60s)
+- 2v2/3v3: 45–90s (unchanged)
+
+### Acceptance Criteria
+- [ ] 1v1 overtime triggers at exactly 45s
+- [ ] 1v1 Sudden Death triggers at exactly 60s
+- [ ] 1v1 timeout at 100s
+- [ ] 2v2/3v3 overtime at 60s, Sudden Death at 75s, timeout at 120s
+- [ ] "OVERTIME!" banner appears at correct threshold per mode
+- [ ] "SUDDEN DEATH!" banner replaces at correct threshold per mode
+- [ ] Run 2,000 1v1 sims: median match length is 35–50s
+- [ ] Run 2,000 1v1 sims: timeout rate < 3%
+- [ ] Arena shrink math still prevents escape (shrink starts at 45s, arena fully collapsed by ~85s for 20-tile arenas)
+
+---
+
+## 6. Overall Charm — Bot Personality & Feel
+
+**Player Fantasy:** "These aren't sprites. These are little guys with personality."
+
+### 6a. Movement Personality
+
+Each chassis has a distinct **idle animation** and **movement quirk:**
+
+| Chassis | Idle Animation | Movement Quirk |
+|---------|---------------|-----------------|
+| **Scout** | Slight hover-bob (1px up/down, 0.8s cycle) | Occasionally does a quick 360° spin when changing direction (10% chance on direction change) |
+| **Brawler** | Subtle side-to-side rock (1px, 1.2s cycle) | Small dust puff particles when starting movement from standstill |
+| **Fortress** | Slow mechanical breathing (0.5px up/down, 2.0s cycle) | Screen micro-shake (0.5px, 0.1s) when Fortress starts or stops moving. Visible gear-grinding particle on deceleration. |
+
+### 6b. Equip Feedback
+
+Beyond the animation in Section 2:
+- **Sound cue:** Mechanical "clunk" on equip, "whirr-click" on unequip (design note for audio — can be placeholder SFX initially)
+- **Bot reaction:** Bot preview does a small "nod" (2px down, 2px up, 0.2s) when an item is equipped, as if acknowledging the new part
+- **Weight feedback:** When equipping a heavy item (>12 kg), the bot preview sinks slightly (1px) and bounces back — it FELT that weight
+
+### 6c. Victory / Defeat Reactions
+
+| Event | Winner Reaction | Loser Reaction |
+|-------|----------------|----------------|
+| **Match End** | Bot does a small spin + jump (4px up, 0.3s) — like a happy hop | Bot slumps down (2px, stays down for 0.5s), then sparks fly from chassis |
+| **Perfect Win (100% HP)** | Double spin + slightly bigger jump (6px) | Same as normal loss |
+| **Close Win (<20% HP)** | Single wobbly spin (bot visibly shaking) — barely made it | Same as normal loss |
+
+### 6d. Combat Flavor
+
+- **Low HP warning:** Below 25% HP, bot starts trailing smoke particles
+- **Critical hit reaction:** On receiving a crit, bot recoils 2px away from attacker (visual only, not gameplay movement)
+- **Module activation flash:** When a module activates, a brief colored ring expands from the bot (matching module color from Section 2)
+- **Overtime tension:** When overtime triggers, all bots' eyes/lights glow brighter (slight emissive increase)
+
+### Acceptance Criteria
+- [ ] All 3 chassis have distinct idle animations at correct rates
+- [ ] Movement quirks trigger at specified rates
+- [ ] Equip "nod" plays on item equip
+- [ ] Heavy item equip causes weight "sink" animation
+- [ ] Victory animation plays for winner (with perfect/close variants)
+- [ ] Defeat animation plays for loser
+- [ ] Smoke particles appear below 25% HP
+- [ ] Crit recoil visual plays on crit hits
+- [ ] Module activation ring plays in correct color
+- [ ] Overtime glow increase is visible
+- [ ] None of these animations affect gameplay logic (purely visual)
+
+---
+
+## GDD Update Section
+
+The following changes should be applied to `docs/gdd.md`:
+
+### Section 3.2 — Weapons Table
+Update Plasma Cutter range: 1.5 → **2.5**
+
+### Section 5.3 — Movement & Targeting (NEW subsection 5.3.2)
+Add **5.3.2 Movement Physics** with the acceleration/deceleration/turn speed table and rules.
+
+### Section 9 — Match Format
+Update overtime/timing values for 1v1 (45s/60s/100s) and clarify 2v2/3v3 keep existing values. Update target match lengths.
+
+### Section 10 — Art Direction (NEW subsection: Bot Personality)
+Add idle animations, movement quirks, victory/defeat reactions, combat flavor effects, and visual loadout spec.
+
+### Section 10 — Art Direction (UPDATE: UI Layout)
+Add visual loadout preview spec and equipped/unequipped card styling.
+
+---
+
+*This spec is the complete design input for Sprint 12. All numbers are final pending playtest results. Ett: plan accordingly.*

--- a/godot/combat/brott_state.gd
+++ b/godot/combat/brott_state.gd
@@ -15,6 +15,9 @@ var module_types: Array[ModuleData.ModuleType] = []
 # Cached stats
 var max_hp: int = 0
 var base_speed: float = 0.0
+var base_accel: float = 0.0
+var base_decel: float = 0.0
+var turn_speed: float = 0.0  # visual only (°/s)
 var dodge_chance: float = 0.0
 
 # Runtime combat state
@@ -22,6 +25,8 @@ var hp: float = 0.0
 var energy: float = 100.0
 var position: Vector2 = Vector2.ZERO
 var velocity: Vector2 = Vector2.ZERO
+var current_speed: float = 0.0  # current movement speed (px/s)
+var facing_angle: float = 0.0  # visual sprite rotation (degrees)
 var alive: bool = true
 
 # Weapon cooldowns (ticks until next fire)
@@ -73,6 +78,9 @@ func setup() -> void:
 	max_hp = ch["hp"]
 	hp = max_hp
 	base_speed = ch["speed"]
+	base_accel = ch["accel"]
+	base_decel = ch["decel"]
+	turn_speed = ch["turn_speed"]
 	dodge_chance = ch["dodge_chance"]
 	energy = 100.0
 	alive = true
@@ -92,6 +100,23 @@ func get_effective_speed() -> float:
 	if afterburner_active:
 		spd *= 1.80
 	return spd
+
+func get_effective_accel() -> float:
+	var accel := base_accel
+	if afterburner_active:
+		accel *= 1.80
+	return accel
+
+func get_effective_decel() -> float:
+	# Decel unchanged by afterburner per spec
+	return base_decel
+
+func accelerate_toward_speed(target_speed: float, dt: float) -> void:
+	## Ramps current_speed toward target_speed using accel/decel curves
+	if current_speed < target_speed:
+		current_speed = minf(current_speed + get_effective_accel() * dt, target_speed)
+	elif current_speed > target_speed:
+		current_speed = maxf(current_speed - get_effective_decel() * dt, target_speed)
 
 func get_fire_rate_multiplier() -> float:
 	if overclock_active:

--- a/godot/combat/combat_sim.gd
+++ b/godot/combat/combat_sim.gd
@@ -9,7 +9,7 @@ const MAX_ENERGY: float = 100.0
 const ENERGY_REGEN_PER_TICK: float = 5.0 / 10.0
 const CRIT_CHANCE: float = 0.05
 const CRIT_MULT: float = 1.5
-const MATCH_TIMEOUT_TICKS: int = 90 * 10
+const MATCH_TIMEOUT_TICKS: int = 100 * 10  # Legacy: matches 1v1 default
 
 # Per-mode overtime thresholds (ticks)
 const OVERTIME_TICKS_1V1: int = 45 * 10   # 450 ticks = 45s

--- a/godot/combat/combat_sim.gd
+++ b/godot/combat/combat_sim.gd
@@ -10,10 +10,20 @@ const ENERGY_REGEN_PER_TICK: float = 5.0 / 10.0
 const CRIT_CHANCE: float = 0.05
 const CRIT_MULT: float = 1.5
 const MATCH_TIMEOUT_TICKS: int = 90 * 10
-const OVERTIME_TICKS: int = 60 * 10  # 600 ticks = 60s — triggers overtime aggression
+
+# Per-mode overtime thresholds (ticks)
+const OVERTIME_TICKS_1V1: int = 45 * 10   # 450 ticks = 45s
+const OVERTIME_TICKS_TEAM: int = 60 * 10  # 600 ticks = 60s
+const SUDDEN_DEATH_TICKS_1V1: int = 60 * 10   # 600 ticks = 60s
+const SUDDEN_DEATH_TICKS_TEAM: int = 75 * 10  # 750 ticks = 75s
+const MATCH_TIMEOUT_TICKS_1V1: int = 100 * 10  # 1000 ticks = 100s
+const MATCH_TIMEOUT_TICKS_TEAM: int = 120 * 10 # 1200 ticks = 120s
+
+# Legacy constants kept for backward compat (default to 1v1)
+const OVERTIME_TICKS: int = 45 * 10
 const OVERTIME_SPEED_MULT: float = 1.2  # +20% movement speed in overtime
 const OVERTIME_DAMAGE_MULT: float = 1.5  # 50% damage amp during overtime (60s+)
-const SUDDEN_DEATH_TICKS: int = 75 * 10  # 750 ticks = 75s — sudden death escalation
+const SUDDEN_DEATH_TICKS: int = 60 * 10   # default 1v1
 const SUDDEN_DEATH_DAMAGE_MULT: float = 2.0  # 100% damage amp during sudden death (75s+)
 const ARENA_SHRINK_RATE: float = 0.5  # tiles per second boundary contracts
 const ARENA_BOUNDARY_DAMAGE: float = 10.0  # damage per second outside boundary (ignores armor)
@@ -30,6 +40,16 @@ var winner_team: int = -1
 var overtime_active: bool = false
 var sudden_death_active: bool = false
 var arena_boundary_tiles: float = 8.0  # half-size in tiles from center (starts at 8 = full 16x16)
+var match_mode: String = "1v1"  # "1v1", "2v2", "3v3" — controls overtime thresholds
+
+func _get_overtime_ticks() -> int:
+	return OVERTIME_TICKS_1V1 if match_mode == "1v1" else OVERTIME_TICKS_TEAM
+
+func _get_sudden_death_ticks() -> int:
+	return SUDDEN_DEATH_TICKS_1V1 if match_mode == "1v1" else SUDDEN_DEATH_TICKS_TEAM
+
+func _get_timeout_ticks() -> int:
+	return MATCH_TIMEOUT_TICKS_1V1 if match_mode == "1v1" else MATCH_TIMEOUT_TICKS_TEAM
 
 # --- Instrumentation (S11.2) ---
 var shots_fired: Dictionary = {}   # weapon_name -> int
@@ -56,7 +76,7 @@ func simulate_tick() -> void:
 	tick_count += 1
 	
 	# Check overtime trigger
-	if not overtime_active and tick_count >= OVERTIME_TICKS:
+	if not overtime_active and tick_count >= _get_overtime_ticks():
 		overtime_active = true
 		for b in brotts:
 			if b.alive:
@@ -64,13 +84,13 @@ func simulate_tick() -> void:
 				b.overtime = true
 	
 	# Check sudden death escalation
-	if not sudden_death_active and tick_count >= SUDDEN_DEATH_TICKS:
+	if not sudden_death_active and tick_count >= _get_sudden_death_ticks():
 		sudden_death_active = true
 
 	# Shrink arena boundary during overtime
 	if overtime_active:
 		var shrink_per_tick: float = ARENA_SHRINK_RATE / float(TICKS_PER_SEC)
-		arena_boundary_tiles = maxf(0.0, 8.0 - (float(tick_count - OVERTIME_TICKS) / float(TICKS_PER_SEC)) * ARENA_SHRINK_RATE)
+		arena_boundary_tiles = maxf(0.0, 8.0 - (float(tick_count - _get_overtime_ticks()) / float(TICKS_PER_SEC)) * ARENA_SHRINK_RATE)
 	
 	# Apply boundary damage to bots outside the shrinking arena
 	if overtime_active:
@@ -319,10 +339,14 @@ func _exit_combat_movement(b: BrottState) -> void:
 
 func _move_brott(b: BrottState) -> void:
 	if b.target == null:
+		# Decelerate to stop
+		b.accelerate_toward_speed(0.0, TICK_DELTA)
 		return
-	var spd: float = b.get_effective_speed() * TICK_DELTA
+	
+	# Determine target speed for this tick
+	var target_speed: float = b.get_effective_speed()
 	if overtime_active:
-		spd *= OVERTIME_SPEED_MULT
+		target_speed *= OVERTIME_SPEED_MULT
 	
 	# Check movement override from brain
 	var move_override: String = ""
@@ -330,6 +354,8 @@ func _move_brott(b: BrottState) -> void:
 		move_override = b.brain.movement_override
 	
 	if move_override == "center":
+		b.accelerate_toward_speed(target_speed, TICK_DELTA)
+		var spd: float = b.current_speed * TICK_DELTA
 		var center := Vector2(8.0 * TILE_SIZE, 8.0 * TILE_SIZE)
 		var to_center := center - b.position
 		if to_center.length() > spd:
@@ -337,6 +363,8 @@ func _move_brott(b: BrottState) -> void:
 		else:
 			b.position = center
 	elif move_override == "cover":
+		b.accelerate_toward_speed(target_speed, TICK_DELTA)
+		var spd: float = b.current_speed * TICK_DELTA
 		var best_pillar := Vector2.ZERO
 		var best_dist := INF
 		for p in _get_pillar_positions():
@@ -351,6 +379,18 @@ func _move_brott(b: BrottState) -> void:
 		var dist: float = to_target.length()
 		var max_weapon_range: float = _get_max_weapon_range_px(b)
 		var has_los: bool = _has_los(b.position, b.target.position)
+		
+		# Determine if bot is actively moving this tick
+		var wants_to_move: bool = true
+		if b.stance == 3:  # Ambush — hold position
+			wants_to_move = false
+		
+		# Accelerate or decelerate based on intent
+		if wants_to_move:
+			b.accelerate_toward_speed(target_speed, TICK_DELTA)
+		else:
+			b.accelerate_toward_speed(0.0, TICK_DELTA)
+		var spd: float = b.current_speed * TICK_DELTA
 		
 		# Combat movement entry/exit
 		if b.stance == 3:  # Ambush — hold position
@@ -389,6 +429,17 @@ func _move_brott(b: BrottState) -> void:
 				3:  # Ambush
 					pass
 	
+	# Update visual facing angle (turn speed is visual-only)
+	if b.target != null:
+		var desired_angle: float = rad_to_deg((b.target.position - b.position).angle())
+		var angle_diff: float = fmod(desired_angle - b.facing_angle + 540.0, 360.0) - 180.0
+		var max_turn: float = b.turn_speed * TICK_DELTA
+		if absf(angle_diff) <= max_turn:
+			b.facing_angle = desired_angle
+		else:
+			b.facing_angle += signf(angle_diff) * max_turn
+		b.facing_angle = fmod(b.facing_angle + 360.0, 360.0)
+	
 	# Bot-bot separation force (S11.1: 32px threshold, 60% base speed)
 	var sep_threshold: float = TILE_SIZE  # 32px = 1 tile
 	for other in brotts:
@@ -426,12 +477,16 @@ func _do_combat_movement(b: BrottState, base_spd: float) -> void:
 	var ideal: float = engage["ideal"]
 	var tolerance: float = engage["tolerance"]
 	
-	# Juke active
+	# Juke active — juke bursts at 120% base speed subject to accel
 	if b.juke_active_timer > 0:
 		b.juke_active_timer -= 1.0
-		var juke_spd: float = b.base_speed * 1.2 * TICK_DELTA
+		var juke_target_speed: float = b.base_speed * 1.2
+		if b.afterburner_active:
+			juke_target_speed *= 1.80
 		if overtime_active:
-			juke_spd *= OVERTIME_SPEED_MULT
+			juke_target_speed *= OVERTIME_SPEED_MULT
+		b.accelerate_toward_speed(juke_target_speed, TICK_DELTA)
+		var juke_spd: float = b.current_speed * TICK_DELTA
 		match b.juke_type:
 			"lateral":
 				var perp: Vector2 = Vector2(-to_target.y, to_target.x).normalized()
@@ -466,10 +521,14 @@ func _do_combat_movement(b: BrottState, base_spd: float) -> void:
 			b.juke_type = "away"
 		return
 	
-	# Normal combat movement
-	var orbit_spd: float = b.base_speed * 0.7 * TICK_DELTA
+	# Normal combat movement — orbit at 70% base speed subject to accel
+	var orbit_target_speed: float = b.base_speed * 0.7
+	if b.afterburner_active:
+		orbit_target_speed *= 1.80
 	if overtime_active:
-		orbit_spd *= OVERTIME_SPEED_MULT
+		orbit_target_speed *= OVERTIME_SPEED_MULT
+	b.accelerate_toward_speed(orbit_target_speed, TICK_DELTA)
+	var orbit_spd: float = b.current_speed * TICK_DELTA
 	
 	if dist > ideal + tolerance:
 		b.position += to_target.normalized() * base_spd
@@ -675,7 +734,7 @@ func _check_match_end() -> void:
 		match_over = true
 		winner_team = 1
 		on_match_end.emit(winner_team)
-	elif tick_count >= MATCH_TIMEOUT_TICKS:
+	elif tick_count >= _get_timeout_ticks():
 		match_over = true
 		var hp_pct_0: float = _team_hp_pct(0)
 		var hp_pct_1: float = _team_hp_pct(1)

--- a/godot/data/chassis_data.gd
+++ b/godot/data/chassis_data.gd
@@ -9,6 +9,9 @@ const CHASSIS := {
 		"name": "Scout",
 		"hp": 150,
 		"speed": 220.0, # px/s
+		"accel": 660.0, # px/s²
+		"decel": 880.0, # px/s²
+		"turn_speed": 360.0, # °/s (visual only)
 		"weight_cap": 30,
 		"weapon_slots": 2,
 		"module_slots": 3,
@@ -19,6 +22,9 @@ const CHASSIS := {
 		"name": "Brawler",
 		"hp": 225,
 		"speed": 120.0,
+		"accel": 240.0,
+		"decel": 360.0,
+		"turn_speed": 240.0,
 		"weight_cap": 55,
 		"weapon_slots": 2,
 		"module_slots": 2,
@@ -29,6 +35,9 @@ const CHASSIS := {
 		"name": "Fortress",
 		"hp": 270,
 		"speed": 60.0,
+		"accel": 90.0,
+		"decel": 150.0,
+		"turn_speed": 150.0,
 		"weight_cap": 80,
 		"weapon_slots": 2,
 		"module_slots": 1,

--- a/godot/data/weapon_data.gd
+++ b/godot/data/weapon_data.gd
@@ -66,7 +66,7 @@ const WEAPONS := {
 		"archetype": "⚡ Melee Blaster",
 		"description": "In-your-face rapid fire beam. Brutal when you can stick to a target.",
 		"damage": 14,
-		"range_tiles": 1.5,
+		"range_tiles": 2.5,
 		"fire_rate": 3.0,
 		"spread_deg": 0.0,
 		"energy_cost": 4,

--- a/godot/tests/test_runner.gd
+++ b/godot/tests/test_runner.gd
@@ -212,11 +212,11 @@ func _run_combat_tests() -> void:
 	sim2.add_brott(b1)
 	sim2.add_brott(b2)
 	
-	# Fast forward to timeout (90s * 10 ticks/sec = 900 ticks)
-	for i in 900:
+	# Fast forward to timeout (100s * 10 ticks/sec = 1000 ticks)
+	for i in 1000:
 		sim2.simulate_tick()
 	assert_true(sim2.match_over, "Match ends at timeout")
-	assert_eq(sim2.tick_count, 900, "Tick count = 900 at timeout")
+	assert_eq(sim2.tick_count, 1000, "Tick count = 1000 at timeout")
 	
 	# Test brott death
 	var sim3 := CombatSim.new(3)

--- a/godot/tests/test_runner.gd
+++ b/godot/tests/test_runner.gd
@@ -205,10 +205,14 @@ func _run_combat_tests() -> void:
 	b1.position = Vector2(256, 256)
 	b1.weapon_types = []
 	b1.weapon_cooldowns = []
+	b1.hp = 99999.0
+	b1.max_hp = 99999
 	var b2 := _make_brott(1, ChassisData.ChassisType.FORTRESS)
 	b2.position = Vector2(260, 260)
 	b2.weapon_types = []
 	b2.weapon_cooldowns = []
+	b2.hp = 99999.0
+	b2.max_hp = 99999
 	sim2.add_brott(b1)
 	sim2.add_brott(b2)
 	
@@ -376,17 +380,22 @@ func _make_brott(team: int, chassis: ChassisData.ChassisType) -> BrottState:
 func _run_sprint10_tests() -> void:
 	print("\n--- Sprint 10 Tests ---")
 	# Stalemate detection: 300-tick sim, bots should move
-	var sim := CombatSim.new()
-	sim.rng_seed = 42
-	var bd := {"name": "TestBot", "hp": 100, "max_hp": 100, "armor_dr": 0, "speed": 3.0,
-		"weapons": [{"type": "plasma_cutter", "damage": 10, "cooldown": 5, "range": 80.0, "projectile_speed": 200.0}],
-		"stance": 0, "team": 0, "modules": [], "chassis": "standard"}
-	var bd2 := bd.duplicate(true)
-	bd2["team"] = 1
-	sim.setup([bd], [bd2])
+	var sim := CombatSim.new(42)
+	var bot_a := _make_brott(0, ChassisData.ChassisType.BRAWLER)
+	bot_a.position = Vector2(64, 128)
+	bot_a.stance = 0  # Aggressive
+	bot_a.weapon_types = [WeaponData.WeaponType.PLASMA_CUTTER]
+	bot_a.weapon_cooldowns = [0.0]
+	var bot_b := _make_brott(1, ChassisData.ChassisType.BRAWLER)
+	bot_b.position = Vector2(448, 384)
+	bot_b.stance = 0  # Aggressive
+	bot_b.weapon_types = [WeaponData.WeaponType.PLASMA_CUTTER]
+	bot_b.weapon_cooldowns = [0.0]
+	sim.add_brott(bot_a)
+	sim.add_brott(bot_b)
 	var positions: Array[Vector2] = []
 	for tick in range(300):
-		sim.tick()
+		sim.simulate_tick()
 		if tick % 50 == 0 and sim.brotts.size() > 0 and sim.brotts[0].alive:
 			positions.append(sim.brotts[0].position)
 	var moved := false

--- a/godot/tests/test_runner.gd
+++ b/godot/tests/test_runner.gd
@@ -202,11 +202,11 @@ func _run_combat_tests() -> void:
 	# Test match timeout
 	var sim2 := CombatSim.new(2)
 	var b1 := _make_brott(0, ChassisData.ChassisType.FORTRESS)
-	b1.position = Vector2(32, 32)
+	b1.position = Vector2(256, 256)
 	b1.weapon_types = []
 	b1.weapon_cooldowns = []
 	var b2 := _make_brott(1, ChassisData.ChassisType.FORTRESS)
-	b2.position = Vector2(480, 480)
+	b2.position = Vector2(260, 260)
 	b2.weapon_types = []
 	b2.weapon_cooldowns = []
 	sim2.add_brott(b1)

--- a/godot/tests/test_sprint10.gd
+++ b/godot/tests/test_sprint10.gd
@@ -8,7 +8,7 @@ var test_count := 0
 var _hit_count := 0
 
 const CombatSim = preload("res://combat/combat_sim.gd")
-const BrottData = preload("res://combat/brott_data.gd")
+#const BrottData = preload("res://combat/brott_data.gd")  # removed: file doesn't exist
 
 func _init() -> void:
 	print("=== BattleBrotts Sprint 10 Test Suite ===\n")

--- a/godot/tests/test_sprint10.gd.uid
+++ b/godot/tests/test_sprint10.gd.uid
@@ -1,0 +1,1 @@
+uid://bwapw347jej6v

--- a/godot/tests/test_sprint11.gd.uid
+++ b/godot/tests/test_sprint11.gd.uid
@@ -1,0 +1,1 @@
+uid://jegsmge1pldm

--- a/godot/tests/test_sprint11_2.gd.uid
+++ b/godot/tests/test_sprint11_2.gd.uid
@@ -1,0 +1,1 @@
+uid://c2nh4u20xdio8

--- a/godot/tests/test_sprint12_1.gd
+++ b/godot/tests/test_sprint12_1.gd
@@ -1,0 +1,284 @@
+## Sprint 12.1 test suite — Movement Physics + Plasma Cutter Range + Overtime Tuning
+extends SceneTree
+
+var pass_count := 0
+var fail_count := 0
+var test_count := 0
+
+func _init() -> void:
+	print("=== BattleBrotts Sprint 12.1 Test Suite ===")
+	print("=== Movement Physics + Balance Tuning ===\n")
+
+	test_chassis_accel_decel_values()
+	test_scout_time_to_max()
+	test_brawler_time_to_max()
+	test_fortress_time_to_max()
+	test_afterburner_accel_multiplier()
+	test_decel_to_stop()
+	test_plasma_cutter_range_2_5()
+	test_plasma_cutter_no_fire_2_6()
+	test_overtime_1v1_at_45s()
+	test_overtime_2v2_at_60s()
+	test_sudden_death_1v1_at_60s()
+	test_sudden_death_2v2_at_75s()
+	test_timeout_1v1_at_100s()
+	test_timeout_2v2_at_120s()
+
+	print("\n--- Results ---")
+	print("%d passed, %d failed out of %d" % [pass_count, fail_count, test_count])
+	quit(1 if fail_count > 0 else 0)
+
+func _assert(cond: bool, msg: String) -> void:
+	test_count += 1
+	if cond:
+		pass_count += 1
+		print("  PASS: %s" % msg)
+	else:
+		fail_count += 1
+		print("  FAIL: %s" % msg)
+
+func _assert_approx(a: float, b: float, eps: float, msg: String) -> void:
+	_assert(absf(a - b) < eps, "%s (got %.4f, expected %.4f, eps %.4f)" % [msg, a, b, eps])
+
+# --- Acceleration / Deceleration math tests ---
+
+func test_chassis_accel_decel_values() -> void:
+	print("\n[Test] Chassis accel/decel/turn values")
+	var scout := ChassisData.get_chassis(ChassisData.ChassisType.SCOUT)
+	_assert(scout["accel"] == 660.0, "Scout accel = 660")
+	_assert(scout["decel"] == 880.0, "Scout decel = 880")
+	_assert(scout["turn_speed"] == 360.0, "Scout turn_speed = 360")
+
+	var brawler := ChassisData.get_chassis(ChassisData.ChassisType.BRAWLER)
+	_assert(brawler["accel"] == 240.0, "Brawler accel = 240")
+	_assert(brawler["decel"] == 360.0, "Brawler decel = 360")
+	_assert(brawler["turn_speed"] == 240.0, "Brawler turn_speed = 240")
+
+	var fortress := ChassisData.get_chassis(ChassisData.ChassisType.FORTRESS)
+	_assert(fortress["accel"] == 90.0, "Fortress accel = 90")
+	_assert(fortress["decel"] == 150.0, "Fortress decel = 150")
+	_assert(fortress["turn_speed"] == 150.0, "Fortress turn_speed = 150")
+
+func _make_brott(chassis_type: ChassisData.ChassisType, team: int = 0) -> BrottState:
+	var b := BrottState.new()
+	b.chassis_type = chassis_type
+	b.weapon_types = [WeaponData.WeaponType.MINIGUN]
+	b.armor_type = ArmorData.ArmorType.NONE
+	b.module_types = []
+	b.team = team
+	b.bot_name = "test_%d" % team
+	b.setup()
+	return b
+
+func test_scout_time_to_max() -> void:
+	print("\n[Test] Scout reaches max speed in ~0.33s")
+	var b := _make_brott(ChassisData.ChassisType.SCOUT)
+	# Simulate acceleration ticks: accel=660, max=220, so time=220/660=0.333s
+	var dt := 1.0 / 10.0  # TICK_DELTA
+	var ticks := 0
+	while b.current_speed < b.base_speed and ticks < 100:
+		b.accelerate_toward_speed(b.base_speed, dt)
+		ticks += 1
+	var time_sec: float = float(ticks) * dt
+	_assert_approx(time_sec, 0.33, 0.05, "Scout 0→max in ~0.33s")
+	_assert_approx(b.current_speed, 220.0, 0.01, "Scout at max speed 220")
+
+func test_brawler_time_to_max() -> void:
+	print("\n[Test] Brawler reaches max speed in ~0.50s")
+	var b := _make_brott(ChassisData.ChassisType.BRAWLER)
+	var dt := 1.0 / 10.0
+	var ticks := 0
+	while b.current_speed < b.base_speed and ticks < 100:
+		b.accelerate_toward_speed(b.base_speed, dt)
+		ticks += 1
+	var time_sec: float = float(ticks) * dt
+	_assert_approx(time_sec, 0.50, 0.05, "Brawler 0→max in ~0.50s")
+
+func test_fortress_time_to_max() -> void:
+	print("\n[Test] Fortress reaches max speed in ~0.67s")
+	var b := _make_brott(ChassisData.ChassisType.FORTRESS)
+	var dt := 1.0 / 10.0
+	var ticks := 0
+	while b.current_speed < b.base_speed and ticks < 100:
+		b.accelerate_toward_speed(b.base_speed, dt)
+		ticks += 1
+	var time_sec: float = float(ticks) * dt
+	_assert_approx(time_sec, 0.67, 0.05, "Fortress 0→max in ~0.67s")
+
+func test_afterburner_accel_multiplier() -> void:
+	print("\n[Test] Afterburner multiplies accel by 1.8x")
+	var b := _make_brott(ChassisData.ChassisType.SCOUT)
+	b.afterburner_active = true
+	var expected_accel: float = 660.0 * 1.8
+	_assert_approx(b.get_effective_accel(), expected_accel, 0.01, "Afterburner accel = 660*1.8 = 1188")
+	# Decel unchanged
+	_assert_approx(b.get_effective_decel(), 880.0, 0.01, "Afterburner decel unchanged = 880")
+
+func test_decel_to_stop() -> void:
+	print("\n[Test] Deceleration stops bot correctly")
+	var b := _make_brott(ChassisData.ChassisType.SCOUT)
+	b.current_speed = 220.0  # at max
+	var dt := 1.0 / 10.0
+	var ticks := 0
+	while b.current_speed > 0.0 and ticks < 100:
+		b.accelerate_toward_speed(0.0, dt)
+		ticks += 1
+	var time_sec: float = float(ticks) * dt
+	# 220/880 = 0.25s
+	_assert_approx(time_sec, 0.25, 0.05, "Scout stops in ~0.25s")
+	_assert(b.current_speed == 0.0, "Scout fully stopped")
+
+# --- Plasma Cutter range tests ---
+
+func test_plasma_cutter_range_2_5() -> void:
+	print("\n[Test] Plasma Cutter fires at 2.5 tiles")
+	var sim := CombatSim.new(42)
+	var attacker := _make_brott(ChassisData.ChassisType.SCOUT, 0)
+	attacker.weapon_types = [WeaponData.WeaponType.PLASMA_CUTTER]
+	attacker.weapon_cooldowns = [0.0]
+	attacker.position = Vector2(0, 0)
+
+	var target := _make_brott(ChassisData.ChassisType.BRAWLER, 1)
+	target.position = Vector2(2.5 * 32.0, 0)  # exactly 2.5 tiles away
+
+	sim.add_brott(attacker)
+	sim.add_brott(target)
+
+	var initial_projectiles := sim.projectiles.size()
+	# Run one tick to fire
+	sim.simulate_tick()
+	_assert(sim.projectiles.size() > initial_projectiles or sim.shots_fired.size() > 0, "Plasma Cutter fires at 2.5 tiles")
+
+func test_plasma_cutter_no_fire_2_6() -> void:
+	print("\n[Test] Plasma Cutter does NOT fire at 2.6 tiles")
+	var sim := CombatSim.new(42)
+	var attacker := _make_brott(ChassisData.ChassisType.SCOUT, 0)
+	attacker.weapon_types = [WeaponData.WeaponType.PLASMA_CUTTER]
+	attacker.weapon_cooldowns = [0.0]
+	attacker.position = Vector2(0, 0)
+
+	var target := _make_brott(ChassisData.ChassisType.BRAWLER, 1)
+	target.position = Vector2(2.6 * 32.0, 0)  # 2.6 tiles away — out of range
+
+	sim.add_brott(attacker)
+	sim.add_brott(target)
+
+	sim.simulate_tick()
+	_assert(sim.shots_fired.size() == 0, "Plasma Cutter does NOT fire at 2.6 tiles")
+
+# --- Overtime threshold tests ---
+
+func test_overtime_1v1_at_45s() -> void:
+	print("\n[Test] 1v1 overtime triggers at 45s")
+	var sim := CombatSim.new(1)
+	sim.match_mode = "1v1"
+	var a := _make_brott(ChassisData.ChassisType.SCOUT, 0)
+	a.position = Vector2(64, 64)
+	var b := _make_brott(ChassisData.ChassisType.SCOUT, 1)
+	b.position = Vector2(400, 400)
+	sim.add_brott(a)
+	sim.add_brott(b)
+
+	# Tick to just before 45s (449 ticks)
+	for i in range(449):
+		sim.simulate_tick()
+	_assert(sim.overtime_active == false, "No overtime before 45s (tick 449)")
+
+	# Tick to 45s (tick 450)
+	sim.simulate_tick()
+	_assert(sim.overtime_active == true, "Overtime active at 45s (tick 450)")
+
+func test_overtime_2v2_at_60s() -> void:
+	print("\n[Test] 2v2 overtime triggers at 60s")
+	var sim := CombatSim.new(1)
+	sim.match_mode = "2v2"
+	var a := _make_brott(ChassisData.ChassisType.SCOUT, 0)
+	a.position = Vector2(64, 64)
+	var b := _make_brott(ChassisData.ChassisType.SCOUT, 1)
+	b.position = Vector2(400, 400)
+	sim.add_brott(a)
+	sim.add_brott(b)
+
+	# At tick 450 (45s) — should NOT be overtime for 2v2
+	for i in range(450):
+		sim.simulate_tick()
+	_assert(sim.overtime_active == false, "No overtime at 45s for 2v2")
+
+	# Tick to 60s (tick 600)
+	for i in range(150):
+		sim.simulate_tick()
+	_assert(sim.overtime_active == true, "Overtime active at 60s for 2v2 (tick 600)")
+
+func test_sudden_death_1v1_at_60s() -> void:
+	print("\n[Test] 1v1 sudden death triggers at 60s")
+	var sim := CombatSim.new(1)
+	sim.match_mode = "1v1"
+	var a := _make_brott(ChassisData.ChassisType.FORTRESS, 0)
+	a.position = Vector2(64, 64)
+	var b := _make_brott(ChassisData.ChassisType.FORTRESS, 1)
+	b.position = Vector2(400, 400)
+	sim.add_brott(a)
+	sim.add_brott(b)
+
+	# Tick to just before 60s (599 ticks)
+	for i in range(599):
+		sim.simulate_tick()
+	_assert(sim.sudden_death_active == false, "No sudden death before 60s (tick 599)")
+
+	sim.simulate_tick()
+	_assert(sim.sudden_death_active == true, "Sudden death at 60s (tick 600)")
+
+func test_sudden_death_2v2_at_75s() -> void:
+	print("\n[Test] 2v2 sudden death triggers at 75s")
+	var sim := CombatSim.new(1)
+	sim.match_mode = "2v2"
+	var a := _make_brott(ChassisData.ChassisType.FORTRESS, 0)
+	a.position = Vector2(64, 64)
+	var b := _make_brott(ChassisData.ChassisType.FORTRESS, 1)
+	b.position = Vector2(400, 400)
+	sim.add_brott(a)
+	sim.add_brott(b)
+
+	for i in range(600):
+		sim.simulate_tick()
+	_assert(sim.sudden_death_active == false, "No sudden death at 60s for 2v2")
+
+	for i in range(150):
+		sim.simulate_tick()
+	_assert(sim.sudden_death_active == true, "Sudden death at 75s for 2v2 (tick 750)")
+
+func test_timeout_1v1_at_100s() -> void:
+	print("\n[Test] 1v1 timeout at 100s")
+	var sim := CombatSim.new(1)
+	sim.match_mode = "1v1"
+	var a := _make_brott(ChassisData.ChassisType.FORTRESS, 0)
+	a.position = Vector2(64, 64)
+	var b := _make_brott(ChassisData.ChassisType.FORTRESS, 1)
+	b.position = Vector2(400, 400)
+	sim.add_brott(a)
+	sim.add_brott(b)
+
+	# Tick to 100s
+	for i in range(1000):
+		sim.simulate_tick()
+	_assert(sim.match_over == true, "1v1 match over at 100s")
+
+func test_timeout_2v2_at_120s() -> void:
+	print("\n[Test] 2v2 timeout at 120s")
+	var sim := CombatSim.new(1)
+	sim.match_mode = "2v2"
+	var a := _make_brott(ChassisData.ChassisType.FORTRESS, 0)
+	a.position = Vector2(64, 64)
+	var b := _make_brott(ChassisData.ChassisType.FORTRESS, 1)
+	b.position = Vector2(400, 400)
+	sim.add_brott(a)
+	sim.add_brott(b)
+
+	# At 100s should NOT be over for 2v2
+	for i in range(1000):
+		sim.simulate_tick()
+	_assert(sim.match_over == false, "2v2 match NOT over at 100s")
+
+	for i in range(200):
+		sim.simulate_tick()
+	_assert(sim.match_over == true, "2v2 match over at 120s")

--- a/godot/tests/test_sprint12_1.gd
+++ b/godot/tests/test_sprint12_1.gd
@@ -252,9 +252,9 @@ func test_timeout_1v1_at_100s() -> void:
 	var sim := CombatSim.new(1)
 	sim.match_mode = "1v1"
 	var a := _make_brott(ChassisData.ChassisType.FORTRESS, 0)
-	a.position = Vector2(64, 64)
+	a.position = Vector2(256, 256)
 	var b := _make_brott(ChassisData.ChassisType.FORTRESS, 1)
-	b.position = Vector2(400, 400)
+	b.position = Vector2(260, 260)
 	sim.add_brott(a)
 	sim.add_brott(b)
 
@@ -268,9 +268,9 @@ func test_timeout_2v2_at_120s() -> void:
 	var sim := CombatSim.new(1)
 	sim.match_mode = "2v2"
 	var a := _make_brott(ChassisData.ChassisType.FORTRESS, 0)
-	a.position = Vector2(64, 64)
+	a.position = Vector2(256, 256)
 	var b := _make_brott(ChassisData.ChassisType.FORTRESS, 1)
-	b.position = Vector2(400, 400)
+	b.position = Vector2(260, 260)
 	sim.add_brott(a)
 	sim.add_brott(b)
 

--- a/godot/tests/test_sprint12_1.gd.uid
+++ b/godot/tests/test_sprint12_1.gd.uid
@@ -1,0 +1,1 @@
+uid://dwpmond4nbe5w

--- a/godot/tests/test_sprint4.gd
+++ b/godot/tests/test_sprint4.gd
@@ -129,7 +129,7 @@ func _test_tick_rate_halved() -> void:
 
 func _test_match_timeout_ticks() -> void:
 	print("test_match_timeout_ticks")
-	assert_eq(CombatSim.MATCH_TIMEOUT_TICKS, 900, "MATCH_TIMEOUT = 90 * 10 = 900")
+	assert_eq(CombatSim.MATCH_TIMEOUT_TICKS, 1000, "MATCH_TIMEOUT = 100 * 10 = 1000")
 
 func _test_energy_regen_per_tick() -> void:
 	print("test_energy_regen_per_tick")
@@ -301,7 +301,7 @@ func _test_combat_sim_ticks_per_sec() -> void:
 func _test_combat_match_timeout() -> void:
 	print("test_combat_match_timeout")
 	var sim := CombatSim.new(42)
-	assert_eq(sim.MATCH_TIMEOUT_TICKS, 900, "Match timeout = 900 ticks")
+	assert_eq(sim.MATCH_TIMEOUT_TICKS, 1000, "Match timeout = 1000 ticks")
 
 func _test_death_sets_death_timer() -> void:
 	print("test_death_sets_death_timer")

--- a/kb/patterns/fun-evaluation-approaches.md
+++ b/kb/patterns/fun-evaluation-approaches.md
@@ -1,0 +1,63 @@
+# Fun Evaluation Approaches
+
+> Spike sprint findings — April 2026
+
+## Three Approaches to Measuring Fun
+
+### Approach A: Proxy Metrics
+Tension (lead changes), drama (close finishes), variety (event diversity), momentum shifts. Combine into a composite "fun score."
+
+**Status:** 🔴 BLOCKED — needs JSON match logging from combat engine.
+
+### Approach B: LLM-as-Critic
+Feed match replay narrative to LLM, get excitement rating 1–10 with explanation.
+
+**Status:** 🔴 BLOCKED — needs JSON match logging.
+
+### Approach C: Comparative Evaluation
+Run matches with different settings, rank from most to least fun, analyze what makes the best ones better.
+
+**Status:** 🟢 WORKS NOW — no JSON needed, uses sim output directly.
+
+---
+
+## What Makes Combat Fun (Approach C Findings)
+
+- **Loadout diversity is the #1 fun driver**
+- Sweet spot: **5–10s duration**, diverse weapons, close HP finishes
+- Shotgun is most entertaining (risk/reward gameplay)
+- Plasma Cutter is dead — 1.5 tile range means it never fires
+- BrottBrain AI is essential — brainless matches are boring
+- Overtime threshold should be **45s not 60s**
+
+---
+
+## Proposed Production Fun Score
+
+Five metrics, weighted:
+
+| Metric | Weight |
+|---|---|
+| Loadout Diversity Index | 25% |
+| HP Closeness | 25% |
+| Duration Score (bell curve centered at 7s) | 20% |
+| Lead Changes | 15% |
+| Weapon Variety Hits | 15% |
+
+---
+
+## Three-Layer Verification System
+
+| Layer | What | When |
+|---|---|---|
+| **L1** | Automated `fun_score` from telemetry | Every match |
+| **L2** | Comparative tuning sessions | Per-patch |
+| **L3** | LLM narrative evaluation | On-demand for outliers |
+
+---
+
+## Blockers & Next Steps
+
+**Critical blocker:** JSON match logging needed to unblock Approaches A and B.
+
+**Prerequisite for next spike re-run:** Add `--json-log` flag to combat engine that dumps per-tick state.


### PR DESCRIPTION
## What Changed

### 1. Per-chassis acceleration/deceleration/turn speed
- Added `accel`, `decel`, `turn_speed` to chassis config
  - Scout: 660/880/360 (px/s², px/s², °/s) → 0→max in ~0.33s
  - Brawler: 240/360/240 → 0→max in ~0.50s
  - Fortress: 90/150/150 → 0→max in ~0.67s
- Movement system uses acceleration curves instead of instant speed
- Turn speed is visual-only (sprite rotation); movement direction changes via acceleration
- Afterburner multiplies acceleration by 1.8× during boost (decel unchanged)
- Combat orbit (70% base) and juke bursts (120% base) still subject to accel curves
- `BrottState` gains `current_speed`, `facing_angle`, `accelerate_toward_speed()`, `get_effective_accel()`, `get_effective_decel()`

### 2. Plasma Cutter range: 1.5 → 2.5 tiles
- Single constant change in weapon_data.gd

### 3. Overtime thresholds (1v1 only)
- 1v1: Overtime 45s, Sudden Death 60s, Timeout 100s
- 2v2/3v3: Unchanged (60s/75s/120s)
- Added `match_mode` var and `_get_overtime_ticks()`, `_get_sudden_death_ticks()`, `_get_timeout_ticks()` helpers

## Tests
- `test_sprint12_1.gd` with 14 test functions covering:
  - Chassis accel/decel/turn values
  - Time-to-max for each chassis
  - Afterburner accel multiplier (1.8×) with unchanged decel
  - Deceleration to stop
  - Plasma Cutter fires at 2.5 tiles, does NOT fire at 2.6
  - Overtime triggers at 45s for 1v1, 60s for 2v2
  - Sudden death triggers at 60s for 1v1, 75s for 2v2
  - Timeout at 100s for 1v1, 120s for 2v2

## How to Verify
Run test: `godot --headless --script tests/test_sprint12_1.gd`