### PR TITLE
[S12.5] feat: JSON match logging for combat engine

### DIFF
--- a/godot/combat/combat_sim.gd
+++ b/godot/combat/combat_sim.gd
@@ -51,6 +51,11 @@ func _get_sudden_death_ticks() -> int:
 func _get_timeout_ticks() -> int:
 	return MATCH_TIMEOUT_TICKS_1V1 if match_mode == "1v1" else MATCH_TIMEOUT_TICKS_TEAM
 
+# --- JSON match logging (S12.5) ---
+var json_log_enabled: bool = false
+var _json_log: Array = []
+var _tick_events: Array = []  # transient: events for current tick
+
 # --- Instrumentation (S11.2) ---
 var shots_fired: Dictionary = {}   # weapon_name -> int
 var shots_hit: Dictionary = {}     # weapon_name -> int
@@ -70,10 +75,15 @@ func _init(seed_val: int = 0) -> void:
 func add_brott(brott: BrottState) -> void:
 	brotts.append(brott)
 
+func get_json_log() -> Array:
+	return _json_log
+
 func simulate_tick() -> void:
 	if match_over:
 		return
 	tick_count += 1
+	if json_log_enabled:
+		_tick_events = []
 	
 	# Check overtime trigger
 	if not overtime_active and tick_count >= _get_overtime_ticks():
@@ -82,10 +92,14 @@ func simulate_tick() -> void:
 			if b.alive:
 				b.stance = 0  # Force Aggressive
 				b.overtime = true
+		if json_log_enabled:
+			_tick_events.append({"type": "overtime_triggered", "tick": tick_count})
 	
 	# Check sudden death escalation
 	if not sudden_death_active and tick_count >= _get_sudden_death_ticks():
 		sudden_death_active = true
+		if json_log_enabled:
+			_tick_events.append({"type": "sudden_death_triggered", "tick": tick_count})
 
 	# Shrink arena boundary during overtime
 	if overtime_active:
@@ -137,6 +151,9 @@ func simulate_tick() -> void:
 	
 	_update_projectiles()
 	_check_match_end()
+	
+	if json_log_enabled:
+		_append_tick_log()
 
 func _evaluate_brain(b: BrottState) -> void:
 	if b.target == null or not b.target.alive:
@@ -254,6 +271,9 @@ func _activate_module(b: BrottState, module_index: int) -> void:
 	var mdata: Dictionary = ModuleData.get_module(mt)
 	if not mdata["activated"]:
 		return
+	
+	if json_log_enabled:
+		_tick_events.append({"type": "module_activated", "bot_id": b.bot_name, "module": str(mdata.get("name", str(mt)))})
 	
 	var dur_ticks: float = float(mdata.get("duration", 0.0)) * float(TICKS_PER_SEC)
 	b.module_active_timers[module_index] = dur_ticks
@@ -603,6 +623,8 @@ func _fire_weapons(b: BrottState) -> void:
 		# Instrumentation: track shots fired
 		var wname: String = str(wd.get("name", str(wt)))
 		shots_fired[wname] = shots_fired.get(wname, 0) + 1
+		if json_log_enabled:
+			_tick_events.append({"type": "weapon_fired", "bot_id": b.bot_name, "weapon": wname, "target_id": b.target.bot_name})
 		if first_engagement_tick < 0:
 			first_engagement_tick = tick_count
 		
@@ -685,6 +707,8 @@ func _apply_damage(target: BrottState, base_dmg: float, is_crit: bool, source: B
 	if effective > 0:
 		target.hp -= effective
 		target.flash_timer = 3.0
+		if json_log_enabled:
+			_tick_events.append({"type": "damage_dealt", "target_id": target.bot_name, "amount": effective, "is_crit": is_crit})
 		on_damage.emit(target, effective, is_crit, hit_pos)
 		# Instrumentation: track shots hit (by source weapon)
 		if source != null:
@@ -710,6 +734,8 @@ func _kill_brott(b: BrottState) -> void:
 	# Instrumentation: record kill tick
 	if not kill_ticks.has(b.bot_name):
 		kill_ticks[b.bot_name] = tick_count
+	if json_log_enabled:
+		_tick_events.append({"type": "bot_destroyed", "bot_id": b.bot_name, "tick": tick_count})
 	on_death.emit(b)
 
 func _check_match_end() -> void:
@@ -809,6 +835,39 @@ static func batch_regression_summary(results: Array[Dictionary]) -> Dictionary:
 		"avg_ttk_sec": avg_ttk,
 		"avg_hit_rates": avg_hit_rates,
 	}
+
+## --- JSON match log (S12.5) ---
+
+func _get_match_state() -> String:
+	if match_over:
+		return "completed"
+	if sudden_death_active:
+		return "sudden_death"
+	if overtime_active:
+		return "overtime"
+	return "in_progress"
+
+func _append_tick_log() -> void:
+	var bot_states: Array = []
+	for b in brotts:
+		bot_states.append({
+			"id": b.bot_name,
+			"position_x": b.position.x,
+			"position_y": b.position.y,
+			"hp": b.hp,
+			"max_hp": b.max_hp,
+			"energy": b.energy,
+			"current_speed": b.current_speed,
+			"stance": b.stance,
+			"target_id": b.target.bot_name if b.target else "",
+			"facing_angle": b.facing_angle,
+		})
+	_json_log.append({
+		"tick": tick_count,
+		"bots": bot_states,
+		"events": _tick_events,
+		"match_state": _get_match_state(),
+	})
 
 func _team_hp_pct(team: int) -> float:
 	var total_hp: float = 0.0

--- a/godot/tests/test_sprint12_5.gd
+++ b/godot/tests/test_sprint12_5.gd
@@ -1,0 +1,140 @@
+## Sprint 12.5 test suite — JSON Match Logging
+extends SceneTree
+
+var pass_count := 0
+var fail_count := 0
+var test_count := 0
+
+func _init() -> void:
+	print("=== BattleBrotts Sprint 12.5 Test Suite ===")
+	print("=== JSON Match Logging ===\n")
+
+	test_json_log_disabled()
+	test_json_log_enabled_captures_ticks()
+	test_log_bot_state_fields()
+	test_events_weapon_fired_and_damage()
+	test_log_file_write()
+
+	print("\n--- Results ---")
+	print("%d passed, %d failed out of %d" % [pass_count, fail_count, test_count])
+	quit(1 if fail_count > 0 else 0)
+
+func _assert(cond: bool, msg: String) -> void:
+	test_count += 1
+	if cond:
+		pass_count += 1
+		print("  PASS: %s" % msg)
+	else:
+		fail_count += 1
+		print("  FAIL: %s" % msg)
+
+func _make_sim(enable_log: bool) -> CombatSim:
+	var sim := CombatSim.new(42)
+	sim.json_log_enabled = enable_log
+
+	var b1 := BrottState.new()
+	b1.team = 0
+	b1.bot_name = "Alpha"
+	b1.chassis_type = ChassisData.ChassisType.BRAWLER
+	b1.weapon_types = [WeaponData.WeaponType.SHOTGUN]
+	b1.armor_type = ArmorData.ArmorType.PLATING
+	b1.module_types = [ModuleData.ModuleType.OVERCLOCK]
+	b1.stance = 0
+	b1.position = Vector2(4 * 32.0, 8 * 32.0)
+	b1.setup()
+
+	var b2 := BrottState.new()
+	b2.team = 1
+	b2.bot_name = "Bravo"
+	b2.chassis_type = ChassisData.ChassisType.SCOUT
+	b2.weapon_types = [WeaponData.WeaponType.MINIGUN]
+	b2.armor_type = ArmorData.ArmorType.REACTIVE_MESH
+	b2.module_types = [ModuleData.ModuleType.SHIELD_PROJECTOR]
+	b2.stance = 2
+	b2.position = Vector2(12 * 32.0, 8 * 32.0)
+	b2.setup()
+
+	sim.add_brott(b1)
+	sim.add_brott(b2)
+	return sim
+
+func test_json_log_disabled() -> void:
+	print("\n[Test] json_log_enabled=false produces no log")
+	var sim := _make_sim(false)
+	for _i in range(50):
+		sim.simulate_tick()
+	_assert(sim.get_json_log().size() == 0, "Log is empty when disabled")
+
+func test_json_log_enabled_captures_ticks() -> void:
+	print("\n[Test] json_log_enabled=true captures ticks")
+	var sim := _make_sim(true)
+	for _i in range(50):
+		sim.simulate_tick()
+	var log := sim.get_json_log()
+	_assert(log.size() == 50, "Log has 50 entries for 50 ticks (got %d)" % log.size())
+	_assert(log[0]["tick"] == 1, "First entry tick == 1")
+	_assert(log[49]["tick"] == 50, "Last entry tick == 50")
+
+func test_log_bot_state_fields() -> void:
+	print("\n[Test] Log contains correct bot state fields")
+	var sim := _make_sim(true)
+	sim.simulate_tick()
+	var log := sim.get_json_log()
+	var entry: Dictionary = log[0]
+	_assert(entry.has("tick"), "Entry has 'tick'")
+	_assert(entry.has("bots"), "Entry has 'bots'")
+	_assert(entry.has("events"), "Entry has 'events'")
+	_assert(entry.has("match_state"), "Entry has 'match_state'")
+	_assert(entry["match_state"] == "in_progress", "match_state is 'in_progress'")
+
+	var bots: Array = entry["bots"]
+	_assert(bots.size() == 2, "2 bots in entry")
+	var bot: Dictionary = bots[0]
+	var required_fields := ["id", "position_x", "position_y", "hp", "max_hp", "energy", "current_speed", "stance", "target_id", "facing_angle"]
+	for field in required_fields:
+		_assert(bot.has(field), "Bot state has '%s'" % field)
+
+func test_events_weapon_fired_and_damage() -> void:
+	print("\n[Test] Events capture weapon_fired and damage_dealt")
+	var sim := _make_sim(true)
+	# Run enough ticks for combat to happen
+	for _i in range(200):
+		sim.simulate_tick()
+		if sim.match_over:
+			break
+	var log := sim.get_json_log()
+	var found_weapon_fired := false
+	var found_damage_dealt := false
+	for entry in log:
+		for evt in entry["events"]:
+			if evt["type"] == "weapon_fired":
+				found_weapon_fired = true
+			if evt["type"] == "damage_dealt":
+				found_damage_dealt = true
+	_assert(found_weapon_fired, "Found weapon_fired event in log")
+	_assert(found_damage_dealt, "Found damage_dealt event in log")
+
+func test_log_file_write() -> void:
+	print("\n[Test] Log file write works")
+	var sim := _make_sim(true)
+	for _i in range(10):
+		sim.simulate_tick()
+	var log := sim.get_json_log()
+	var path := "res://tests/test_json_log_output.json"
+	var file := FileAccess.open(path, FileAccess.WRITE)
+	_assert(file != null, "Can open file for writing")
+	if file:
+		file.store_string(JSON.stringify(log, "  "))
+		file.close()
+		# Read back and verify
+		var read_file := FileAccess.open(path, FileAccess.READ)
+		_assert(read_file != null, "Can read file back")
+		if read_file:
+			var json := JSON.new()
+			var err := json.parse(read_file.get_as_text())
+			read_file.close()
+			_assert(err == OK, "Written JSON is valid")
+			_assert(json.data is Array, "Parsed data is Array")
+			_assert(json.data.size() == 10, "Written log has 10 entries (got %d)" % json.data.size())
+		# Cleanup
+		DirAccess.remove_absolute(path)

--- a/godot/tools/test_harness.gd
+++ b/godot/tools/test_harness.gd
@@ -22,6 +22,8 @@ var state_log: Array = []
 var current_screen_name: String = "main_menu"
 var viewport_size := Vector2i(1280, 720)
 
+var json_log_path: String = ""  # S12.5: --json-log <filepath>
+
 # Tick waiting
 var wait_remaining: int = 0
 
@@ -37,10 +39,15 @@ func _initialize() -> void:
 	# Load commands
 	var cmd_path := DEFAULT_COMMANDS
 	var args := OS.get_cmdline_user_args()
-	for arg in args:
-		if arg.ends_with(".json"):
-			cmd_path = arg
-			break
+	var i := 0
+	while i < args.size():
+		if args[i] == "--json-log" and i + 1 < args.size():
+			json_log_path = args[i + 1]
+			i += 2
+			continue
+		if args[i].ends_with(".json"):
+			cmd_path = args[i]
+		i += 1
 
 	var file := FileAccess.open(cmd_path, FileAccess.READ)
 	if file == null:
@@ -206,6 +213,8 @@ func _start_arena_match() -> void:
 
 	# Create sim
 	sim = CombatSim.new(42)  # deterministic seed for testing
+	if json_log_path != "":
+		sim.json_log_enabled = true
 	sim.add_brott(player_brott)
 	sim.add_brott(enemy_brott)
 
@@ -356,6 +365,16 @@ func _log_state(event: String) -> void:
 	})
 
 func _finish() -> void:
+	# S12.5: Write JSON match log if requested
+	if json_log_path != "" and sim != null:
+		var jlog_file := FileAccess.open(json_log_path, FileAccess.WRITE)
+		if jlog_file:
+			jlog_file.store_string(JSON.stringify(sim.get_json_log(), "  "))
+			jlog_file.close()
+			print("JSON match log saved to %s (%d ticks)" % [json_log_path, sim.get_json_log().size()])
+		else:
+			printerr("ERROR: Cannot write JSON log to %s" % json_log_path)
+	
 	# Save state log
 	var file := FileAccess.open(STATE_LOG_PATH, FileAccess.WRITE)
 	if file:


### PR DESCRIPTION
## What changed

Adds a `json_log_enabled` flag to `CombatSim` that captures per-tick state dumps during combat simulation.

### CombatSim changes (`combat_sim.gd`)
- New property: `json_log_enabled: bool` (default `false`)
- When enabled, after each tick appends a JSON object to `_json_log` with:
  - `tick`: tick number
  - `bots`: array of bot states (id, position x/y, hp, max_hp, energy, current_speed, stance, target_id, facing_angle)
  - `events`: array of events (weapon_fired, damage_dealt, module_activated, overtime_triggered, sudden_death_triggered, bot_destroyed)
  - `match_state`: in_progress | overtime | sudden_death | completed
- New method: `get_json_log() -> Array` returns the full log

### CLI support (`test_harness.gd`)
- New flag: `--json-log <filepath>` writes the match log to a file after sim completes

### Tests (`test_sprint12_5.gd`)
- `json_log_enabled=false` produces no log
- `json_log_enabled=true` captures correct number of ticks
- Log contains all required bot state fields
- Events include weapon_fired and damage_dealt
- File write round-trips valid JSON

## How to verify

Run: `godot --headless --script res://tests/test_sprint12_5.gd`