### PR TITLE
[S13.2-AUDIT] KB entries — mirror-test blind spot + tick-rate collision coupling

### DIFF
--- a/docs/kb/mirror-only-test-coverage-gap.md
+++ b/docs/kb/mirror-only-test-coverage-gap.md
@@ -1,0 +1,42 @@
+# KB: Mirror-Only Test Coverage Hides Cross-Chassis Bugs
+
+**Sprint:** 13.2
+**Discovered by:** Optic (verification), Specc (pattern)
+**Severity:** Medium
+**Status:** Open
+
+## Problem
+
+Combat-mechanics sprints (S11.1 juke, S13.2 TCR) have repeatedly shipped with test suites composed entirely of symmetric / mirror matchups. The tests pass green, but the mechanic breaks as soon as Optic runs it with heterogeneous chassis. Two concrete examples from this project:
+
+- **S11.1:** Juke movement worked when both bots had the same movement speed and engagement distance. Cross-chassis exposed a cap-bypass on the "away" juke.
+- **S13.2:** TCR cycle completed normally in mirror sims (4.8 cycles / 20.7% hit rate for Fortress). Cross-chassis dropped to 1.3 cycles / 1.7% hit rate because different `ideal_distance` values caused bots to oscillate in/out of combat-movement range, resetting TCR state each time.
+
+Mirror tests are cheap and easy to assert on. That's exactly why they're written first and, often, only.
+
+## Root Cause
+
+Mirror matchups are a symmetric fixed point of the combat system. Almost any timing, state-machine, or geometry bug that depends on *asymmetry* between the two bots is invisible to them. Specifically:
+
+- Two bots with identical speeds never create differential timing windows.
+- Two bots with identical `ideal_distance` values never oscillate in/out of each other's combat-movement range.
+- Two bots with identical projectile speeds and hitbox sizes hit or miss in symmetric patterns — any leak of "fast projectile vs small hitbox" looks fine because both sides leak equally.
+
+The bug is not in the mirror test. The bug is in the inference that "mirror green → mechanic correct."
+
+## Pattern
+
+**Any PR that introduces or modifies a combat-timing, state-machine, or projectile-geometry mechanic must include at least one cross-chassis integration test in the same PR.**
+
+Concretely:
+- Pair at least two chassis with materially different `movement_speed` and `ideal_distance`.
+- Assert on an end-to-end metric (hit rate, match duration, state-cycle count), not just on "state transitions happen in order."
+- If the metric depends on chassis parameters, assert a reasonable *range*, not a point value, so the test survives later balance tuning.
+
+If that test can't be written easily, that's a signal the mechanic's coupling to chassis parameters isn't well understood yet — which is itself a sprint-relevant finding.
+
+## Prevention
+
+- PR template for `godot/combat/*` changes should have a check: "Cross-chassis integration test included? Which chassis pair?"
+- Optic should treat "all tests are mirror" as an automatic request for additional sims before signing off.
+- Boltz review should flag mirror-only test suites on combat-mechanics PRs as a quality concern, not just a completeness concern.

--- a/docs/kb/tick-rate-collision-coupling.md
+++ b/docs/kb/tick-rate-collision-coupling.md
@@ -1,0 +1,51 @@
+# KB: Tick Rate × Projectile Speed Is an Implicit Collision Constraint
+
+**Sprint:** 13.2
+**Discovered by:** Optic (hit-rate collapse), Nutts (fix)
+**Severity:** High
+**Status:** Fixed in PR #56
+
+## Problem
+
+After S13.1 lowered the fixed tick rate from 20Hz to 10Hz, projectiles started passing through targets. Hit rates collapsed from the 20% range to 1.7% in cross-chassis matchups. The projectile code was unchanged; the bug surfaced purely because projectile step distance per tick doubled without a corresponding upgrade to the hit-detection geometry.
+
+At 400 px/s with a 10Hz tick, projectiles move 40 px per tick. Target hitbox radius is 12 px. Point-vs-circle collision tested at the per-tick endpoint positions could skip entirely over the target between two consecutive ticks:
+
+```
+tick N:   projectile at (100, 100), target at (130, 100)  → not hit (distance 30 > 12)
+tick N+1: projectile at (140, 100), target at (130, 100)  → not hit (distance 10 < 12 but already past)
+```
+
+Depending on exact timing, a 24 px diameter target had roughly a 60% chance of being skipped entirely by a 400 px/s projectile on a 10Hz tick.
+
+## Root Cause
+
+Per-tick point-vs-circle collision implicitly assumes `per_tick_travel < target_diameter`. The invariant was satisfied at 20Hz (20 px/tick vs 24 px diameter, mostly OK) and silently violated at 10Hz (40 px/tick vs 24 px diameter, frequently skips).
+
+The S13.1 tick-rate change correctly re-derived all per-tick *movement* constants (regen rates, pathfinding cadence) but did not audit per-tick *collision* geometry.
+
+## Pattern
+
+**Any change to fixed timestep rate is an implicit change to every per-tick motion primitive.** When the timestep grows, any collision test that only samples endpoints becomes unreliable for fast-moving entities.
+
+The general fix is swept collision: test the line segment from the previous position to the current position against the target, not just the endpoints. For projectile-vs-circle:
+
+```
+# closest point on segment AB to circle center C
+AB = B - A
+t = clamp(((C - A) dot AB) / AB.length_squared(), 0, 1)
+closest = A + AB * t
+hit = (closest - C).length() <= radius
+```
+
+Clamp projectile step distance to remaining range so projectiles don't overshoot their max range in a single tick either.
+
+## Prevention
+
+- **Any PR that changes `PHYSICS_FPS` / tick rate must include an explicit audit item:** "Per-tick travel distance of every moving entity (bots, projectiles, splash) vs smallest relevant hitbox radius. List each; confirm `travel_per_tick < 2 × smallest_radius` or use swept collision."
+- Per-weapon projectile speeds should be declared explicitly on `WeaponData` (not hardcoded) so the audit above is a single-file review, not a code-wide search.
+- End-to-end hit-rate assertions in sim tests catch this class of bug. Unit tests of individual collision calls do not.
+
+## Related
+
+- `docs/kb/mirror-only-test-coverage-gap.md` — why unit and mirror tests missed this despite the bug being severe.


### PR DESCRIPTION
Two KB entries extracted from the Sprint 13.2 audit.

## 1. `mirror-only-test-coverage-gap.md`
Mirror matchups are a symmetric fixed point of the combat system — most TCR / state-machine / geometry bugs need asymmetry to surface. S11.1 (juke cap-bypass) and S13.2 (TCR state reset across combat-movement re-entry) were both green on mirror tests and broken on cross-chassis. Second occurrence is the pattern.

**Recommendation:** combat-mechanics PRs must include at least one cross-chassis integration test with asymmetric chassis params and an end-to-end metric assertion.

## 2. `tick-rate-collision-coupling.md`
The S13.1 tick-rate change (20Hz → 10Hz) silently doubled per-tick projectile travel from 20 to 40 px without a corresponding upgrade to endpoint-sampled point-vs-circle hit detection. Result: 1.7% hit rate in cross-chassis sims. PR #56 fixed this with swept line-segment collision.

**Recommendation:** any `PHYSICS_FPS` change must include an explicit per-tick-travel vs hitbox-radius audit, and per-weapon projectile speeds should be declared on `WeaponData` so the audit is single-file.

---
See full reasoning in [studio-audits v2-sprint-13.2.md](https://github.com/brott-studio/studio-audits/blob/main/audits/battlebrotts-v2/v2-sprint-13.2.md).