### PR TITLE
[S13.4] feat: shop card grid MVP (pivot from balance → shop visual)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ Thumbs.db
 test-results/
 tools/screenshots/
 tools/state_log.json
+tests/screenshots/

--- a/docs/design/sprint13.4-shop-card-grid.md
+++ b/docs/design/sprint13.4-shop-card-grid.md
@@ -1,0 +1,202 @@
+# Sprint 13.4 — Shop Card Grid MVP
+
+**Status:** Design handoff — Gizmo → Nutts
+**Sprint:** 13.4 (UI-only pivot; balance deferred to S14)
+**Scope:** Replace text-list shop with card grid. MVP only. Polish (animations, SFX, real art) → S13.5.
+
+---
+
+## 1. Why this sprint
+
+The current shop (pre-S13.4) is a vertical text list of 19 items (7 weapons, 3 armor, 3 chassis, 6 modules). Playtesters in the S13.2/13.3 TCR sessions consistently reported:
+
+- **"Feels like a spreadsheet, not a shop"** — no visual differentiation between items, prices blur together.
+- **"I don't know what I'm looking at"** — archetype labels use emoji + adjective but the scannable information density is low.
+- **"Too many clicks to see stats"** — the 📊 expand toggle opens stats for one item at a time and still returns you to the scrolling list.
+
+The combat loop is landing (S13.3 validation: mirror matchups resolve in 10–42s, no instant kills). The next playtest bottleneck is shop engagement — players need to *want* to spend bolts.
+
+**S13.4 is UI-only.** No economy changes, no balance changes, no new items. We're reskinning the shop with a card grid and inline expansion. If this lands we pick up polish (animations, real art swap-in points, SFX) in S13.5 and return to balance (Fortress loadout pass) in S14.
+
+---
+
+## 2. Goals & non-goals
+
+### Goals
+1. Card grid layout — 3-col desktop, 2-col mobile.
+2. At-a-glance scan: art tile, name, archetype tag, price. No digging required to identify an item's role.
+3. Inline expansion for stats + buy action (NOT modal). Players stay in context.
+4. Clear state rendering: owned, affordable, unaffordable all readable from the card.
+5. Preserve `continue_pressed` signal contract and `GameState.buy_*` call sites.
+
+### Non-goals (S13.4)
+- Real commissioned art (placeholder tiles only).
+- Card hover animations, press SFX, purchase-confirm animations.
+- Compare-two-items mode.
+- Filtering / sorting UI.
+- Re-rolling the item catalog.
+- Any balance / price / economy change.
+
+---
+
+## 3. Visual & interaction spec
+
+### 3.1 Layout
+
+```
+┌─────────────────────────────────────────────────────────┐
+│ 🔩 SHOP                                      1240 🔩    │  ← header, bolts @ 36pt
+├─────────────────────────────────────────────────────────┤
+│ — WEAPONS —                                             │
+│ ┌─────────┐  ┌─────────┐  ┌─────────┐                   │
+│ │  [art]  │  │  [art]  │  │  [art]  │                   │
+│ │ 120x120 │  │         │  │         │                   │
+│ │         │  │         │  │         │                   │
+│ │ Railgun │  │ Minigun │  │ Shotgun │                   │
+│ │ Sniper  │  │ RapFire │  │ Burst   │   ← archetype tag │
+│ │   300🔩 │  │    50🔩 │  │   150🔩 │                   │
+│ └─────────┘  └─────────┘  └─────────┘                   │
+│   200x240      200x240      200x240                     │
+│                                                         │
+│ ┌─────────┐  ┌─────────┐  ┌─────────┐                   │
+│ │ ...     │  │ ...     │  │ ...     │                   │
+│ └─────────┘  └─────────┘  └─────────┘                   │
+│ — ARMOR —                                               │
+│ ...                                                     │
+└─────────────────────────────────────────────────────────┘
+```
+
+- **Section order:** WEAPONS → ARMOR → CHASSIS → MODULES (weapons first; this is what players hunt for post-fight).
+- **Card size:** fixed 200 × 240 px.
+- **Column count:** viewport width ≥ 1024 px → 3 cols; < 1024 px → 2 cols. 720 px is our mobile reference width.
+- **Gutters:** 16 px between cards, 20 px section padding.
+- **Bolts counter:** top-right of header, 36pt, format `{N} 🔩`.
+
+### 3.2 Card anatomy
+
+```
+┌─────────────────┐
+│                 │
+│   [ART TILE]    │  ← 120x120, category-colored placeholder with monogram glyph
+│                 │
+│                 │
+├─────────────────┤
+│ Railgun         │  ← 16pt bold, left-aligned
+│ Sniper • Weapon │  ← 11pt muted (#A0A0A0): {archetype} • {category}
+│                 │
+│           300 🔩│  ← 18pt, right-aligned, bottom
+└─────────────────┘
+```
+
+- **Art tile:** top 120 px of the card. Placeholder = category-colored fill + first-letter monogram (48pt, cream `#F4E4BC`, centered). See §5 for palette.
+- **Name:** 16pt bold, cream, left-aligned, 10 px below art.
+- **Archetype tag:** 11pt, muted grey, format `{archetype} • {category}`. E.g. `Sniper • Weapon`, `Light • Armor`.
+- **Price:** 18pt, bottom-right with 10 px inset.
+  - Affordable → default color (cream).
+  - Unaffordable → red (`#D04040`).
+  - Owned → replaced with `✓ Owned` in green (`#6FCF6F`).
+
+### 3.3 Card states
+
+| State | Opacity | Price area | Badge | Tappable? |
+|---|---|---|---|---|
+| Available (affordable) | 1.0 | `{N} 🔩` cream | none | yes |
+| Available (unaffordable) | 1.0 | `{N} 🔩` red | none | yes |
+| Owned | 0.5 | `✓ Owned` green | green ✓ top-right of art | yes (stats still viewable) |
+
+The owned-but-tappable behavior is intentional: players should be able to inspect stats of items they already own.
+
+### 3.4 Expand-in-place
+
+Tapping a card expands an **inline stats panel** directly below that row (not a modal, not a sidebar). Only one card is expanded at a time; tapping a second card collapses the first.
+
+```
+│ ┌─────────┐  ┌─────────┐  ┌─────────┐                   │
+│ │ Railgun │  │ Minigun │  │ Shotgun │ ← tap Railgun     │
+│ │  300🔩  │  │   50🔩  │  │  150🔩  │                   │
+│ └─────────┘  └─────────┘  └─────────┘                   │
+│ ╔═════════════════════════════════════════════════════╗ │
+│ ║ RAILGUN                                      ✕      ║ │ ← collapse button
+│ ║ Sniper • Weapon                                     ║ │
+│ ║                                                     ║ │
+│ ║ Damage: 40      Range: 400    Fire rate: 0.5/s      ║ │
+│ ║ Projectile spd: 800            Energy cost: 25      ║ │
+│ ║                                                     ║ │
+│ ║ High damage, long range, slow fire. Line of sight.  ║ │ ← description
+│ ║                                                     ║ │
+│ ║               [ BUY — 300 🔩 ]                      ║ │ ← buy button in panel
+│ ╚═════════════════════════════════════════════════════╝ │
+│ ┌─────────┐  ┌─────────┐  ┌─────────┐                   │
+│ │ Plasma  │  │ ...     │  │ ...     │                   │  ← next row of weapons
+│ └─────────┘  └─────────┘  └─────────┘                   │
+```
+
+- Panel spans full grid width, rendered between the row containing the tapped card and the next row.
+- Stats are laid out in a 2- or 3-column arrangement that fits in ~120 px panel height.
+- Description text (from `data["description"]`) rendered below stats, italic, 11pt muted.
+- **Buy button** inside the panel: enabled if affordable + not owned; disabled + labeled `Need {N} more` if unaffordable; hidden (or replaced with `✓ Owned`) if already owned.
+- The collapse `✕` button (top-right of panel) also closes it. Tapping the same card a second time = close.
+
+**Implementation note (Ett flag):** If `GridContainer` reflow misbehaves when a full-width child is inserted mid-grid, fall back to **VBox-of-HBox rows**: each section is a VBox whose children alternate between HBox rows of cards and (optionally) a full-width ExpandPanel inserted after the row that owns the expanded card.
+
+### 3.5 Continue button
+Unchanged semantics: bottom-right `Continue →` button emits `continue_pressed`. Keep position reasonable relative to the shop — bottom of viewport, right-aligned.
+
+---
+
+## 4. Acceptance criteria (15 items)
+
+For S13.4 to ship, all of the following must be visible in screenshots and verifiable by unit/Playwright tests.
+
+1. **Desktop 3-col grid** — at 1280w, first WEAPONS row contains exactly 3 cards side-by-side.
+2. **Mobile 2-col grid** — at 720w, first WEAPONS row contains exactly 2 cards side-by-side.
+3. **Card size 200×240** — every rendered card has `custom_minimum_size == (200, 240)`.
+4. **Section order** — sections render in order: WEAPONS → ARMOR → CHASSIS → MODULES.
+5. **All items rendered** — 7 weapons + 3 armor + 3 chassis + 6 modules = 19 cards.
+6. **Bolts counter 36pt** — header bolts label has `font_size = 36`.
+7. **Continue signal contract** — pressing `ContinueButton` emits `continue_pressed`, no args.
+8. **Unaffordable = red price** — at bolts=100, Railgun's price label has red font color.
+9. **Affordable exists** — at bolts=100, at least one non-owned card has non-red price.
+10. **Owned = ✓ + 50% opacity** — default loadout (Plasma Cutter, Plating, Scout) renders with `✓ Owned` text and green ✓ badge; card opacity = 0.5.
+11. **Archetype tag format** — weapon cards show `{archetype} • Weapon`; armor cards show `Light` / `Adaptive` / `Heavy`.
+12. **Expand in place** — tapping a card creates exactly one `ExpandPanel_` node; no panels exist pre-tap.
+13. **Only one expanded at a time** — tapping a second card collapses the first; total panel count always ≤ 1.
+14. **Buy flow works** — tapping Buy on an affordable card decrements `game_state.bolts` by price and adds type to `owned_*` set; card re-renders as owned.
+15. **Buy button disabled when unaffordable** — in expanded panel of Railgun at bolts=10, the BuyButton is `disabled=true` and its text contains `Need`.
+
+---
+
+## 5. Placeholder art palette
+
+Real art is an S13.5+ concern. For S13.4 every card uses a colored tile with a monogram (first letter of item name). Palette is intentional — color coding per category has meaning even after real art lands.
+
+| Category | Fill | Border | Glyph |
+|---|---|---|---|
+| Weapon | `#8B2E2E` (rust red) | `#D4A84A` gold | 48pt cream (`#F4E4BC`) |
+| Armor | `#2E5A8B` (steel blue) | `#8FAECB` light steel | 48pt cream |
+| Chassis | `#4A4A4A` (gunmetal) | `#A0A0A0` silver | 48pt cream |
+| Module | `#2E6B4A` (industrial green) | `#7BCA9E` mint | 48pt cream |
+
+The placeholders should read as *intentionally chunky* — playtesters should recognize them as not-final art, not mistake them for shipped visuals.
+
+---
+
+## 6. Handoff to S14 (Balance)
+
+Nothing in this sprint touches balance. S14 picks up the Fortress loadout pass flagged in S13.3 validation:
+
+- Scout vs Fortress 100/0 and Brawler vs Fortress 100/0 cross-chassis skews (S13.3 closed instant-kill regressions but not the outcome gap).
+- Fortress long-range identity — does it have the weapons/modules to actually punish Scout's kiting?
+- Mirror-match TTM floor (Scout mirror ~10s; Brawler mirror ~10s). Long enough to be readable, short enough to feel punchy?
+
+None of these are in scope for S13.4. Flagging here so the S14 author has a running list.
+
+---
+
+## 7. Open questions for Nutts
+- If `GridContainer` expand-in-place feels wrong, fall back to VBox-of-HBox — your call, just document the decision in your PR.
+- Monogram glyph for multi-word names (e.g. "Reactive Mesh", "Plasma Cutter") — use first letter of the **last word** (M, C). First letter of first word collides too often (P for Plating and Plasma Cutter).
+
+---
+
+*Gizmo, S13.4 design handoff, pre-commit.*

--- a/docs/gdd.md
+++ b/docs/gdd.md
@@ -487,6 +487,34 @@ Example: Any Brott → 20 🔩 repair on win, 50 🔩 on loss, regardless of equ
 ### Combat Log
 The combat log is **optional and collapsible** — tucked away by default to keep the focus on the visual action. Available for players who want to analyze tick-by-tick details.
 
+### Shop Card Grid (S13.4)
+
+The shop is a **card grid**, not a text list. Cards are 200x240 px, arranged 3-wide on desktop and 2-wide on mobile (viewport <= 720 px wide). Each card shows:
+
+- **Art tile** (120x120) — category-colored placeholder with monogram glyph (see Placeholder Art Palette below)
+- **Name** (16pt bold)
+- **Archetype tag** (11pt muted, e.g. `Sniper • Weapon`, `Light • Armor`)
+- **Price** (18pt, bottom-right) — default color if affordable, red if unaffordable, `✓ Owned` in green if owned
+
+Tap/click a card to expand an **inline stats panel** below that row (not a modal). The buy button lives inside the expanded panel, not on the card. Only one card is expanded at a time. Owned items render at 50% opacity with a green ✓ badge overlay but remain tappable so players can inspect stats.
+
+**Section order:** WEAPONS → ARMOR → CHASSIS → MODULES (weapons first because weapons are what players shop for after a fight). The bolts counter is top-right of the shop header at 36pt.
+
+Implementation note: the grid uses VBox-of-HBox rows rather than a GridContainer to keep reflow-on-expand deterministic (Ett flagged GridContainer as flaky for mid-grid full-width inserts).
+
+### Placeholder Art Palette (S13.4)
+
+Until commissioned art lands, item cards use category-colored tiles with a letter monogram (first letter of the last word of the item name — disambiguates "Plasma Cutter" vs "Plating"). The palette is intentional — color coding per category has meaning even after real art is in, so the palette carries forward as the card background or accent.
+
+| Category | Fill | Border | Glyph |
+|---|---|---|---|
+| Weapon | `#8B2E2E` (rust red) | `#D4A84A` gold | 48pt cream (`#F4E4BC`) |
+| Armor | `#2E5A8B` (steel blue) | `#8FAECB` light steel | same |
+| Chassis | `#4A4A4A` (gunmetal) | `#A0A0A0` silver | same |
+| Module | `#2E6B4A` (industrial green) | `#7BCA9E` mint | same |
+
+The placeholder scheme is *intentionally* chunky — playtesters should read these as "not final art", not mistake them for shipped visuals. Animations, SFX, and real art swap-in are deferred to S13.5.
+
 ---
 
 ## 11. Key Metrics for Playtest Lead
@@ -600,3 +628,9 @@ The core feelings we're targeting:
 
 **S13.3 results (N=100 per matchup, default loadouts, no armor, no modules):**
 See PR description for the 6-matchup table.
+
+### S13.4 — No balance changes (UI-only)
+
+Sprint 13.4 is a **UI-only pivot** to the Shop Card Grid (see §10 Art Direction → Shop Card Grid). No chassis, weapon, armor, or module numbers were touched. The only data change is `ArmorData.archetype` values normalized to `Light` / `Adaptive` / `Heavy` for consistent card-tag display — this is a naming change, not a balance change.
+
+The next balance pass is **S14 Fortress Loadout Pass**, which will address residual cross-chassis gaps at the loadout level (Fortress long-range identity, Scout-vs-Brawler asymmetry, mirror TTM floor). See design handoff in `docs/design/sprint13.4-shop-card-grid.md` §6.

--- a/godot/data/armor_data.gd
+++ b/godot/data/armor_data.gd
@@ -15,7 +15,7 @@ const ARMORS := {
 	},
 	ArmorType.PLATING: {
 		"name": "Plating",
-		"archetype": "🛡️ Reliable",
+		"archetype": "Light",
 		"description": "Flat damage reduction. No surprises, no downsides. The safe pick.",
 		"reduction": 0.20,
 		"weight": 15,
@@ -23,7 +23,7 @@ const ARMORS := {
 	},
 	ArmorType.REACTIVE_MESH: {
 		"name": "Reactive Mesh",
-		"archetype": "🪞 Thorns",
+		"archetype": "Adaptive",
 		"description": "Light protection, but attackers take damage too. Punishes rapid-fire weapons.",
 		"reduction": 0.10,
 		"weight": 8,
@@ -31,7 +31,7 @@ const ARMORS := {
 	},
 	ArmorType.ABLATIVE_SHELL: {
 		"name": "Ablative Shell",
-		"archetype": "🧱 Glass Fortress",
+		"archetype": "Heavy",
 		"description": "Incredible protection — until it isn't. Crumbles when you're on your last legs.",
 		"reduction": 0.40,
 		"weight": 25,

--- a/godot/game_main.gd
+++ b/godot/game_main.gd
@@ -40,6 +40,14 @@ func _ready() -> void:
 		if screen_param == "battle":
 			_start_demo_match()
 			return
+		if screen_param == "shop":
+			# S13.4: route ?screen=shop for shop card grid screenshot tests.
+			game_flow.new_game()
+			var bolts_param = JavaScriptBridge.eval("new URLSearchParams(window.location.search).get('bolts')")
+			if typeof(bolts_param) == TYPE_STRING and String(bolts_param).is_valid_int():
+				game_flow.game_state.bolts = int(bolts_param)
+			_show_shop()
+			return
 	# Default: show main menu (also handles ?screen=menu and ?screen=dashboard)
 	_show_main_menu()
 

--- a/godot/tests/test_s13_2_validation.gd.uid
+++ b/godot/tests/test_s13_2_validation.gd.uid
@@ -1,0 +1,1 @@
+uid://djvm8kmju626x

--- a/godot/tests/test_sprint13_3.gd.uid
+++ b/godot/tests/test_sprint13_3.gd.uid
@@ -1,0 +1,1 @@
+uid://ygmckew3vevt

--- a/godot/tests/test_sprint13_4.gd
+++ b/godot/tests/test_sprint13_4.gd
@@ -1,0 +1,315 @@
+## Sprint 13.4 — Shop card grid UI tests
+## Usage: godot --headless --script tests/test_sprint13_4.gd
+## Validates structural properties of ShopScreen against Gizmo's 15 acceptance
+## criteria (see docs/design/sprint13.4-shop-card-grid.md §4): card sizes,
+## section order, column counts at different viewport widths, expand/collapse
+## state, owned / unaffordable rendering, buy flow, continue signal contract.
+extends SceneTree
+
+var pass_count := 0
+var fail_count := 0
+var test_count := 0
+
+func _init() -> void:
+	pass
+
+func _initialize() -> void:
+	print("=== Sprint 13.4 Shop Card Grid Tests ===\n")
+	_run_all()
+	print("\n=== Results: %d passed, %d failed, %d total ===" % [pass_count, fail_count, test_count])
+	if fail_count > 0:
+		quit(1)
+	else:
+		quit(0)
+
+func assert_eq(a, b, msg: String) -> void:
+	test_count += 1
+	if a == b:
+		pass_count += 1
+	else:
+		fail_count += 1
+		print("  FAIL: %s (got %s, expected %s)" % [msg, str(a), str(b)])
+
+func assert_true(cond: bool, msg: String) -> void:
+	test_count += 1
+	if cond:
+		pass_count += 1
+	else:
+		fail_count += 1
+		print("  FAIL: %s" % msg)
+
+func _make_shop(viewport_w: int, bolts: int = 500) -> ShopScreen:
+	# Clean up any leftover children from previous tests (queue_free is deferred,
+	# so old shops can still be in the tree when the next test scans).
+	for c in root.get_children():
+		if c is ShopScreen:
+			root.remove_child(c)
+			c.free()
+	var gs := GameState.new()
+	gs.bolts = bolts
+	var shop := ShopScreen.new()
+	root.add_child(shop)
+	shop.setup_for_viewport(gs, viewport_w)
+	return shop
+
+func _find_recursive(node: Node, name_prefix: String, out: Array) -> void:
+	if node.name.begins_with(name_prefix):
+		out.append(node)
+	for c in node.get_children():
+		_find_recursive(c, name_prefix, out)
+
+func _run_all() -> void:
+	_test_columns_desktop()
+	_test_columns_mobile()
+	_test_card_dimensions()
+	_test_section_order()
+	_test_all_items_present()
+	_test_bolts_counter_font_size()
+	_test_continue_signal_contract()
+	_test_unaffordable_price_color()
+	_test_owned_state_rendering()
+	_test_archetype_tag_format()
+	_test_expand_card_inline()
+	_test_only_one_card_expanded()
+	_test_buy_flow()
+	_test_buy_button_disabled_when_unaffordable()
+	_test_armor_archetype_values()
+
+# AC #1
+func _test_columns_desktop() -> void:
+	print("test_columns_desktop")
+	var shop := _make_shop(1280)
+	var rows: Array = []
+	_find_recursive(shop, "Row_WEAPONS_", rows)
+	assert_true(rows.size() > 0, "at least one weapons row exists")
+	var first_row: Node = rows[0]
+	var cards := 0
+	for c in first_row.get_children():
+		if c.name.begins_with("Card_"):
+			cards += 1
+	assert_eq(cards, 3, "desktop 1280w → 3 columns in first weapons row")
+	shop.queue_free()
+
+# AC #2
+func _test_columns_mobile() -> void:
+	print("test_columns_mobile")
+	var shop := _make_shop(720)
+	var rows: Array = []
+	_find_recursive(shop, "Row_WEAPONS_", rows)
+	var first_row: Node = rows[0]
+	var cards := 0
+	for c in first_row.get_children():
+		if c.name.begins_with("Card_"):
+			cards += 1
+	assert_eq(cards, 2, "mobile 720w → 2 columns in first weapons row")
+	shop.queue_free()
+
+# AC #3
+func _test_card_dimensions() -> void:
+	print("test_card_dimensions")
+	var shop := _make_shop(1280)
+	var cards: Array = []
+	_find_recursive(shop, "Card_", cards)
+	assert_true(cards.size() > 0, "cards exist")
+	var sample: Control = cards[0]
+	assert_eq(int(sample.custom_minimum_size.x), 200, "card width = 200")
+	assert_eq(int(sample.custom_minimum_size.y), 240, "card height = 240")
+	shop.queue_free()
+
+# AC #4
+func _test_section_order() -> void:
+	print("test_section_order")
+	var shop := _make_shop(1280)
+	var sections: Array = []
+	_find_recursive(shop, "Section_", sections)
+	var order: Array = []
+	for s in sections:
+		order.append(String(s.name).replace("Section_", ""))
+	assert_eq(order, ["WEAPONS", "ARMOR", "CHASSIS", "MODULES"], "section order WEAPONS→ARMOR→CHASSIS→MODULES")
+	shop.queue_free()
+
+# AC #5
+func _test_all_items_present() -> void:
+	print("test_all_items_present")
+	var shop := _make_shop(1280)
+	var cards: Array = []
+	_find_recursive(shop, "Card_", cards)
+	var expected := GameState.WEAPON_PRICES.size() \
+		+ GameState.ARMOR_PRICES.size() \
+		+ GameState.CHASSIS_PRICES.size() \
+		+ GameState.MODULE_PRICES.size()
+	assert_eq(cards.size(), expected, "all catalog items rendered (%d)" % expected)
+	shop.queue_free()
+
+# AC #6
+func _test_bolts_counter_font_size() -> void:
+	print("test_bolts_counter_font_size")
+	var shop := _make_shop(1280, 1240)
+	var b: Label = shop.find_child("BoltsCounter", true, false)
+	assert_true(b != null, "BoltsCounter label exists")
+	assert_eq(b.get_theme_font_size("font_size"), 36, "bolts counter font_size = 36")
+	assert_true(String(b.text).begins_with("1240"), "bolts text shows current bolts")
+	shop.queue_free()
+
+# AC #7
+func _test_continue_signal_contract() -> void:
+	print("test_continue_signal_contract")
+	var shop := _make_shop(1280)
+	var emitted := [false]
+	shop.continue_pressed.connect(func(): emitted[0] = true)
+	var btn: Button = shop.find_child("ContinueButton", true, false)
+	assert_true(btn != null, "ContinueButton exists")
+	btn.pressed.emit()
+	assert_eq(emitted[0], true, "continue_pressed emitted on button press")
+	shop.queue_free()
+
+# AC #8, #9
+func _test_unaffordable_price_color() -> void:
+	print("test_unaffordable_price_color")
+	var shop := _make_shop(1280, 100)
+	var cards: Array = []
+	_find_recursive(shop, "Card_", cards)
+	var found_unaffordable := false
+	var found_affordable := false
+	for card in cards:
+		var pl: Label = card.find_child("Price", true, false)
+		if pl == null:
+			continue
+		if bool(card.get_meta("owned")):
+			continue
+		var price: int = int(card.get_meta("price"))
+		if price > 100 and price > 0:
+			var col: Color = pl.get_theme_color("font_color")
+			if col.r > 0.8 and col.g < 0.4:
+				found_unaffordable = true
+		elif price > 0 and price <= 100:
+			found_affordable = true
+	assert_true(found_unaffordable, "at least one unaffordable card shows red price")
+	assert_true(found_affordable, "at least one affordable card exists at bolts=100")
+	shop.queue_free()
+
+# AC #10
+func _test_owned_state_rendering() -> void:
+	print("test_owned_state_rendering")
+	var shop := _make_shop(1280)
+	var cards: Array = []
+	_find_recursive(shop, "Card_", cards)
+	var owned_count := 0
+	var badges_count := 0
+	for card in cards:
+		if bool(card.get_meta("owned")):
+			owned_count += 1
+			var badge = card.find_child("OwnedBadge", true, false)
+			if badge != null:
+				badges_count += 1
+			var pl: Label = card.find_child("Price", true, false)
+			assert_true(String(pl.text) == "✓ Owned", "owned card shows ✓ Owned")
+			# 50% opacity
+			assert_true(abs(card.modulate.a - 0.5) < 0.01, "owned card opacity = 0.5")
+	assert_true(owned_count >= 3, "at least 3 items owned by default")
+	assert_eq(badges_count, owned_count, "every owned card has ✓ badge")
+	shop.queue_free()
+
+# AC #11
+func _test_archetype_tag_format() -> void:
+	print("test_archetype_tag_format")
+	var shop := _make_shop(1280)
+	var cards: Array = []
+	_find_recursive(shop, "Card_", cards)
+	var weapon_checked := false
+	var armor_checked := false
+	for card in cards:
+		if String(card.get_meta("category")) == "weapon" and not weapon_checked:
+			var tag: Label = card.find_child("Tag", true, false)
+			assert_true(String(tag.text).find("• Weapon") >= 0, "weapon card tag contains '• Weapon'")
+			weapon_checked = true
+		if String(card.get_meta("category")) == "armor" and not armor_checked:
+			var tag2: Label = card.find_child("Tag", true, false)
+			var t := String(tag2.text)
+			assert_true(t.find("Light") >= 0 or t.find("Adaptive") >= 0 or t.find("Heavy") >= 0, "armor card tag shows Light/Adaptive/Heavy")
+			armor_checked = true
+	assert_true(weapon_checked, "found a weapon card to check")
+	assert_true(armor_checked, "found an armor card to check")
+	shop.queue_free()
+
+# AC #12
+func _test_expand_card_inline() -> void:
+	print("test_expand_card_inline")
+	var shop := _make_shop(1280)
+	var panels: Array = []
+	_find_recursive(shop, "ExpandPanel_", panels)
+	assert_eq(panels.size(), 0, "no panel expanded initially")
+	var cards: Array = []
+	_find_recursive(shop, "Card_", cards)
+	var target: Control = null
+	for card in cards:
+		if String(card.get_meta("category")) == "weapon" and String(card.get_meta("name")) == "Railgun":
+			target = card
+			break
+	assert_true(target != null, "Railgun card found")
+	var wt := int(target.get_meta("type"))
+	shop._toggle_expand({"category": "weapon", "type": wt, "data": WeaponData.get_weapon(wt), "price": int(target.get_meta("price")), "owned": bool(target.get_meta("owned")), "name": "Railgun", "archetype": ""})
+	panels = []
+	_find_recursive(shop, "ExpandPanel_", panels)
+	assert_eq(panels.size(), 1, "exactly one panel after expand")
+	shop.queue_free()
+
+# AC #13
+func _test_only_one_card_expanded() -> void:
+	print("test_only_one_card_expanded")
+	var shop := _make_shop(1280)
+	shop._toggle_expand({"category": "weapon", "type": 0, "data": WeaponData.get_weapon(0), "price": int(GameState.WEAPON_PRICES[0]), "owned": 0 in shop.game_state.owned_weapons, "name": "x", "archetype": ""})
+	shop._toggle_expand({"category": "weapon", "type": 1, "data": WeaponData.get_weapon(1), "price": int(GameState.WEAPON_PRICES[1]), "owned": 1 in shop.game_state.owned_weapons, "name": "y", "archetype": ""})
+	var panels: Array = []
+	_find_recursive(shop, "ExpandPanel_", panels)
+	assert_eq(panels.size(), 1, "only one panel expanded at a time")
+	assert_eq(shop._expanded_key, "weapon_1", "expanded_key reflects second toggle")
+	shop.queue_free()
+
+# AC #14
+func _test_buy_flow() -> void:
+	print("test_buy_flow")
+	var shop := _make_shop(1280, 1000)
+	var gs: GameState = shop.game_state
+	var target_wt := -1
+	var target_price := 99999
+	for wt in GameState.WEAPON_PRICES.keys():
+		if not (wt in gs.owned_weapons):
+			var p: int = int(GameState.WEAPON_PRICES[wt])
+			if p < target_price:
+				target_price = p
+				target_wt = wt
+	assert_true(target_wt >= 0, "found a purchasable weapon")
+	var bolts_before: int = gs.bolts
+	shop._on_buy("weapon", target_wt)
+	assert_true(target_wt in gs.owned_weapons, "weapon owned after buy")
+	assert_eq(gs.bolts, bolts_before - target_price, "bolts decremented by price")
+	var cards: Array = []
+	_find_recursive(shop, "Card_", cards)
+	var found_owned_card := false
+	for card in cards:
+		if String(card.get_meta("category")) == "weapon" and int(card.get_meta("type")) == target_wt:
+			if bool(card.get_meta("owned")):
+				found_owned_card = true
+				break
+	assert_true(found_owned_card, "card re-renders as owned after buy")
+	shop.queue_free()
+
+# AC #15
+func _test_buy_button_disabled_when_unaffordable() -> void:
+	print("test_buy_button_disabled_when_unaffordable")
+	var shop := _make_shop(1280, 10)
+	var wt := WeaponData.WeaponType.RAILGUN
+	shop._toggle_expand({"category": "weapon", "type": int(wt), "data": WeaponData.get_weapon(wt), "price": int(GameState.WEAPON_PRICES[wt]), "owned": wt in shop.game_state.owned_weapons, "name": "Railgun", "archetype": ""})
+	var buy: Button = shop.find_child("BuyButton", true, false)
+	assert_true(buy != null, "BuyButton exists in expanded panel")
+	assert_eq(buy.disabled, true, "buy button disabled when unaffordable")
+	assert_true(String(buy.text).find("Need") >= 0, "button text says 'Need X more'")
+	shop.queue_free()
+
+# Bonus: verify archetype data values
+func _test_armor_archetype_values() -> void:
+	print("test_armor_archetype_values")
+	assert_eq(ArmorData.get_armor(ArmorData.ArmorType.PLATING)["archetype"], "Light", "Plating archetype = Light")
+	assert_eq(ArmorData.get_armor(ArmorData.ArmorType.REACTIVE_MESH)["archetype"], "Adaptive", "Reactive Mesh archetype = Adaptive")
+	assert_eq(ArmorData.get_armor(ArmorData.ArmorType.ABLATIVE_SHELL)["archetype"], "Heavy", "Ablative Shell archetype = Heavy")

--- a/godot/tests/test_sprint13_4.gd.uid
+++ b/godot/tests/test_sprint13_4.gd.uid
@@ -1,0 +1,1 @@
+uid://cfh2dlrpupr3b

--- a/godot/tests/test_sprint4.gd
+++ b/godot/tests/test_sprint4.gd
@@ -226,7 +226,7 @@ func _test_railgun_archetype() -> void:
 func _test_plating_archetype() -> void:
 	print("test_plating_archetype")
 	var ad := ArmorData.get_armor(ArmorData.ArmorType.PLATING)
-	assert_eq(ad["archetype"], "🛡️ Reliable", "Plating archetype = Reliable")
+	assert_eq(ad["archetype"], "Light", "Plating archetype = Light")
 
 func _test_overclock_archetype() -> void:
 	print("test_overclock_archetype")

--- a/godot/tests/validate_s13_3.gd.uid
+++ b/godot/tests/validate_s13_3.gd.uid
@@ -1,0 +1,1 @@
+uid://ji0wly8ms6tm

--- a/godot/ui/shop_screen.gd
+++ b/godot/ui/shop_screen.gd
@@ -1,201 +1,449 @@
-## Shop screen — Sprint 4: shows archetype + description, stats behind toggle
+## Shop Screen — Sprint 13.4: card grid MVP (pivot from balance → shop visual)
+##
+## Card grid layout per Gizmo's spec (docs/design/sprint13.4-shop-card-grid.md):
+## - 3 cols at viewport width >= 1024, else 2 cols.
+## - Cards 200x240 with placeholder art tile (category-colored), name, archetype tag, price.
+## - Tap-to-expand inline stats panel below the row (not modal). Buy button lives in the panel.
+## - Sections WEAPONS -> ARMOR -> CHASSIS -> MODULES.
+## - Owned: 50% opacity + green check. Unaffordable: red price. continue_pressed unchanged.
+##
+## Implementation uses VBox-of-HBox rows (not GridContainer) so we can insert a
+## full-width ExpandPanel between rows deterministically — Ett flagged the
+## GridContainer reflow as flaky for mid-grid inserts.
 class_name ShopScreen
 extends Control
 
 signal item_purchased(category: String, type: int)
 signal continue_pressed
 
+# Palette (see design doc §5)
+const COLOR_CREAM := Color("#F4E4BC")
+const COLOR_MUTED := Color("#A0A0A0")
+const COLOR_UNAFFORDABLE := Color("#D04040")
+const COLOR_OWNED_GREEN := Color("#6FCF6F")
+
+const CAT_COLORS := {
+	"weapon":  { "fill": Color("#8B2E2E"), "border": Color("#D4A84A") },
+	"armor":   { "fill": Color("#2E5A8B"), "border": Color("#8FAECB") },
+	"chassis": { "fill": Color("#4A4A4A"), "border": Color("#A0A0A0") },
+	"module":  { "fill": Color("#2E6B4A"), "border": Color("#7BCA9E") },
+}
+
+const CARD_W := 200
+const CARD_H := 240
+const ART_H := 120
+const GUTTER := 16
+const DESKTOP_MIN_W := 1024
+
 var game_state: GameState
-var details_expanded: Dictionary = {}  # track which items have stats expanded
-var _item_container: Control  # scroll content container for shop items
+var _content_vbox: VBoxContainer
+var _expanded_key: String = ""
+var _forced_width: int = -1  # test hook; -1 = use viewport width
+
+# --- Public API (kept backwards-compatible) ---
 
 func setup(state: GameState) -> void:
 	game_state = state
 	_build_ui()
 
+func setup_for_viewport(state: GameState, viewport_w: int) -> void:
+	## Test hook: force a specific viewport width for deterministic layout checks.
+	game_state = state
+	_forced_width = viewport_w
+	_build_ui()
+
+# --- UI construction ---
+
 func _build_ui() -> void:
-	# Clear children
+	# Remove children immediately (queue_free is deferred and leaves stale
+	# nodes visible to the tree between rebuilds — breaks tests and can
+	# briefly show two expanded panels during rapid taps).
 	for c in get_children():
+		remove_child(c)
 		c.queue_free()
-	
-	# Title + Bolts
-	var header := Label.new()
-	header.text = "🔩 SHOP — %d Bolts" % game_state.bolts
-	header.add_theme_font_size_override("font_size", 28)
-	header.position = Vector2(20, 10)
-	header.size = Vector2(600, 40)
+
+	var viewport_w := _resolve_width()
+	var cols := 3 if viewport_w >= DESKTOP_MIN_W else 2
+
+	# --- Header (bolts counter top-right, title top-left) ---
+	var header := Control.new()
+	header.name = "Header"
+	header.custom_minimum_size = Vector2(viewport_w, 60)
+	header.position = Vector2(0, 0)
 	add_child(header)
-	
-	# ScrollContainer for shop items
+
+	var title := Label.new()
+	title.text = "SHOP"
+	title.add_theme_font_size_override("font_size", 28)
+	title.add_theme_color_override("font_color", COLOR_CREAM)
+	title.position = Vector2(20, 10)
+	header.add_child(title)
+
+	var bolts := Label.new()
+	bolts.name = "BoltsCounter"
+	bolts.text = "%d 🔩" % game_state.bolts
+	bolts.add_theme_font_size_override("font_size", 36)
+	bolts.add_theme_color_override("font_color", COLOR_CREAM)
+	bolts.horizontal_alignment = HORIZONTAL_ALIGNMENT_RIGHT
+	bolts.size = Vector2(300, 50)
+	bolts.position = Vector2(viewport_w - 320, 5)
+	header.add_child(bolts)
+
+	# --- Scroll area for cards ---
 	var scroll := ScrollContainer.new()
-	scroll.position = Vector2(0, 60)
-	scroll.size = Vector2(1280, 580)  # Leave room for header and continue button
+	scroll.name = "ScrollArea"
+	scroll.position = Vector2(0, 70)
+	scroll.custom_minimum_size = Vector2(viewport_w, 600)
+	scroll.size = Vector2(viewport_w, 600)
 	scroll.horizontal_scroll_mode = ScrollContainer.SCROLL_MODE_DISABLED
 	add_child(scroll)
-	
-	var scroll_content := Control.new()
-	scroll.add_child(scroll_content)
-	_item_container = scroll_content
-	
-	var y_offset := 0
-	
-	# Weapons section
-	y_offset = _add_section("WEAPONS", y_offset)
-	for wt in GameState.WEAPON_PRICES.keys():
-		var wd := WeaponData.get_weapon(wt)
-		var price: int = GameState.WEAPON_PRICES[wt]
-		var owned: bool = wt in game_state.owned_weapons
-		y_offset = _add_shop_item_v2(wd, price, owned, "weapon", wt, y_offset)
-	
-	# Armor section
-	y_offset = _add_section("ARMOR", y_offset + 10)
-	for at in GameState.ARMOR_PRICES.keys():
-		var ad := ArmorData.get_armor(at)
-		var price: int = GameState.ARMOR_PRICES[at]
-		var owned: bool = at in game_state.owned_armor
-		y_offset = _add_shop_item_v2(ad, price, owned, "armor", at, y_offset)
-	
-	# Chassis section
-	y_offset = _add_section("CHASSIS", y_offset + 10)
-	for ct in GameState.CHASSIS_PRICES.keys():
-		var cd := ChassisData.get_chassis(ct)
-		var price: int = GameState.CHASSIS_PRICES[ct]
-		var owned: bool = ct in game_state.owned_chassis
-		y_offset = _add_shop_item(cd["name"], price, owned, "chassis", ct, y_offset)
-	
-	# Modules section
-	y_offset = _add_section("MODULES", y_offset + 10)
-	for mt in GameState.MODULE_PRICES.keys():
-		var md := ModuleData.get_module(mt)
-		var price: int = GameState.MODULE_PRICES[mt]
-		var owned: bool = mt in game_state.owned_modules
-		y_offset = _add_shop_item_v2(md, price, owned, "module", mt, y_offset)
-	
-	# Set scroll content height so ScrollContainer knows the full extent
-	scroll_content.custom_minimum_size.y = y_offset
-	
-	# Continue button
+
+	_content_vbox = VBoxContainer.new()
+	_content_vbox.name = "Content"
+	_content_vbox.add_theme_constant_override("separation", 12)
+	_content_vbox.custom_minimum_size = Vector2(viewport_w, 0)
+	scroll.add_child(_content_vbox)
+
+	# --- Sections in spec order ---
+	_build_section("WEAPONS", "weapon", GameState.WEAPON_PRICES, cols, func(t): return WeaponData.get_weapon(t), game_state.owned_weapons)
+	_build_section("ARMOR",   "armor",  GameState.ARMOR_PRICES,  cols, func(t): return ArmorData.get_armor(t),  game_state.owned_armor)
+	_build_section("CHASSIS", "chassis",GameState.CHASSIS_PRICES,cols, func(t): return ChassisData.get_chassis(t), game_state.owned_chassis)
+	_build_section("MODULES", "module", GameState.MODULE_PRICES, cols, func(t): return ModuleData.get_module(t), game_state.owned_modules)
+
+	# --- Continue button ---
 	var btn := Button.new()
+	btn.name = "ContinueButton"
 	btn.text = "Continue →"
-	btn.position = Vector2(1050, 650)
+	btn.position = Vector2(viewport_w - 220, 680)
 	btn.size = Vector2(200, 50)
 	btn.add_theme_font_size_override("font_size", 18)
 	btn.pressed.connect(func(): continue_pressed.emit())
 	add_child(btn)
 
-func _add_section(title: String, y: int) -> int:
+func _resolve_width() -> int:
+	if _forced_width > 0:
+		return _forced_width
+	var vp := get_viewport()
+	if vp != null:
+		var sz := vp.get_visible_rect().size
+		if sz.x > 0:
+			return int(sz.x)
+	return 1280  # sensible default for headless/startup
+
+func _build_section(title: String, category: String, prices: Dictionary, cols: int, data_fn: Callable, owned: Array) -> void:
+	# Section container
+	var section := VBoxContainer.new()
+	section.name = "Section_%s" % title
+	section.add_theme_constant_override("separation", 8)
+
+	# Section header
 	var lbl := Label.new()
 	lbl.text = "— %s —" % title
 	lbl.add_theme_font_size_override("font_size", 18)
-	lbl.position = Vector2(20, y)
-	lbl.size = Vector2(300, 30)
-	_item_container.add_child(lbl)
-	return y + 30
+	lbl.add_theme_color_override("font_color", COLOR_CREAM)
+	section.add_child(lbl)
 
-func _add_shop_item_v2(data: Dictionary, price: int, owned: bool, category: String, type: int, y: int) -> int:
-	var item_name: String = data["name"]
-	var archetype: String = data.get("archetype", "")
-	var desc: String = data.get("description", "")
-	var key: String = "%s_%d" % [category, type]
-	
-	# Main row: archetype + name + price/owned
-	var hbox := HBoxContainer.new()
-	hbox.position = Vector2(40, y)
-	hbox.size = Vector2(700, 30)
-	
-	var lbl := Label.new()
-	var display_text: String = ""
-	if owned:
-		display_text = "✅ %s — %s" % [item_name, archetype]
-	elif price == 0:
-		display_text = "%s — %s (Free)" % [item_name, archetype]
-	else:
-		display_text = "%s — %s — %d 🔩" % [item_name, archetype, price]
-	lbl.text = display_text
-	lbl.size = Vector2(400, 30)
-	hbox.add_child(lbl)
-	
-	if not owned:
-		var btn := Button.new()
-		btn.text = "Buy" if price <= game_state.bolts else "Can't afford"
-		btn.disabled = price > game_state.bolts
-		btn.size = Vector2(120, 28)
-		btn.pressed.connect(_on_buy.bind(category, type))
-		hbox.add_child(btn)
-	
-	# Details toggle
-	var det_btn := Button.new()
-	det_btn.text = "📊" if not details_expanded.get(key, false) else "▲"
-	det_btn.size = Vector2(40, 28)
-	det_btn.pressed.connect(func():
-		details_expanded[key] = not details_expanded.get(key, false)
-		_build_ui()
-	)
-	hbox.add_child(det_btn)
-	
-	_item_container.add_child(hbox)
-	y += 30
-	
-	# Description line
-	if desc != "":
-		var desc_lbl := Label.new()
-		desc_lbl.text = desc
-		desc_lbl.add_theme_font_size_override("font_size", 11)
-		desc_lbl.add_theme_color_override("font_color", Color(0.7, 0.7, 0.7))
-		desc_lbl.position = Vector2(60, y)
-		desc_lbl.size = Vector2(600, 20)
-		_item_container.add_child(desc_lbl)
-		y += 20
-	
-	# Expanded stats
-	if details_expanded.get(key, false):
-		for stat_key in data.keys():
-			if stat_key in ["name", "archetype", "description"]:
-				continue
-			var stat_lbl := Label.new()
-			stat_lbl.text = "  %s: %s" % [stat_key, str(data[stat_key])]
-			stat_lbl.add_theme_font_size_override("font_size", 10)
-			stat_lbl.add_theme_color_override("font_color", Color(0.5, 0.5, 0.5))
-			stat_lbl.position = Vector2(70, y)
-			stat_lbl.size = Vector2(500, 16)
-			_item_container.add_child(stat_lbl)
-			y += 16
-	
-	return y
+	# Collect items for this section
+	var items: Array = []
+	for t in prices.keys():
+		var d: Dictionary = data_fn.call(t)
+		items.append({
+			"category": category,
+			"type": int(t),
+			"data": d,
+			"price": int(prices[t]),
+			"owned": t in owned,
+			"name": String(d.get("name", "???")),
+			"archetype": String(d.get("archetype", "")),
+		})
 
-func _add_shop_item(item_name: String, price: int, owned: bool, category: String, type: int, y: int) -> int:
-	var hbox := HBoxContainer.new()
-	hbox.position = Vector2(40, y)
-	hbox.size = Vector2(500, 30)
-	
-	var lbl := Label.new()
-	if owned:
-		lbl.text = "✅ %s" % item_name
-	elif price == 0:
-		lbl.text = "%s (Free)" % item_name
+	# Rows of `cols` cards
+	var row_index := 0
+	var i := 0
+	while i < items.size():
+		var row_items: Array = items.slice(i, min(i + cols, items.size()))
+		var row := HBoxContainer.new()
+		row.name = "Row_%s_%d" % [title, row_index]
+		row.add_theme_constant_override("separation", GUTTER)
+		for it in row_items:
+			row.add_child(_build_card(it))
+		section.add_child(row)
+
+		# Expand panel goes BELOW this row if any of its cards is the expanded one
+		for it in row_items:
+			var key := _key_for(it)
+			if key == _expanded_key:
+				section.add_child(_build_expand_panel(it))
+				break
+
+		i += cols
+		row_index += 1
+
+	_content_vbox.add_child(section)
+
+func _key_for(it: Dictionary) -> String:
+	return "%s_%d" % [String(it["category"]), int(it["type"])]
+
+# --- Card ---
+
+func _build_card(it: Dictionary) -> Control:
+	var category := String(it["category"])
+	var item_name := String(it["name"])
+	var archetype := String(it["archetype"])
+	var price := int(it["price"])
+	var owned := bool(it["owned"])
+	var key := _key_for(it)
+
+	var card := Button.new()  # Button to get built-in click handling
+	card.name = "Card_%s" % key
+	card.flat = true
+	card.toggle_mode = false
+	card.custom_minimum_size = Vector2(CARD_W, CARD_H)
+	card.size = Vector2(CARD_W, CARD_H)
+	card.set_meta("category", category)
+	card.set_meta("type", int(it["type"]))
+	card.set_meta("price", price)
+	card.set_meta("owned", owned)
+	card.set_meta("name", item_name)
+
+	# Background panel
+	var bg := ColorRect.new()
+	bg.name = "Bg"
+	bg.color = Color(0.12, 0.12, 0.14)
+	bg.position = Vector2.ZERO
+	bg.size = Vector2(CARD_W, CARD_H)
+	bg.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	card.add_child(bg)
+
+	# Art tile (placeholder: category fill + border + monogram)
+	var art := Panel.new()
+	art.name = "Art"
+	art.position = Vector2(0, 0)
+	art.size = Vector2(CARD_W, ART_H)
+	art.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	var sb := StyleBoxFlat.new()
+	sb.bg_color = CAT_COLORS[category]["fill"]
+	sb.border_color = CAT_COLORS[category]["border"]
+	sb.set_border_width_all(3)
+	art.add_theme_stylebox_override("panel", sb)
+	card.add_child(art)
+
+	# Monogram: first letter of the last word of the name (spec §7: multi-word items)
+	var glyph := _monogram(item_name)
+	var mono := Label.new()
+	mono.name = "Monogram"
+	mono.text = glyph
+	mono.add_theme_font_size_override("font_size", 48)
+	mono.add_theme_color_override("font_color", COLOR_CREAM)
+	mono.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	mono.vertical_alignment = VERTICAL_ALIGNMENT_CENTER
+	mono.position = Vector2(0, 0)
+	mono.size = Vector2(CARD_W, ART_H)
+	mono.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	card.add_child(mono)
+
+	# Name
+	var name_lbl := Label.new()
+	name_lbl.name = "Name"
+	name_lbl.text = item_name
+	name_lbl.add_theme_font_size_override("font_size", 16)
+	name_lbl.add_theme_color_override("font_color", COLOR_CREAM)
+	name_lbl.position = Vector2(10, ART_H + 10)
+	name_lbl.size = Vector2(CARD_W - 20, 22)
+	name_lbl.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	card.add_child(name_lbl)
+
+	# Archetype tag: "{archetype} • {Category}" (Category capitalized)
+	var tag := Label.new()
+	tag.name = "Tag"
+	var arch_str := archetype
+	if arch_str == "":
+		arch_str = _category_display(category)
+		tag.text = arch_str
 	else:
-		lbl.text = "%s — %d 🔩" % [item_name, price]
-	lbl.size = Vector2(300, 30)
-	hbox.add_child(lbl)
-	
-	if not owned:
-		var btn := Button.new()
-		btn.text = "Buy" if price <= game_state.bolts else "Can't afford"
-		btn.disabled = price > game_state.bolts
-		btn.size = Vector2(120, 28)
-		btn.pressed.connect(_on_buy.bind(category, type))
-		hbox.add_child(btn)
-	
-	_item_container.add_child(hbox)
-	return y + 30
+		tag.text = "%s • %s" % [arch_str, _category_display(category)]
+	tag.add_theme_font_size_override("font_size", 11)
+	tag.add_theme_color_override("font_color", COLOR_MUTED)
+	tag.position = Vector2(10, ART_H + 34)
+	tag.size = Vector2(CARD_W - 20, 16)
+	tag.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	card.add_child(tag)
+
+	# Price (bottom-right)
+	var price_lbl := Label.new()
+	price_lbl.name = "Price"
+	if owned:
+		price_lbl.text = "✓ Owned"
+		price_lbl.add_theme_color_override("font_color", COLOR_OWNED_GREEN)
+	elif price == 0:
+		price_lbl.text = "Free"
+		price_lbl.add_theme_color_override("font_color", COLOR_CREAM)
+	else:
+		price_lbl.text = "%d 🔩" % price
+		if price > game_state.bolts:
+			price_lbl.add_theme_color_override("font_color", COLOR_UNAFFORDABLE)
+		else:
+			price_lbl.add_theme_color_override("font_color", COLOR_CREAM)
+	price_lbl.add_theme_font_size_override("font_size", 18)
+	price_lbl.horizontal_alignment = HORIZONTAL_ALIGNMENT_RIGHT
+	price_lbl.position = Vector2(10, CARD_H - 32)
+	price_lbl.size = Vector2(CARD_W - 20, 22)
+	price_lbl.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	card.add_child(price_lbl)
+
+	# Owned badge overlay (green check top-right of art)
+	if owned:
+		var badge := Label.new()
+		badge.name = "OwnedBadge"
+		badge.text = "✓"
+		badge.add_theme_font_size_override("font_size", 28)
+		badge.add_theme_color_override("font_color", COLOR_OWNED_GREEN)
+		badge.position = Vector2(CARD_W - 34, 6)
+		badge.size = Vector2(28, 28)
+		badge.mouse_filter = Control.MOUSE_FILTER_IGNORE
+		card.add_child(badge)
+		card.modulate = Color(1, 1, 1, 0.5)
+
+	# Tap handler — capture the full dict
+	card.pressed.connect(_toggle_expand.bind(it))
+	return card
+
+func _monogram(item_name: String) -> String:
+	# Use first letter of the last word so "Plasma Cutter" -> "C" vs "Plating" -> "P".
+	var parts := item_name.strip_edges().split(" ", false)
+	if parts.size() == 0:
+		return "?"
+	var last: String = String(parts[parts.size() - 1])
+	if last.length() == 0:
+		return "?"
+	return last.substr(0, 1).to_upper()
+
+func _category_display(category: String) -> String:
+	match category:
+		"weapon": return "Weapon"
+		"armor": return "Armor"
+		"chassis": return "Chassis"
+		"module": return "Module"
+	return category.capitalize()
+
+# --- Expand panel ---
+
+func _toggle_expand(it: Dictionary) -> void:
+	var key := _key_for(it)
+	if _expanded_key == key:
+		_expanded_key = ""
+	else:
+		_expanded_key = key
+	_build_ui()
+
+func _build_expand_panel(it: Dictionary) -> Control:
+	var category := String(it["category"])
+	var item_name := String(it["name"])
+	var data: Dictionary = it["data"]
+	var price := int(it["price"])
+	var owned := bool(it["owned"])
+
+	var panel := PanelContainer.new()
+	panel.name = "ExpandPanel_%s" % _key_for(it)
+	var sb := StyleBoxFlat.new()
+	sb.bg_color = Color(0.08, 0.08, 0.1)
+	sb.border_color = CAT_COLORS[category]["border"]
+	sb.set_border_width_all(2)
+	sb.content_margin_left = 16
+	sb.content_margin_right = 16
+	sb.content_margin_top = 12
+	sb.content_margin_bottom = 12
+	panel.add_theme_stylebox_override("panel", sb)
+
+	var v := VBoxContainer.new()
+	v.add_theme_constant_override("separation", 6)
+	panel.add_child(v)
+
+	# Top row: title + collapse
+	var top := HBoxContainer.new()
+	var title_lbl := Label.new()
+	title_lbl.text = item_name.to_upper()
+	title_lbl.add_theme_font_size_override("font_size", 20)
+	title_lbl.add_theme_color_override("font_color", COLOR_CREAM)
+	title_lbl.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	top.add_child(title_lbl)
+
+	var close_btn := Button.new()
+	close_btn.name = "CollapseButton"
+	close_btn.text = "✕"
+	close_btn.custom_minimum_size = Vector2(32, 32)
+	close_btn.pressed.connect(_toggle_expand.bind(it))
+	top.add_child(close_btn)
+	v.add_child(top)
+
+	# Subtitle: archetype + category
+	var arch := String(it["archetype"])
+	var sub := Label.new()
+	if arch != "":
+		sub.text = "%s • %s" % [arch, _category_display(category)]
+	else:
+		sub.text = _category_display(category)
+	sub.add_theme_font_size_override("font_size", 12)
+	sub.add_theme_color_override("font_color", COLOR_MUTED)
+	v.add_child(sub)
+
+	# Stats grid (2 cols)
+	var grid := GridContainer.new()
+	grid.columns = 2
+	grid.add_theme_constant_override("h_separation", 24)
+	for k in data.keys():
+		if String(k) in ["name", "archetype", "description"]:
+			continue
+		var s := Label.new()
+		s.text = "%s: %s" % [str(k), str(data[k])]
+		s.add_theme_font_size_override("font_size", 12)
+		s.add_theme_color_override("font_color", COLOR_CREAM)
+		grid.add_child(s)
+	v.add_child(grid)
+
+	# Description
+	var desc_text: String = String(data.get("description", ""))
+	if desc_text != "":
+		var desc := Label.new()
+		desc.text = desc_text
+		desc.add_theme_font_size_override("font_size", 11)
+		desc.add_theme_color_override("font_color", COLOR_MUTED)
+		desc.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+		desc.custom_minimum_size.x = 600
+		v.add_child(desc)
+
+	# Buy row
+	var buy_row := HBoxContainer.new()
+	buy_row.alignment = BoxContainer.ALIGNMENT_CENTER
+	var buy := Button.new()
+	buy.name = "BuyButton"
+	if owned:
+		buy.text = "✓ Owned"
+		buy.disabled = true
+	elif price > game_state.bolts:
+		buy.text = "Need %d more 🔩" % (price - game_state.bolts)
+		buy.disabled = true
+	else:
+		buy.text = "BUY — %d 🔩" % price if price > 0 else "TAKE (Free)"
+		buy.pressed.connect(_on_buy.bind(category, int(it["type"])))
+	buy.custom_minimum_size = Vector2(240, 40)
+	buy.add_theme_font_size_override("font_size", 16)
+	buy_row.add_child(buy)
+	v.add_child(buy_row)
+
+	return panel
+
+# --- Buy ---
 
 func _on_buy(category: String, type: int) -> void:
 	var success := false
 	match category:
-		"weapon": success = game_state.buy_weapon(type)
-		"armor": success = game_state.buy_armor(type)
+		"weapon":  success = game_state.buy_weapon(type)
+		"armor":   success = game_state.buy_armor(type)
 		"chassis": success = game_state.buy_chassis(type)
-		"module": success = game_state.buy_module(type)
+		"module":  success = game_state.buy_module(type)
 	if success:
 		item_purchased.emit(category, type)
-		_build_ui()  # Rebuild to reflect changes
+		# Collapse panel after successful buy
+		_expanded_key = ""
+		_build_ui()

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -3,7 +3,7 @@ const { defineConfig } = require('@playwright/test');
 
 module.exports = defineConfig({
   testDir: './tests',
-  testMatch: ['smoke.spec.js', 'sprint0-verify.spec.js', 'screen-nav.spec.js', 'battle-view.spec.js'],
+  testMatch: ['smoke.spec.js', 'sprint0-verify.spec.js', 'screen-nav.spec.js', 'battle-view.spec.js', 's13.4-shop-visual.spec.js'],
   timeout: 30000,
   use: {
     baseURL: 'http://localhost:8080',

--- a/tests/s13.4-shop-visual.spec.js
+++ b/tests/s13.4-shop-visual.spec.js
@@ -1,0 +1,127 @@
+// tests/s13.4-shop-visual.spec.js — Sprint 13.4 shop card grid screenshot tests
+// Generates screenshots at 1280w (desktop 3-col) and 720w (mobile 2-col).
+//
+// Note: this spec runs against the local _site build. The deployed build is a
+// Godot canvas, so these tests produce visual-reference screenshots rather than
+// asserting DOM properties. Structural verification (AC #1–15) lives in:
+//   godot/tests/test_sprint13_4.gd (42 unit tests against real ShopScreen nodes)
+//
+// Route `?screen=shop` (added in game_main.gd for S13.4) seeds a new run and
+// lands on the shop directly. `?bolts=N` overrides bolt count for
+// unaffordable/affordable/owned-state screenshots.
+const { test, expect } = require('@playwright/test');
+const fs = require('fs');
+const path = require('path');
+
+const OUT_DIR = 'tests/screenshots/s13.4-shop';
+fs.mkdirSync(OUT_DIR, { recursive: true });
+
+const WAIT_LOAD_MS = 8000;
+
+async function gotoShop(page, bolts) {
+  const qs = bolts != null ? `?screen=shop&bolts=${bolts}` : '?screen=shop';
+  await page.goto(`/game/${qs}`, { waitUntil: 'networkidle', timeout: 30000 });
+  await page.waitForTimeout(WAIT_LOAD_MS);
+}
+
+async function snap(page, name) {
+  const out = path.join(OUT_DIR, `${name}.png`);
+  await page.screenshot({ path: out, fullPage: true });
+  console.log(`  -> ${out}`);
+}
+
+async function hasCanvasOrContent(page) {
+  return page.evaluate(() => {
+    return document.querySelector('canvas') !== null || document.body.innerText.length > 0;
+  });
+}
+
+// --- Desktop (1280w) ---
+test('s13.4 shop - desktop 3-col grid layout', async ({ browser }) => {
+  const ctx = await browser.newContext({ viewport: { width: 1280, height: 720 } });
+  const page = await ctx.newPage();
+  await gotoShop(page, 500);
+  expect(await hasCanvasOrContent(page)).toBeTruthy();
+  await snap(page, 'desktop-3col-grid');
+  await ctx.close();
+});
+
+test('s13.4 shop - desktop bolts counter prominent', async ({ browser }) => {
+  const ctx = await browser.newContext({ viewport: { width: 1280, height: 720 } });
+  const page = await ctx.newPage();
+  await gotoShop(page, 1240);
+  await snap(page, 'desktop-bolts-counter');
+  await ctx.close();
+});
+
+test('s13.4 shop - desktop unaffordable state (bolts=100)', async ({ browser }) => {
+  const ctx = await browser.newContext({ viewport: { width: 1280, height: 720 } });
+  const page = await ctx.newPage();
+  await gotoShop(page, 100);
+  await snap(page, 'desktop-unaffordable');
+  await ctx.close();
+});
+
+test('s13.4 shop - desktop owned state (default loadout visible)', async ({ browser }) => {
+  const ctx = await browser.newContext({ viewport: { width: 1280, height: 720 } });
+  const page = await ctx.newPage();
+  await gotoShop(page, 500);
+  await snap(page, 'desktop-owned-state');
+  await ctx.close();
+});
+
+test('s13.4 shop - desktop expanded card (click a card)', async ({ browser }) => {
+  const ctx = await browser.newContext({ viewport: { width: 1280, height: 720 } });
+  const page = await ctx.newPage();
+  await gotoShop(page, 500);
+  await page.mouse.click(200, 240);
+  await page.waitForTimeout(1000);
+  await snap(page, 'desktop-expanded-card');
+  await ctx.close();
+});
+
+test('s13.4 shop - desktop buy flow before', async ({ browser }) => {
+  const ctx = await browser.newContext({ viewport: { width: 1280, height: 720 } });
+  const page = await ctx.newPage();
+  await gotoShop(page, 500);
+  await snap(page, 'desktop-buy-before');
+  await ctx.close();
+});
+
+test('s13.4 shop - desktop section headers visible', async ({ browser }) => {
+  const ctx = await browser.newContext({ viewport: { width: 1280, height: 720 } });
+  const page = await ctx.newPage();
+  await gotoShop(page, 500);
+  await page.mouse.wheel(0, 400);
+  await page.waitForTimeout(500);
+  await snap(page, 'desktop-section-order');
+  await ctx.close();
+});
+
+// --- Mobile (720w) ---
+test('s13.4 shop - mobile 2-col grid layout', async ({ browser }) => {
+  const ctx = await browser.newContext({ viewport: { width: 720, height: 1024 } });
+  const page = await ctx.newPage();
+  await gotoShop(page, 500);
+  expect(await hasCanvasOrContent(page)).toBeTruthy();
+  await snap(page, 'mobile-2col-grid');
+  await ctx.close();
+});
+
+test('s13.4 shop - mobile unaffordable state', async ({ browser }) => {
+  const ctx = await browser.newContext({ viewport: { width: 720, height: 1024 } });
+  const page = await ctx.newPage();
+  await gotoShop(page, 100);
+  await snap(page, 'mobile-unaffordable');
+  await ctx.close();
+});
+
+test('s13.4 shop - mobile expanded card', async ({ browser }) => {
+  const ctx = await browser.newContext({ viewport: { width: 720, height: 1024 } });
+  const page = await ctx.newPage();
+  await gotoShop(page, 500);
+  await page.mouse.click(160, 240);
+  await page.waitForTimeout(1000);
+  await snap(page, 'mobile-expanded-card');
+  await ctx.close();
+});


### PR DESCRIPTION
## Summary

Sprint 13.4 is a **UI-only pivot** to the Shop Card Grid MVP (Gizmo's design in `docs/design/sprint13.4-shop-card-grid.md`). The prior shop was a vertical text list of 19 items — playtesters consistently read it as "a spreadsheet, not a shop". S13.4 reskins it into a card grid with inline expansion. No combat / balance / economy changes.

**Balance pass is deferred to S14 Fortress Loadout Pass.** S13.4 ships the shop visual only.

## What shipped

### 1. Design doc
- `docs/design/sprint13.4-shop-card-grid.md` — Gizmo's spec committed as-is.

### 2. `ArmorData.archetype` normalized
- Plating → `"Light"` (was `"🛡️ Reliable"`)
- Reactive Mesh → `"Adaptive"` (was `"🪞 Thorns"`)
- Ablative Shell → `"Heavy"` (was `"🧱 Glass Fortress"`)
- Card tags now read cleanly: `Light • Armor`, `Heavy • Armor`, etc.
- One corresponding assertion in `test_sprint4.gd::_test_plating_archetype` updated to `"Light"`.

### 3. `godot/ui/shop_screen.gd` — rewritten
- **Grid:** 3 cols at viewport ≥ 1024w, 2 cols at < 1024w (720w mobile reference).
- **Cards:** 200×240, category-colored art placeholder (weapon=rust, armor=steel, chassis=gunmetal, module=green) with last-word-first-letter monogram ("Plasma Cutter" → `C`, "Plating" → `P`).
- **Inline expansion:** tapping a card opens a stats + buy panel below that row (not modal). Only one panel open at a time. Collapse via `✕` button or tapping same card.
- **Section order:** WEAPONS → ARMOR → CHASSIS → MODULES.
- **Bolts counter:** top-right, 36pt.
- **States:**
  - Owned → 50% opacity + green `✓` badge + `✓ Owned` green text (panel still expandable).
  - Unaffordable → red price (`#D04040`).
  - Expanded buy button shows `Need {N} more 🔩` (disabled) if you can't afford.
- **Backwards-compat:** `setup(state)` kept unchanged; `setup_for_viewport(state, width)` added as a test hook. `continue_pressed` signal contract unchanged. `GameState.buy_*` call sites untouched.
- **Layout implementation:** VBox-of-HBox rows (not `GridContainer`) — Ett flagged `GridContainer` reflow as flaky for mid-grid full-width inserts. Expand panel is inserted between row and next row.
- **Rebuild strategy:** `_build_ui()` uses `remove_child + queue_free` (not just `queue_free`) so there's never a frame where two panels are visible during rapid taps.

### 4. `?screen=shop&bolts=N` URL route
- Added to `godot/game_main.gd` so Playwright can land directly on the shop. Mirrors the existing `?screen=battle` hook.

### 5. GDD updates (`docs/gdd.md`)
- **§10 Art Direction:** new "Shop Card Grid (S13.4)" subsection + "Placeholder Art Palette (S13.4)" palette table.
- **§Balance Changes v4:** new "S13.4 — No balance changes (UI-only)" note flagging S14 as the next balance pass.

## Acceptance criteria (15/15 covered)

All 15 criteria from design doc §4 are asserted by unit tests in `godot/tests/test_sprint13_4.gd`:

| # | Criterion | Test |
|---|---|---|
| 1 | Desktop 3-col grid at 1280w | `_test_columns_desktop` |
| 2 | Mobile 2-col grid at 720w | `_test_columns_mobile` |
| 3 | Card size 200×240 | `_test_card_dimensions` |
| 4 | Section order W→A→C→M | `_test_section_order` |
| 5 | All 19 items rendered | `_test_all_items_present` |
| 6 | Bolts counter 36pt | `_test_bolts_counter_font_size` |
| 7 | `continue_pressed` contract | `_test_continue_signal_contract` |
| 8 | Unaffordable = red price | `_test_unaffordable_price_color` |
| 9 | Affordable coexists at bolts=100 | `_test_unaffordable_price_color` |
| 10 | Owned = ✓ + 50% opacity + badge | `_test_owned_state_rendering` |
| 11 | Archetype tag format | `_test_archetype_tag_format` |
| 12 | Expand-in-place creates panel | `_test_expand_card_inline` |
| 13 | Only one expanded at a time | `_test_only_one_card_expanded` |
| 14 | Buy flow + re-render as owned | `_test_buy_flow` |
| 15 | Buy button disabled when unaffordable | `_test_buy_button_disabled_when_unaffordable` |

Plus: `_test_armor_archetype_values` asserts the Light/Adaptive/Heavy rename.

## Playwright screenshot coverage (10 shots)

New spec `tests/s13.4-shop-visual.spec.js` drives `?screen=shop&bolts=N` at both viewports:

**Desktop (1280w):** `desktop-3col-grid`, `desktop-bolts-counter` (bolts=1240), `desktop-unaffordable` (bolts=100), `desktop-owned-state`, `desktop-expanded-card`, `desktop-buy-before`, `desktop-section-order`.

**Mobile (720w):** `mobile-2col-grid`, `mobile-unaffordable`, `mobile-expanded-card`.

These are visual-reference screenshots against a Godot canvas — structural assertions live in the 42 unit tests (above). Screenshots are generated on CI; not checked in (`.gitignore`).

## Test results

```
godot --headless --script tests/test_runner.gd      → 72 passed / 0 failed (unchanged)
godot --headless --script tests/test_sprint13_4.gd  → 42 passed / 0 failed (new)
npx playwright test                                  → 22 passed / 0 failed (12 prior + 10 new s13.4)
```

Pre-existing `test_sprint4.gd` has 13 unrelated failures (sprint4 stalemate/arena boundary drift, pre-S13.4). My only change there was flipping the Plating archetype assertion to `"Light"` — that specific test passes.

## Files changed

- `docs/design/sprint13.4-shop-card-grid.md` (new, 202 lines)
- `docs/gdd.md` (+34)
- `godot/data/armor_data.gd` (archetype values)
- `godot/game_main.gd` (+8 for `?screen=shop`)
- `godot/tests/test_sprint13_4.gd` (new, 315 lines)
- `godot/tests/test_sprint4.gd` (1-line assertion update)
- `godot/ui/shop_screen.gd` (rewrite)
- `playwright.config.js` (+1 testMatch entry)
- `tests/s13.4-shop-visual.spec.js` (new, 127 lines)

## Scope discipline check
- ✅ UI-only. Combat/balance/economy untouched.
- ✅ No animations, no SFX, no real art commissioning — those are **deferred to S13.5**.
- ✅ Hit the VBox-of-HBox fallback Ett flagged (not a blocker, the deterministic reflow is cleaner anyway).
- ✅ 15/15 acceptance criteria with explicit unit-test coverage.

## Handoff
- **S13.5:** polish — card hover/press animations, purchase SFX, real-art swap-in points for the placeholder tiles.
- **S14:** Fortress Loadout Pass (balance) — see design doc §6.
