### PR TITLE
chore(ci): wire sprint 13.4/13.5 test suites into verify workflow

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -26,6 +26,8 @@ jobs:
           godot --headless --path godot/ --script res://tests/test_runner.gd
           godot --headless --path godot/ --script res://tests/test_sprint13_2.gd
           godot --headless --path godot/ --script res://tests/test_sprint13_3.gd
+          godot --headless --path godot/ --script res://tests/test_sprint13_4.gd
+          godot --headless --path godot/ --script res://tests/test_sprint13_5.gd
 
   playwright:
     name: Playwright Smoke Tests


### PR DESCRIPTION
Addresses Boltz/Specc S13.5 F3 finding — sprint-specific test suites were not running in CI. Includes test_sprint13_4 and test_sprint13_5 (and any other missing sprint suites).