### PR TITLE
[S13.9] feat: opponent loadout pass — templates, picker, integration

### DIFF
--- a/docs/design/sprint13.9-fortress-loadout-pass.md
+++ b/docs/design/sprint13.9-fortress-loadout-pass.md
@@ -1,0 +1,284 @@
+# Sprint 13.9 — S14 Fortress Loadout Pass (Opponent Loadout Templates)
+
+**Status:** Design spec, pre-implementation
+**Author:** Gizmo
+**Depends on:** S13.3 (chassis balance + TCR), S13.4–13.8 (shop/shell UX — no code coupling)
+**Defers from:** S13.3 "Fortress loadout tuning" deferred item
+
+---
+
+## 🚨 TERMINOLOGY ALERT (read first, Ett)
+
+The task brief uses **"Fortress"** to mean **"the AI-brott opponent"** (generic enemy).
+In this codebase, **Fortress is a CHASSIS TYPE** (heavy tank, `ChassisData.ChassisType.FORTRESS`).
+
+To avoid confusion, this spec uses:
+- **Opponent** — the AI-controlled enemy brott (what the brief calls "Fortress")
+- **Fortress (chassis)** — the heavy tank chassis, one of three options
+- **Archetype** — a loadout personality (Tank / Glass Cannon / Skirmisher / Brawler-bully / etc.)
+
+File naming follows suit: **`opponent_loadouts.gd`**, not `fortress_loadouts.gd`.
+If Ett prefers to keep the brief's naming, overrule this — but expect reader whiplash.
+
+---
+
+## §1 Scope
+
+### In scope
+- 4–6 named **opponent loadout templates** in `godot/data/opponent_loadouts.gd`
+- Template picker: `pick_opponent_loadout(difficulty, last_archetype) -> Dictionary`
+- **Variety guarantee**: no back-to-back same archetype
+- **Difficulty scaling**: templates tiered by power level; picker filters by tier
+- Integration into `OpponentData.build_opponent_brott()` (replaces hardcoded scrapyard entries, OR augments for future leagues — see §5)
+- `test_sprint13_9.gd` with ≥12 tests
+- GDD update: `docs/gdd.md §4` (opponents/progression) — document archetype taxonomy
+
+### DO NOT EXCEED
+- ❌ No new weapons / armor / modules / chassis (reuse existing enums only)
+- ❌ No audio (parked, per standing rule)
+- ❌ No visual distinctions beyond the `name` field in `BrottState.bot_name`
+- ❌ No rarity tables / loot / cross-run progression
+- ❌ No changes to `BrottBrain` logic, TCR timings, or combat core
+- ❌ No new leagues (Bronze etc. stay empty; spec leaves hooks only)
+- ❌ **Budget: ≤300 LoC total across `opponent_loadouts.gd` + integration diffs + tests**
+- ❌ If counter-play + variety + difficulty together blow budget → **drop counter-play**
+
+---
+
+## §2 Current Opponent Build Path (verified)
+
+**File:** `godot/game/opponent_data.gd` (single source of truth, ~60 LoC)
+
+**Flow:**
+1. `GameState.current_league` holds league string (currently only `"scrapyard"`; `bronze_unlocked` flag exists but bronze league is empty)
+2. `OpponentData.get_league_opponents(league)` returns a **hardcoded `Array[Dictionary]`** of 3 entries for scrapyard:
+   - `scrapyard_0` "Rusty" — Scout + Plasma Cutter, no armor, aggressive
+   - `scrapyard_1` "Tincan" — Scout + Plasma Cutter + Plating, defensive
+   - `scrapyard_2` "Crusher" — Brawler + Plasma Cutter + Shotgun, no armor, kiting
+3. `OpponentData.build_opponent_brott(league, index)` reads a dict → constructs `BrottState` → assigns `BrottBrain.default_for_chassis()` if no custom brain
+
+**Key facts:**
+- There is **NO "fortress_ai.gd"**, **NO `enemy_builder.gd`**, **NO random picker**. Loadouts are fully static.
+- Difficulty signal: **index within league** (0, 1, 2). No `run_depth`, no explicit difficulty tier. We'll use `(league, index)` → tier mapping (§4).
+- Archetype tagging on chassis: **not present**. Chassis data (`chassis_data.gd`) has stats + TCR timings but no `archetype` field. Archetypes are implicit from stat shape. We introduce archetype as a **template-level concept**, not a chassis-level one.
+- `BrottBrain` has `default_for_chassis()` — opponents inherit per-chassis AI. No custom brains wired in scrapyard data.
+- Enum inventory (for templates):
+  - **Chassis**: SCOUT, BRAWLER, FORTRESS
+  - **Weapons**: MINIGUN, RAILGUN, SHOTGUN, MISSILE_POD, PLASMA_CUTTER, ARC_EMITTER, FLAK_CANNON
+  - **Armor**: NONE, PLATING, REACTIVE_MESH, ABLATIVE_SHELL
+  - **Modules**: OVERCLOCK, REPAIR_NANITES, SHIELD_PROJECTOR, SENSOR_ARRAY, AFTERBURNER, EMP_CHARGE
+  - **Stance**: 0 (Aggressive) / 1 (Defensive) / 2 (Kiting)
+
+---
+
+## §3 Loadout Template Schema + Starter Templates
+
+### 3.1 Schema
+
+```gdscript
+# opponent_loadouts.gd
+class_name OpponentLoadouts
+extends RefCounted
+
+enum Archetype { TANK, GLASS_CANNON, SKIRMISHER, BRUISER, CONTROLLER }
+
+# Each template is a Dictionary with:
+#   "id":        String (stable key)
+#   "name":      String (display; stored in BrottState.bot_name)
+#   "archetype": Archetype enum
+#   "tier":      int  (1=weakest, 2=mid, 3=strongest)
+#   "chassis":   ChassisData.ChassisType
+#   "weapons":   Array[WeaponData.WeaponType]  (respect chassis weapon_slots)
+#   "armor":     ArmorData.ArmorType
+#   "modules":   Array[ModuleData.ModuleType]  (respect chassis module_slots)
+#   "stance":    int  (0/1/2)
+```
+
+### 3.2 Starter templates (5, one per archetype)
+
+| id | name | archetype | tier | chassis | weapons | armor | modules | stance |
+|---|---|---|---|---|---|---|---|---|
+| `tank_ironclad` | "Ironclad" | TANK | 2 | FORTRESS | [SHOTGUN, FLAK_CANNON] | ABLATIVE_SHELL | [REPAIR_NANITES] | 1 (Def) |
+| `glass_sniper` | "Pinprick" | GLASS_CANNON | 2 | SCOUT | [RAILGUN, PLASMA_CUTTER] | NONE | [OVERCLOCK, SENSOR_ARRAY, AFTERBURNER] | 2 (Kite) |
+| `skirmish_wasp` | "Wasp" | SKIRMISHER | 1 | SCOUT | [FLAK_CANNON, PLASMA_CUTTER] | PLATING | [AFTERBURNER, SENSOR_ARRAY, OVERCLOCK] | 2 (Kite) |
+| `bruiser_crusher` | "Crusher-II" | BRUISER | 2 | BRAWLER | [SHOTGUN, MINIGUN] | REACTIVE_MESH | [OVERCLOCK, REPAIR_NANITES] | 0 (Agg) |
+| `controller_jammer` | "Jammer" | CONTROLLER | 3 | BRAWLER | [ARC_EMITTER, MISSILE_POD] | REACTIVE_MESH | [EMP_CHARGE, SHIELD_PROJECTOR] | 1 (Def) |
+
+**Tier-1 variant (weakest, replaces scrapyard_0/1 equivalents):**
+| `tank_tincan` | "Tincan" | TANK | 1 | SCOUT | [PLASMA_CUTTER] | PLATING | [] | 1 (Def) |
+
+→ **6 total templates**, 5 distinct archetypes, all tiers 1–3 represented.
+
+### 3.3 Validity rules
+- Every `weapons.size() ≤ chassis.weapon_slots`
+- Every `modules.size() ≤ chassis.module_slots`
+- All enum values must exist (enforced by test `test_templates_use_valid_enums`)
+
+---
+
+## §4 Picker Algorithm
+
+```gdscript
+static func pick_opponent_loadout(
+    difficulty_tier: int,
+    last_archetype: int = -1,
+) -> Dictionary:
+    # 1. Filter by tier: allow tier == difficulty_tier,
+    #    plus tier == difficulty_tier - 1 (weaker fallback) if filtered pool < 2
+    var pool := TEMPLATES.filter(func(t): return t.tier == difficulty_tier)
+    if pool.size() < 2:
+        pool += TEMPLATES.filter(func(t): return t.tier == difficulty_tier - 1)
+
+    # 2. Variety: if last_archetype set, strip matching archetypes
+    #    UNLESS pool would become empty (then keep it)
+    if last_archetype != -1:
+        var varied := pool.filter(func(t): return t.archetype != last_archetype)
+        if not varied.is_empty():
+            pool = varied
+
+    # 3. Deterministic-ish pick (use RandomNumberGenerator; injectable seed for tests)
+    return pool.pick_random()
+```
+
+### 4.1 Difficulty tier mapping
+- **Scrapyard indices 0,1,2** → tiers **1, 1, 2**
+- **Bronze indices 0,1,2** → tiers **2, 2, 3** (hooks only; league still unpopulated)
+- Mapping lives in `OpponentLoadouts.difficulty_for(league, index)`. Centralizes future adjustments.
+
+### 4.2 Variety state
+- State lives on `GameState` as `var _last_opponent_archetype: int = -1`
+- Set after each `build_opponent_brott` call
+- Cleared on `new_game()` (already reconstructs `GameState`, so automatic)
+
+### 4.3 Counter-play — DEFERRED
+Per LoC budget guidance in brief. Mark as **Sprint 13.10 / S14 stretch**. Hook:
+```gdscript
+# pick_opponent_loadout(tier, last_archetype, player_archetype_hint := -1)
+# Unused param now; reserved for counter-play logic.
+```
+Pass `-1` from all current callers.
+
+---
+
+## §5 Integration Point
+
+**File:** `godot/game/opponent_data.gd`
+
+**Change:** `build_opponent_brott()` uses picker instead of static dict lookup.
+
+```gdscript
+static func build_opponent_brott(league: String, index: int, game_state: GameState = null) -> BrottState:
+    var tier := OpponentLoadouts.difficulty_for(league, index)
+    var last_arch := game_state._last_opponent_archetype if game_state else -1
+    var template := OpponentLoadouts.pick_opponent_loadout(tier, last_arch)
+
+    var b := BrottState.new()
+    b.team = 1
+    b.bot_name = template["name"]
+    b.chassis_type = template["chassis"]
+    for wt in template["weapons"]:
+        b.weapon_types.append(wt)
+    b.armor_type = template["armor"]
+    for mt in template["modules"]:
+        b.module_types.append(mt)
+    b.stance = template["stance"]
+    b.setup()
+    b.brain = BrottBrain.default_for_chassis(template["chassis"])
+
+    if game_state:
+        game_state._last_opponent_archetype = template["archetype"]
+    return b
+```
+
+**Callsite audit:** Every caller of `build_opponent_brott(league, index)` must pass `GameState`. Grep target:
+```
+grep -rn "build_opponent_brott" godot/
+```
+Expected hits: `game_flow.gd` (1–2 spots). Update signature or add overload.
+
+**Backward compat:** Keep `get_opponent(league, index)` returning a static stub dict (just `{id, league, index}`) for UI preview if any UI reads it — verify during impl.
+
+---
+
+## §6 Acceptance Criteria
+
+1. `godot/data/opponent_loadouts.gd` exists with ≥4 named templates (target: 6).
+2. Every template uses only existing enum values; no magic numbers.
+3. `OpponentLoadouts.pick_opponent_loadout(tier, last_archetype)` returns a valid `Dictionary` with all required keys.
+4. **Variety:** 10 sequential picks, each fed the prior archetype, never repeat consecutively (unless pool size = 1 for that tier).
+5. **Difficulty scaling:** tier-1 picks never return tier-3 templates; tier-3 picks prefer tier-3.
+6. All templates are distinct (no duplicate `(chassis, weapons[0], archetype)` triple).
+7. `OpponentData.build_opponent_brott()` uses the picker; no hardcoded league loadouts remain.
+8. No regressions: S13.3/.4/.5/.6/.7/.8 test suites pass.
+9. New `test_sprint13_9.gd` ≥12 tests (§7).
+10. GDD `§4` (or closest opponents section) documents the 5 archetypes + tier taxonomy.
+
+---
+
+## §7 Tests (target 12–14)
+
+`godot/tests/test_sprint13_9.gd`:
+
+1. `test_templates_list_nonempty` — ≥4 templates defined
+2. `test_templates_use_valid_enums` — every chassis/weapon/armor/module/stance is a valid enum value
+3. `test_templates_respect_slot_limits` — weapons.size() ≤ chassis.weapon_slots; modules ≤ module_slots
+4. `test_templates_archetypes_cover_min_four` — ≥4 distinct archetypes present
+5. `test_templates_tiers_span_range` — tiers 1, 2, 3 each have ≥1 template
+6. `test_picker_returns_valid_template_tier1`
+7. `test_picker_returns_valid_template_tier3`
+8. `test_picker_variety_10_picks` — run picker 10× with last_archetype feedback; no back-to-back repeats
+9. `test_picker_variety_fallback_when_pool_size_1` — if only 1 template matches tier, picker returns it even if matches last_archetype
+10. `test_difficulty_for_scrapyard` — returns (1,1,2) for indices 0,1,2
+11. `test_build_opponent_brott_uses_picker` — brott has valid chassis/weapons/armor/modules from a template
+12. `test_build_opponent_brott_updates_last_archetype` — GameState `_last_opponent_archetype` set after build
+13. `test_build_opponent_brott_has_brain` — brain is non-null (default_for_chassis fired)
+14. `test_counter_play_hook_accepts_player_hint` — picker signature accepts hint param without crashing (stretch; deletable if counter-play dropped)
+
+---
+
+## §8 Risks / Flags for Ett
+
+1. **🚨 Terminology collision** (§2 alert). "Fortress" = chassis in code. Spec renames artifacts to "opponent_loadouts". If Ett wants to keep brief's naming, grep-replace is trivial but tests/docs will read weird.
+2. **No `fortress_ai.gd` / `enemy_builder.gd` exists.** All opponent construction is in `opponent_data.gd`. Brief's assumption was wrong; spec adjusted.
+3. **No difficulty / run-depth field.** Using `(league, index) → tier` mapping instead. If Ett wants a real depth signal, that's scope creep → separate ticket.
+4. **No archetype tagging on chassis.** Archetypes live on templates, not chassis. Fine for S13.9 but flag if future work wants chassis-level archetype queries.
+5. **`GameState` plumbing.** `build_opponent_brott` needs `GameState` for variety tracking. Small signature change; ripple to 1–2 callsites. Acceptable.
+6. **Counter-play deferred** per budget. Hook left in picker signature (unused param). Reclaim in S13.10 or fold into S14 stretch.
+7. **Bronze league still empty.** S13.9 adds hooks (`difficulty_for("bronze", i)`) but doesn't populate. Bronze content is future work.
+8. **LoC budget risk:** estimated — loadouts file ~90 LoC, integration diff ~30 LoC, tests ~160 LoC = ~280 LoC. Tight but fits. If GDD section writing spills, land it as a separate doc commit.
+9. **`pick_random()` uses Godot's default RNG.** Tests should inject a seeded RNG or accept non-deterministic ordering (variety test is deterministic regardless — it's an invariant, not a specific sequence).
+
+---
+
+## §9 Split-Spawn Recommendation
+
+**Recommend: 2-way split (A + B). Low coupling after schema is frozen.**
+
+### Subagent A — Templates + Picker + Picker Tests
+- Write `godot/data/opponent_loadouts.gd` (schema, 6 templates, `difficulty_for`, `pick_opponent_loadout`)
+- Write tests 1–10 in `test_sprint13_9.gd`
+- **Est:** ~140 LoC. No dependency on B.
+- **Deliverable:** picker green in isolation.
+
+### Subagent B — Integration + GDD + Integration Tests
+- Modify `opponent_data.gd::build_opponent_brott` to use picker
+- Update callsites in `game_flow.gd` (signature change to pass `GameState`)
+- Add `_last_opponent_archetype` to `GameState`
+- Write tests 11–14 in `test_sprint13_9.gd` (append after A lands)
+- Update `docs/gdd.md` §4 with archetype taxonomy
+- **Est:** ~140 LoC (mostly tests + GDD prose). Depends on A's schema + function signatures being frozen.
+- **Deliverable:** full green, S13.3–13.8 regressions clean, GDD updated.
+
+**Coordination:** A lands first (schema freeze). B starts once A's `pick_opponent_loadout` signature is merged. Ett can serialize A→B or let B stub the picker locally if parallelism matters.
+
+---
+
+## Appendix: Template Design Notes (for playtest feel)
+
+- **Tank** = punish players with no sustain; Repair Nanites force long engagements
+- **Glass Cannon** = punish players with no mobility; Railgun + Afterburner forces chase
+- **Skirmisher** = generalist harasser; tests player's positional discipline
+- **Bruiser** = midrange pressure; rewards players who commit TCR windows well
+- **Controller** = disruption; EMP + Arc Emitter punish module-reliant player builds
+
+All archetypes beatable by any player loadout with correct play. No hard counters. Variety guarantee keeps matchups fresh within a run.

--- a/docs/gdd.md
+++ b/docs/gdd.md
@@ -336,6 +336,55 @@ Total: **26 matches** to complete all leagues.
 
 Enemy Brott stat scaling: **none**. Enemies use the same items and stats as the player. Difficulty comes from better BrottBrains and loadout synergy.
 
+### 6.3 Opponent Archetype Taxonomy (Sprint 13.9)
+
+Opponent loadouts are now **template-driven**: each enemy match draws from a
+pool of named templates (`godot/data/opponent_loadouts.gd`) filtered by
+difficulty tier, with a variety guarantee preventing back-to-back archetype
+repeats. Templates are the single source of truth for an opponent's name,
+chassis, weapons, armor, modules, and stance.
+
+**Archetypes** (5):
+
+- **TANK** — Heavy armor, brawler stance, sustain modules. Punishes players with no sustain.
+- **GLASS_CANNON** — No armor, long-range burst (railgun), kiting stance. Punishes players with no mobility.
+- **SKIRMISHER** — Medium armor, flak + mobility modules, kiting stance. Generalist harasser; tests positional discipline.
+- **BRUISER** — Medium armor, dual weapons, aggressive stance. Midrange pressure; rewards TCR-window commitment.
+- **CONTROLLER** — Disruption (jammer / EMP / arc emitter), defensive stance. Punishes module-reliant player builds.
+
+**Starter templates** (6):
+
+| ID | Name | Archetype | Tier | Composition |
+|---|---|---|---|---|
+| `tank_ironclad` | Ironclad | TANK | 2 | Fortress + Shotgun/Flak + Ablative + Repair Nanites |
+| `glass_sniper` | Pinprick | GLASS_CANNON | 2 | Scout + Railgun/Plasma + None + Overclock/Sensor/Afterburner |
+| `skirmish_wasp` | Wasp | SKIRMISHER | 1 | Scout + Flak/Plasma + Plating + Afterburner/Sensor/Overclock |
+| `bruiser_crusher` | Crusher-II | BRUISER | 2 | Brawler + Shotgun/Minigun + Reactive + Overclock/Repair |
+| `controller_jammer` | Jammer | CONTROLLER | 3 | Brawler + Arc/Missile + Reactive + EMP/Shield Projector |
+| `tank_tincan` | Tincan | TANK | 1 | Scout + Plasma + Plating |
+
+**Difficulty tier mapping** (`OpponentLoadouts.difficulty_for(league, index)`):
+
+- **Scrapyard** indices 0, 1, 2 → tiers **1, 1, 2**
+- **Bronze** indices 0, 1, 2 → tiers **2, 2, 3** (hooks only; league unpopulated)
+
+Picker fallback: when a tier's pool has fewer than 2 entries, tier-1-lower
+templates are added. The variety strip (`last_archetype != pick.archetype`)
+is applied last and skipped when it would empty the pool.
+
+**Variety rule:** no two consecutive opponent builds within a run share the
+same archetype. State lives on `GameState._last_opponent_archetype` and is
+naturally cleared by `GameFlow.new_game()` (fresh GameState per run).
+
+**Design notes:**
+
+- Archetypes are a **template-level** concept, not a chassis-level one
+  (per Ett, S13.9). Chassis data carries stats + TCR only; archetype
+  personality comes from the template's weapon/armor/module combination.
+- Counter-play hook reserved for **Sprint 13.10**: picker signature
+  accepts `_player_archetype_hint` (currently unused) so tier/variety
+  logic can later be composed with matchup-aware filtering.
+
 ---
 
 ## 7. Economy

--- a/godot/data/opponent_loadouts.gd
+++ b/godot/data/opponent_loadouts.gd
@@ -1,0 +1,100 @@
+## Sprint 13.9 — Opponent loadout templates + variety-preserving picker.
+## See docs/design/sprint13.9-fortress-loadout-pass.md §3, §4.
+class_name OpponentLoadouts
+extends RefCounted
+
+enum Archetype { TANK, GLASS_CANNON, SKIRMISHER, BRUISER, CONTROLLER }
+
+# Template schema (§3.1): id, name, archetype, tier, chassis, weapons, armor, modules, stance.
+const TEMPLATES: Array[Dictionary] = [
+	{
+		"id": "tank_ironclad",
+		"name": "Ironclad",
+		"archetype": Archetype.TANK,
+		"tier": 2,
+		"chassis": ChassisData.ChassisType.FORTRESS,
+		"weapons": [WeaponData.WeaponType.SHOTGUN, WeaponData.WeaponType.FLAK_CANNON],
+		"armor": ArmorData.ArmorType.ABLATIVE_SHELL,
+		"modules": [ModuleData.ModuleType.REPAIR_NANITES],
+		"stance": 1,
+	},
+	{
+		"id": "glass_sniper",
+		"name": "Pinprick",
+		"archetype": Archetype.GLASS_CANNON,
+		"tier": 2,
+		"chassis": ChassisData.ChassisType.SCOUT,
+		"weapons": [WeaponData.WeaponType.RAILGUN, WeaponData.WeaponType.PLASMA_CUTTER],
+		"armor": ArmorData.ArmorType.NONE,
+		"modules": [ModuleData.ModuleType.OVERCLOCK, ModuleData.ModuleType.SENSOR_ARRAY, ModuleData.ModuleType.AFTERBURNER],
+		"stance": 2,
+	},
+	{
+		"id": "skirmish_wasp",
+		"name": "Wasp",
+		"archetype": Archetype.SKIRMISHER,
+		"tier": 1,
+		"chassis": ChassisData.ChassisType.SCOUT,
+		"weapons": [WeaponData.WeaponType.FLAK_CANNON, WeaponData.WeaponType.PLASMA_CUTTER],
+		"armor": ArmorData.ArmorType.PLATING,
+		"modules": [ModuleData.ModuleType.AFTERBURNER, ModuleData.ModuleType.SENSOR_ARRAY, ModuleData.ModuleType.OVERCLOCK],
+		"stance": 2,
+	},
+	{
+		"id": "bruiser_crusher",
+		"name": "Crusher-II",
+		"archetype": Archetype.BRUISER,
+		"tier": 2,
+		"chassis": ChassisData.ChassisType.BRAWLER,
+		"weapons": [WeaponData.WeaponType.SHOTGUN, WeaponData.WeaponType.MINIGUN],
+		"armor": ArmorData.ArmorType.REACTIVE_MESH,
+		"modules": [ModuleData.ModuleType.OVERCLOCK, ModuleData.ModuleType.REPAIR_NANITES],
+		"stance": 0,
+	},
+	{
+		"id": "controller_jammer",
+		"name": "Jammer",
+		"archetype": Archetype.CONTROLLER,
+		"tier": 3,
+		"chassis": ChassisData.ChassisType.BRAWLER,
+		"weapons": [WeaponData.WeaponType.ARC_EMITTER, WeaponData.WeaponType.MISSILE_POD],
+		"armor": ArmorData.ArmorType.REACTIVE_MESH,
+		"modules": [ModuleData.ModuleType.EMP_CHARGE, ModuleData.ModuleType.SHIELD_PROJECTOR],
+		"stance": 1,
+	},
+	{
+		"id": "tank_tincan",
+		"name": "Tincan",
+		"archetype": Archetype.TANK,
+		"tier": 1,
+		"chassis": ChassisData.ChassisType.SCOUT,
+		"weapons": [WeaponData.WeaponType.PLASMA_CUTTER],
+		"armor": ArmorData.ArmorType.PLATING,
+		"modules": [],
+		"stance": 1,
+	},
+]
+
+## §4.1 — maps (league, index) to a difficulty tier.
+static func difficulty_for(league: String, index: int) -> int:
+	match league:
+		"scrapyard":
+			var tiers := [1, 1, 2]
+			return tiers[index] if index >= 0 and index < tiers.size() else 1
+		"bronze":
+			var tiers := [2, 2, 3]
+			return tiers[index] if index >= 0 and index < tiers.size() else 2
+		_:
+			return 1
+
+## §4 — tier filter + weaker-tier fallback + variety strip.
+## player_archetype_hint unused; reserved for Sprint 13.10 counter-play.
+static func pick_opponent_loadout(difficulty_tier: int, last_archetype: int = -1, _player_archetype_hint: int = -1) -> Dictionary:
+	var pool: Array = TEMPLATES.filter(func(t): return t.tier == difficulty_tier)
+	if pool.size() < 2:
+		pool += TEMPLATES.filter(func(t): return t.tier == difficulty_tier - 1)
+	if last_archetype != -1:
+		var varied: Array = pool.filter(func(t): return t.archetype != last_archetype)
+		if not varied.is_empty():
+			pool = varied
+	return pool.pick_random()

--- a/godot/data/opponent_loadouts.gd.uid
+++ b/godot/data/opponent_loadouts.gd.uid
@@ -1,0 +1,1 @@
+uid://b8krutfxwynuk

--- a/godot/game/game_state.gd
+++ b/godot/game/game_state.gd
@@ -19,6 +19,11 @@ var equipped_modules: Array[int] = []
 
 ## Progression
 var current_league: String = "scrapyard"
+
+## S13.9: tracks previous opponent archetype for variety-preserving picker.
+## OpponentLoadouts.Archetype enum value, or -1 when unset (fresh run).
+var _last_opponent_archetype: int = -1
+
 var opponents_beaten: Array[String] = []  # "scrapyard_0", "scrapyard_1", etc.
 var first_wins: Array[String] = []  # Tracks first-win bonus
 var bronze_unlocked: bool = false

--- a/godot/game/opponent_data.gd
+++ b/godot/game/opponent_data.gd
@@ -47,27 +47,34 @@ static func get_league_opponents(league: String) -> Array:
 		_:
 			return []
 
-static func build_opponent_brott(league: String, index: int) -> BrottState:
-	var data := get_opponent(league, index)
-	if data.is_empty():
+## S13.9: Uses OpponentLoadouts picker (archetype templates + variety).
+## Legacy get_opponent() retained for UI preview / back-compat reads.
+## game_state is optional; when provided, variety tracking via
+## _last_opponent_archetype prevents back-to-back archetype repeats.
+static func build_opponent_brott(league: String, index: int, game_state: GameState = null) -> BrottState:
+	var tier: int = OpponentLoadouts.difficulty_for(league, index)
+	var last_arch: int = -1
+	if game_state != null:
+		last_arch = game_state._last_opponent_archetype
+	var template: Dictionary = OpponentLoadouts.pick_opponent_loadout(tier, last_arch)
+	if template.is_empty():
 		return null
-	
+
 	var b := BrottState.new()
 	b.team = 1
-	b.bot_name = data["name"]
-	b.chassis_type = data["chassis"]
-	for wt in data["weapons"]:
+	b.bot_name = template["name"]
+	b.chassis_type = template["chassis"]
+	for wt in template["weapons"]:
 		b.weapon_types.append(wt)
-	b.armor_type = data["armor"]
-	for mt in data["modules"]:
+	b.armor_type = template["armor"]
+	for mt in template["modules"]:
 		b.module_types.append(mt)
-	b.stance = data["stance"]
+	b.stance = template["stance"]
 	b.setup()
-	
-	# Use default brain if no custom one specified
-	if data["brain"] == null:
-		b.brain = BrottBrain.default_for_chassis(data["chassis"])
-	
+	b.brain = BrottBrain.default_for_chassis(template["chassis"])
+
+	if game_state != null:
+		game_state._last_opponent_archetype = template["archetype"]
 	return b
 
 static func get_league_size(league: String) -> int:

--- a/godot/game_main.gd
+++ b/godot/game_main.gd
@@ -195,7 +195,7 @@ func _start_match(opponent_index: int) -> void:
 		player_brott.brain = BrottBrain.default_for_chassis(game_flow.game_state.equipped_chassis)
 	
 	# Build enemy brott
-	enemy_brott = OpponentData.build_opponent_brott(game_flow.game_state.current_league, opponent_index)
+	enemy_brott = OpponentData.build_opponent_brott(game_flow.game_state.current_league, opponent_index, game_flow.game_state)
 	enemy_brott.position = Vector2(12 * 32.0, 8 * 32.0)
 	
 	# Create sim

--- a/godot/tests/test_sprint13_8_toast.gd.uid
+++ b/godot/tests/test_sprint13_8_toast.gd.uid
@@ -1,0 +1,1 @@
+uid://c5gt6wfnr14wv

--- a/godot/tests/test_sprint13_9.gd
+++ b/godot/tests/test_sprint13_9.gd
@@ -41,6 +41,10 @@ func _run_all() -> void:
 	_t8_picker_variety_10_picks()
 	_t9_picker_variety_fallback_when_pool_size_1()
 	_t10_difficulty_for_scrapyard()
+	_t11_build_opponent_brott_uses_picker()
+	_t12_build_opponent_brott_variety()
+	_t13_build_opponent_brott_null_game_state()
+	_t14_picker_accepts_player_archetype_hint()
 
 func _is_valid_template(t: Dictionary) -> bool:
 	for k in ["id", "name", "archetype", "tier", "chassis", "weapons", "armor", "modules", "stance"]:
@@ -118,3 +122,63 @@ func _t10_difficulty_for_scrapyard() -> void:
 	assert_eq(OpponentLoadouts.difficulty_for("scrapyard", 0), 1, "T10a scrapyard[0]=1")
 	assert_eq(OpponentLoadouts.difficulty_for("scrapyard", 1), 1, "T10b scrapyard[1]=1")
 	assert_eq(OpponentLoadouts.difficulty_for("scrapyard", 2), 2, "T10c scrapyard[2]=2")
+
+## ===== Nutts-B integration tests (11-14) =====
+
+func _template_archetypes_for_tier(tier: int) -> Array:
+	var pool: Array = []
+	for t in OpponentLoadouts.TEMPLATES:
+		if t.tier == tier:
+			pool.append(t.archetype)
+		elif tier == 1 and t.tier == 0:  # won't happen, tiers start at 1
+			pool.append(t.archetype)
+	return pool
+
+func _t11_build_opponent_brott_uses_picker() -> void:
+	var gs := GameState.new()
+	# scrapyard[2] -> tier 2. Call a few times; every result must match a template.
+	var all_ok := true
+	for i in 5:
+		var b: BrottState = OpponentData.build_opponent_brott("scrapyard", 2, gs)
+		if b == null:
+			all_ok = false
+			break
+		var matched := false
+		for t in OpponentLoadouts.TEMPLATES:
+			if t.name == b.bot_name and t.chassis == b.chassis_type and t.armor == b.armor_type and t.stance == b.stance:
+				matched = true
+				break
+		if not matched:
+			all_ok = false
+			break
+	assert_true(all_ok, "T11 build_opponent_brott_uses_picker — brott fields match a template")
+
+func _t12_build_opponent_brott_variety() -> void:
+	# scrapyard[2] tier 2. Pool at tier 2 has 3 templates across ≥2 archetypes.
+	# 5 consecutive builds with the same GameState: never back-to-back same archetype.
+	var gs := GameState.new()
+	var last_arch: int = -1
+	var no_repeat := true
+	var any_brott := true
+	for i in 5:
+		var b: BrottState = OpponentData.build_opponent_brott("scrapyard", 2, gs)
+		if b == null:
+			any_brott = false
+			break
+		var arch: int = gs._last_opponent_archetype
+		if last_arch != -1 and arch == last_arch:
+			no_repeat = false
+		last_arch = arch
+	assert_true(any_brott, "T12a build_opponent_brott_variety — all builds non-null")
+	assert_true(no_repeat, "T12b build_opponent_brott_variety — no back-to-back archetype")
+
+func _t13_build_opponent_brott_null_game_state() -> void:
+	# Back-compat: callable without GameState; must still return a valid brott.
+	var b: BrottState = OpponentData.build_opponent_brott("scrapyard", 0, null)
+	var ok: bool = b != null and b.team == 1 and b.bot_name != "" and b.brain != null
+	assert_true(ok, "T13 build_opponent_brott_null_game_state — valid brott, no crash")
+
+func _t14_picker_accepts_player_archetype_hint() -> void:
+	# Signature stability: third param (player_archetype_hint) accepted without error.
+	var pick: Dictionary = OpponentLoadouts.pick_opponent_loadout(2, -1, OpponentLoadouts.Archetype.TANK)
+	assert_true(_is_valid_template(pick), "T14 picker_accepts_player_archetype_hint — valid template with hint param")

--- a/godot/tests/test_sprint13_9.gd
+++ b/godot/tests/test_sprint13_9.gd
@@ -1,0 +1,120 @@
+## Sprint 13.9 — Opponent loadout template + picker tests (Nutts-A, tests 1-10).
+## Usage: godot --headless --script tests/test_sprint13_9.gd
+## Spec: docs/design/sprint13.9-fortress-loadout-pass.md §7.
+## Tests 11-14 (build_opponent_brott integration + counter-play hook) are Nutts-B's scope.
+extends SceneTree
+
+var pass_count := 0
+var fail_count := 0
+var test_count := 0
+
+func _initialize() -> void:
+	print("=== Sprint 13.9 Opponent Loadouts Tests (Nutts-A) ===\n")
+	_run_all()
+	print("\n=== Results: %d passed, %d failed, %d total ===" % [pass_count, fail_count, test_count])
+	quit(1 if fail_count > 0 else 0)
+
+func assert_true(cond: bool, msg: String) -> void:
+	test_count += 1
+	if cond:
+		pass_count += 1
+	else:
+		fail_count += 1
+		print("  FAIL: %s" % msg)
+
+func assert_eq(a, b, msg: String) -> void:
+	test_count += 1
+	if a == b:
+		pass_count += 1
+	else:
+		fail_count += 1
+		print("  FAIL: %s (got %s, expected %s)" % [msg, str(a), str(b)])
+
+func _run_all() -> void:
+	_t1_templates_list_nonempty()
+	_t2_templates_use_valid_enums()
+	_t3_templates_respect_slot_limits()
+	_t4_templates_archetypes_cover_min_four()
+	_t5_templates_tiers_span_range()
+	_t6_picker_returns_valid_template_tier1()
+	_t7_picker_returns_valid_template_tier3()
+	_t8_picker_variety_10_picks()
+	_t9_picker_variety_fallback_when_pool_size_1()
+	_t10_difficulty_for_scrapyard()
+
+func _is_valid_template(t: Dictionary) -> bool:
+	for k in ["id", "name", "archetype", "tier", "chassis", "weapons", "armor", "modules", "stance"]:
+		if not t.has(k):
+			return false
+	return true
+
+func _t1_templates_list_nonempty() -> void:
+	assert_true(OpponentLoadouts.TEMPLATES.size() >= 4, "T1 templates_list_nonempty (≥4)")
+
+func _t2_templates_use_valid_enums() -> void:
+	var ok := true
+	for t in OpponentLoadouts.TEMPLATES:
+		if not ChassisData.CHASSIS.has(t["chassis"]): ok = false
+		if not ArmorData.ARMORS.has(t["armor"]): ok = false
+		for w in t["weapons"]:
+			if not WeaponData.WEAPONS.has(w): ok = false
+		for m in t["modules"]:
+			if not ModuleData.MODULES.has(m): ok = false
+		if t["stance"] < 0 or t["stance"] > 2: ok = false
+	assert_true(ok, "T2 templates_use_valid_enums")
+
+func _t3_templates_respect_slot_limits() -> void:
+	var ok := true
+	for t in OpponentLoadouts.TEMPLATES:
+		var c: Dictionary = ChassisData.CHASSIS[t["chassis"]]
+		if t["weapons"].size() > c["weapon_slots"]: ok = false
+		if t["modules"].size() > c["module_slots"]: ok = false
+	assert_true(ok, "T3 templates_respect_slot_limits")
+
+func _t4_templates_archetypes_cover_min_four() -> void:
+	var seen := {}
+	for t in OpponentLoadouts.TEMPLATES:
+		seen[t["archetype"]] = true
+	assert_true(seen.size() >= 4, "T4 templates_archetypes_cover_min_four (got %d)" % seen.size())
+
+func _t5_templates_tiers_span_range() -> void:
+	var tiers := {}
+	for t in OpponentLoadouts.TEMPLATES:
+		tiers[t["tier"]] = true
+	assert_true(tiers.has(1) and tiers.has(2) and tiers.has(3), "T5 templates_tiers_span_range")
+
+func _t6_picker_returns_valid_template_tier1() -> void:
+	var pick := OpponentLoadouts.pick_opponent_loadout(1)
+	assert_true(_is_valid_template(pick), "T6 picker_returns_valid_template_tier1")
+
+func _t7_picker_returns_valid_template_tier3() -> void:
+	var pick := OpponentLoadouts.pick_opponent_loadout(3)
+	assert_true(_is_valid_template(pick), "T7 picker_returns_valid_template_tier3")
+
+func _t8_picker_variety_10_picks() -> void:
+	var last := -1
+	var no_repeat := true
+	for i in 10:
+		var pick := OpponentLoadouts.pick_opponent_loadout(2, last)
+		if last != -1 and pick["archetype"] == last:
+			no_repeat = false
+		last = pick["archetype"]
+	assert_true(no_repeat, "T8 picker_variety_10_picks (no back-to-back)")
+
+func _t9_picker_variety_fallback_when_pool_size_1() -> void:
+	# Tier 3 has exactly one template (CONTROLLER/Jammer). With fallback, tier-2 joins the pool
+	# when pool<2, but if we pre-poison the variety strip to remove everything, picker must
+	# still return a non-empty dict. Repeatedly call with last_archetype=CONTROLLER; picker
+	# should not crash and should return a valid template (either the controller itself via
+	# "keep pool when strip empties" OR a tier-2 fallback).
+	for i in 20:
+		var pick := OpponentLoadouts.pick_opponent_loadout(3, OpponentLoadouts.Archetype.CONTROLLER)
+		if not _is_valid_template(pick):
+			assert_true(false, "T9 picker returned invalid template on iter %d" % i)
+			return
+	assert_true(true, "T9 picker_variety_fallback_when_pool_size_1")
+
+func _t10_difficulty_for_scrapyard() -> void:
+	assert_eq(OpponentLoadouts.difficulty_for("scrapyard", 0), 1, "T10a scrapyard[0]=1")
+	assert_eq(OpponentLoadouts.difficulty_for("scrapyard", 1), 1, "T10b scrapyard[1]=1")
+	assert_eq(OpponentLoadouts.difficulty_for("scrapyard", 2), 2, "T10c scrapyard[2]=2")

--- a/godot/tests/test_sprint13_9.gd.uid
+++ b/godot/tests/test_sprint13_9.gd.uid
@@ -1,0 +1,1 @@
+uid://tx4dsg11crlu

--- a/godot/tools/test_harness.gd
+++ b/godot/tools/test_harness.gd
@@ -208,7 +208,7 @@ func _start_arena_match() -> void:
 	var opp_idx := game_flow.selected_opponent_index
 	if opp_idx < 0:
 		opp_idx = 0
-	enemy_brott = OpponentData.build_opponent_brott(game_flow.game_state.current_league, opp_idx)
+	enemy_brott = OpponentData.build_opponent_brott(game_flow.game_state.current_league, opp_idx, game_flow.game_state)
 	enemy_brott.position = Vector2(12 * 32.0, 8 * 32.0)
 
 	# Create sim


### PR DESCRIPTION
Sprint 13.9 — Opponent Loadout Pass (renamed from "Fortress" per chassis-name collision).

**A (templates + picker):** 6 templates across 5 archetypes (TANK/GLASS_CANNON/SKIRMISHER/BRUISER/CONTROLLER), variety-preserving picker, difficulty_for(league, index), tests 1-10.

**B (integration):** opponent_data.gd uses picker, game_state tracks _last_opponent_archetype, game_flow.gd plumbs GameState, tests 11-14, GDD archetype taxonomy.

**Counter-play deferred to S13.10** — picker signature reserves player_archetype_hint hook.

All tests green, no regressions.