### PR TITLE
[S14.2-A] BrottBrain UI polish

### DIFF
--- a/godot/tests/test_sprint14_2_ui.gd
+++ b/godot/tests/test_sprint14_2_ui.gd
@@ -1,0 +1,226 @@
+## Sprint 14.2-A — BrottBrain UI polish tests.
+## Usage: godot --headless --script tests/test_sprint14_2_ui.gd
+## Spec: docs/design/sprint14.2-brottbrain-aggression.md §2 (AC1–AC5)
+extends SceneTree
+
+var pass_count := 0
+var fail_count := 0
+var test_count := 0
+
+func _initialize() -> void:
+	print("=== Sprint 14.2-A BrottBrain UI Polish Tests ===\n")
+	_test_ac1_selected_row_has_distinct_modulate()
+	_test_ac1_unselected_rows_remain_default()
+	_test_ac2_reorder_buttons_disabled_without_selection()
+	_test_ac2_up_disabled_at_top_down_disabled_at_bottom()
+	_test_ac2_both_enabled_in_the_middle()
+	_test_ac3_delete_button_distinct_and_separated_from_select()
+	_test_ac3_delete_clears_selection_of_removed_row()
+	_test_ac4_tray_does_not_overlap_card_list_at_8_cards()
+	_test_ac5_tutorial_copy_matches_button_reorder_model()
+	print("\n=== Results: %d passed, %d failed, %d total ===" % [pass_count, fail_count, test_count])
+	quit(1 if fail_count > 0 else 0)
+
+func _assert(cond: bool, msg: String) -> void:
+	test_count += 1
+	if cond: pass_count += 1
+	else:
+		fail_count += 1
+		print("  FAIL: %s" % msg)
+
+# --- helpers ---
+
+func _mk_screen(card_count: int) -> BrottBrainScreen:
+	var gs := GameState.new()
+	gs.equipped_chassis = ChassisData.ChassisType.BRAWLER
+	gs.equipped_modules = []
+	var brain := BrottBrain.default_for_chassis(gs.equipped_chassis)
+	# Pad or trim to exactly `card_count` cards so tests can drive a known state.
+	while brain.cards.size() < card_count and brain.cards.size() < BrottBrain.MAX_CARDS:
+		brain.cards.append(BrottBrain.BehaviorCard.new(0, 0.4, 0, 0))
+	while brain.cards.size() > card_count:
+		brain.cards.pop_back()
+	var screen := BrottBrainScreen.new()
+	screen.size = Vector2(1280, 720)
+	root.add_child(screen)
+	# Tutorial overlay would clutter child list; pretend it's already dismissed.
+	screen.tutorial_dismissed = true
+	screen.setup(gs, brain)
+	return screen
+
+# Find all Panel children whose meta "card_index" is set — these are card row panels.
+func _card_panels(screen: BrottBrainScreen) -> Array:
+	var out := []
+	for c in screen.get_children():
+		if c is Panel and c.has_meta("card_index"):
+			out.append(c)
+	return out
+
+# Find all Button children whose text starts with "✕" — delete buttons.
+func _delete_buttons(screen: BrottBrainScreen) -> Array:
+	var out := []
+	for c in screen.get_children():
+		if c is Button and c.text == "✕":
+			out.append(c)
+	return out
+
+# Find select overlays (flat buttons with "select_for_index" meta).
+func _select_overlays(screen: BrottBrainScreen) -> Array:
+	var out := []
+	for c in screen.get_children():
+		if c is Button and c.has_meta("select_for_index"):
+			out.append(c)
+	return out
+
+# All tray-related controls: the tray header, WHEN/THEN labels, and every
+# trigger/action button. We identify by Y position (anything at or below the
+# tray origin that isn't a card row or the nav bar).
+func _tray_controls(screen: BrottBrainScreen) -> Array:
+	var out := []
+	for c in screen.get_children():
+		if not (c is Control): continue
+		if c is Panel and c.has_meta("card_index"): continue
+		# Skip navigation buttons (Back / Fight!) which live far below the tray.
+		if c is Button:
+			var t: String = c.text
+			if t.begins_with("← ") or t.begins_with("Fight!"): continue
+		# Skip ▲/▼ reorder buttons — those live alongside the card list, not the tray.
+			if t == "▲ Up" or t == "▼ Down": continue
+		if c.position.y >= BrottBrainScreen.TRAY_TOP - 1:
+			out.append(c)
+	return out
+
+func _rect_of(ctrl: Control) -> Rect2:
+	return Rect2(ctrl.position, ctrl.size)
+
+# --- tests ---
+
+func _test_ac1_selected_row_has_distinct_modulate() -> void:
+	var screen := _mk_screen(4)
+	screen._select_card(2)
+	var panels := _card_panels(screen)
+	_assert(panels.size() == 4, "AC1 four card panels rendered (got %d)" % panels.size())
+	var selected: Panel = null
+	for p in panels:
+		if p.get_meta("card_index") == 2: selected = p; break
+	_assert(selected != null, "AC1 panel with card_index=2 exists")
+	if selected != null:
+		var m: Color = selected.modulate
+		# Distinct from default (1,1,1,1) — we tint blue-ish; any of R/G/B below 0.95 counts.
+		_assert(m != Color(1, 1, 1, 1), "AC1 selected panel modulate is non-default (got %s)" % str(m))
+		_assert(m.b > m.r, "AC1 selected panel has a blue-ish tint (r=%.2f b=%.2f)" % [m.r, m.b])
+	screen.queue_free()
+
+func _test_ac1_unselected_rows_remain_default() -> void:
+	var screen := _mk_screen(3)
+	screen._select_card(0)
+	for p in _card_panels(screen):
+		if p.get_meta("card_index") != 0:
+			_assert(p.modulate == Color(1, 1, 1, 1),
+				"AC1 non-selected panel index %d retains default modulate" % p.get_meta("card_index"))
+	screen.queue_free()
+
+func _test_ac2_reorder_buttons_disabled_without_selection() -> void:
+	var screen := _mk_screen(3)
+	# Default state — no selection.
+	_assert(screen.selected_card_index == -1, "AC2 initial selection is -1")
+	_assert(screen._move_up_btn.disabled, "AC2 ▲ Up disabled when nothing selected")
+	_assert(screen._move_down_btn.disabled, "AC2 ▼ Down disabled when nothing selected")
+	screen.queue_free()
+
+func _test_ac2_up_disabled_at_top_down_disabled_at_bottom() -> void:
+	var screen := _mk_screen(4)
+	screen._select_card(0)
+	_assert(screen._move_up_btn.disabled, "AC2 ▲ Up disabled at top row (idx 0)")
+	_assert(not screen._move_down_btn.disabled, "AC2 ▼ Down enabled at top row")
+	screen._select_card(3)
+	_assert(not screen._move_up_btn.disabled, "AC2 ▲ Up enabled at bottom row")
+	_assert(screen._move_down_btn.disabled, "AC2 ▼ Down disabled at bottom row (idx 3)")
+	screen.queue_free()
+
+func _test_ac2_both_enabled_in_the_middle() -> void:
+	var screen := _mk_screen(5)
+	screen._select_card(2)
+	_assert(not screen._move_up_btn.disabled, "AC2 ▲ Up enabled mid-list")
+	_assert(not screen._move_down_btn.disabled, "AC2 ▼ Down enabled mid-list")
+	screen.queue_free()
+
+func _test_ac3_delete_button_distinct_and_separated_from_select() -> void:
+	var screen := _mk_screen(3)
+	var dels := _delete_buttons(screen)
+	var sels := _select_overlays(screen)
+	_assert(dels.size() == 3, "AC3 three delete buttons (got %d)" % dels.size())
+	_assert(sels.size() == 3, "AC3 three select overlays (got %d)" % sels.size())
+	# Distinct visual: red tint (R > G and R > B).
+	var d: Button = dels[0]
+	_assert(d.modulate.r > d.modulate.g and d.modulate.r > d.modulate.b,
+		"AC3 delete button has red-ish tint (modulate=%s)" % str(d.modulate))
+	# Wider hit area than the stock 35x28.
+	_assert(d.size.x >= 40 and d.size.y >= 30,
+		"AC3 delete button has wider hit area (size=%s)" % str(d.size))
+	# Non-overlapping hit regions: the select overlay for the same row must stop
+	# before the delete button's x starts — clicking ✕ should never land on select.
+	for i in range(3):
+		var del_for_i: Button = null
+		for b in dels:
+			var row_y: float = b.position.y
+			# Delete button y sits at (card_y + 3); find its row by position ordering.
+			if int(row_y) == int(i) * BrottBrainScreen.CARD_ROW_HEIGHT + BrottBrainScreen.CARD_LIST_TOP + 3:
+				del_for_i = b; break
+		var sel_for_i: Button = null
+		for s in sels:
+			if s.get_meta("select_for_index") == i: sel_for_i = s; break
+		if del_for_i == null or sel_for_i == null: continue
+		var sel_right := sel_for_i.position.x + sel_for_i.size.x
+		_assert(sel_right <= del_for_i.position.x,
+			"AC3 select overlay (right=%d) does not reach delete button (left=%d) for row %d"
+				% [int(sel_right), int(del_for_i.position.x), i])
+	screen.queue_free()
+
+func _test_ac3_delete_clears_selection_of_removed_row() -> void:
+	var screen := _mk_screen(4)
+	screen._select_card(2)
+	_assert(screen.selected_card_index == 2, "AC3 pre: idx 2 selected")
+	screen._remove_card(2)
+	# After removal the same numeric index would land on a different logical card.
+	# Deletion should clear selection rather than silently slide it.
+	_assert(screen.selected_card_index == -1,
+		"AC3 delete of selected row clears selection (got %d)" % screen.selected_card_index)
+	_assert(screen.brain.cards.size() == 3, "AC3 card count decremented to 3")
+	screen.queue_free()
+
+func _test_ac4_tray_does_not_overlap_card_list_at_8_cards() -> void:
+	var screen := _mk_screen(8)
+	var panels := _card_panels(screen)
+	_assert(panels.size() == 8, "AC4 eight card rows rendered (got %d)" % panels.size())
+	var card_rects: Array = []
+	for p in panels: card_rects.append(_rect_of(p))
+	var tray := _tray_controls(screen)
+	_assert(tray.size() >= 10, "AC4 tray rendered (got %d controls)" % tray.size())
+	var overlaps := 0
+	for t in tray:
+		var tr := _rect_of(t)
+		for cr in card_rects:
+			if tr.intersects(cr):
+				overlaps += 1
+				print("  AC4 overlap: tray '%s' rect=%s vs card rect=%s" % [
+					(t.text if (t is Button or t is Label) else "?"), str(tr), str(cr)])
+	_assert(overlaps == 0, "AC4 no tray/card overlaps at 8 cards (found %d)" % overlaps)
+	screen.queue_free()
+
+func _test_ac5_tutorial_copy_matches_button_reorder_model() -> void:
+	# Source the tutorial copy from _show_tutorial() by invoking it and scanning labels.
+	var screen := _mk_screen(0)
+	# tutorial_dismissed was set true, so _build_ui skipped it — call directly.
+	screen._show_tutorial()
+	var matched := false
+	for c in screen.get_children():
+		if c is Label:
+			var t: String = c.text
+			# Must mention button-based reorder (▲/▼) or ✕ removal — not drag.
+			if t.contains("▲") or t.contains("▼") or t.contains("✕"):
+				matched = true
+				_assert(not t.to_lower().contains("drag"),
+					"AC5 tutorial copy doesn't claim drag (got: %s)" % t)
+	_assert(matched, "AC5 tutorial mentions ▲/▼/✕ button-reorder controls")
+	screen.queue_free()

--- a/godot/ui/brottbrain_screen.gd
+++ b/godot/ui/brottbrain_screen.gd
@@ -1,6 +1,7 @@
-## BrottBrain editor — Sprint 4: Card-based visual editor with drag-to-reorder
+## BrottBrain editor — card-based visual editor (Sprint 4; S14.2-A UI polish).
+## Reorder model is button-based: tap a card to select, then ▲ Up / ▼ Down to move.
 ## Each card: [emoji] "When..." → [emoji] "Then..."
-## 8 slots, up/down buttons for reorder, smart defaults, tutorial on first visit
+## 8 slots, button-based reorder, smart defaults, tutorial on first visit.
 class_name BrottBrainScreen
 extends Control
 
@@ -40,7 +41,25 @@ const STANCE_NAMES := ["🔥 Go Get 'Em!", "🛡️ Play it Safe", "🔄 Hit & R
 const TARGET_MODES := ["nearest", "weakest", "biggest_threat"]
 const WEAPON_MODES := ["all_fire", "conserve", "hold_fire"]
 
+# S14.2-A layout constants — compact rows so 8 cards + tray fit without overlap.
+const CARD_LIST_TOP: int = 132
+const CARD_ROW_HEIGHT: int = 44       # row pitch (panel 40 + 4 gap)
+const CARD_PANEL_HEIGHT: int = 40
+# Tray is pinned below the max-cards region so AC4 holds even at 8 cards.
+const TRAY_TOP: int = CARD_LIST_TOP + CARD_ROW_HEIGHT * BrottBrain.MAX_CARDS + 12  # = 496
+
+# AC1 — selected-row visual state (light blue tint; default rows render white).
+const SELECTED_MODULATE: Color = Color(0.55, 0.85, 1.0, 1.0)
+# AC3 — delete button distinct tint (red) + wider hit area.
+const DELETE_BTN_MODULATE: Color = Color(1.0, 0.55, 0.55, 1.0)
+const DELETE_BTN_SIZE: Vector2 = Vector2(48, 34)
+
 var selected_card_index: int = -1
+# AC2 — button refs so we can toggle disabled state without rebuilding UI.
+var _move_up_btn: Button = null
+var _move_down_btn: Button = null
+# AC1 — track per-row panels so selecting a card repaints without full rebuild.
+var _card_panels: Array = []
 
 func setup(state: GameState, existing_brain: BrottBrain = null) -> void:
 	game_state = state
@@ -104,39 +123,40 @@ func _build_ui() -> void:
 	add_child(list_hdr)
 	
 	# Draw card slots
-	var y := 132
+	_card_panels = []
+	var y := CARD_LIST_TOP
 	for i in range(brain.cards.size()):
 		y = _draw_card(i, y)
 	
-	# Empty slot indicator
+	# Empty slot indicator (hint text where the next card will land).
 	if brain.cards.size() < BrottBrain.MAX_CARDS:
 		var empty := Label.new()
-		empty.text = "  %d. ┌ ─ ─  + Drag a card here  ─ ─ ┐" % (brain.cards.size() + 1)
+		empty.text = "  %d. ┌ ─ ─  tap a WHEN then a THEN to add  ─ ─ ┐" % (brain.cards.size() + 1)
 		empty.add_theme_font_size_override("font_size", 12)
 		empty.add_theme_color_override("font_color", Color(0.4, 0.4, 0.4))
 		empty.position = Vector2(30, y)
-		empty.size = Vector2(600, 25)
+		empty.size = Vector2(600, 22)
 		add_child(empty)
-		y += 30
 	
-	# Reorder / remove buttons (right side)
+	# Reorder / remove buttons (right side) — state updated by _refresh_reorder_buttons().
 	var btn_x := 680
-	var move_up := Button.new()
-	move_up.text = "▲ Up"
-	move_up.position = Vector2(btn_x, 132)
-	move_up.size = Vector2(90, 32)
-	move_up.pressed.connect(_move_card_up)
-	add_child(move_up)
+	_move_up_btn = Button.new()
+	_move_up_btn.text = "▲ Up"
+	_move_up_btn.position = Vector2(btn_x, CARD_LIST_TOP)
+	_move_up_btn.size = Vector2(90, 32)
+	_move_up_btn.pressed.connect(_move_card_up)
+	add_child(_move_up_btn)
 	
-	var move_down := Button.new()
-	move_down.text = "▼ Down"
-	move_down.position = Vector2(btn_x, 168)
-	move_down.size = Vector2(90, 32)
-	move_down.pressed.connect(_move_card_down)
-	add_child(move_down)
+	_move_down_btn = Button.new()
+	_move_down_btn.text = "▼ Down"
+	_move_down_btn.position = Vector2(btn_x, CARD_LIST_TOP + 36)
+	_move_down_btn.size = Vector2(90, 32)
+	_move_down_btn.pressed.connect(_move_card_down)
+	add_child(_move_down_btn)
+	_refresh_reorder_buttons()
 	
-	# Available cards tray
-	var tray_y: int = maxi(y + 15, 380)
+	# Available cards tray — FIXED Y so card list and tray never collide (AC4).
+	var tray_y: int = TRAY_TOP
 	var tray_hdr := Label.new()
 	tray_hdr.text = "── Available Cards ──"
 	tray_hdr.add_theme_font_size_override("font_size", 14)
@@ -197,15 +217,15 @@ func _build_ui() -> void:
 	# Navigation
 	var back_btn := Button.new()
 	back_btn.text = "← Loadout"
-	back_btn.position = Vector2(20, 650)
-	back_btn.size = Vector2(150, 50)
+	back_btn.position = Vector2(20, 680)
+	back_btn.size = Vector2(150, 40)
 	back_btn.pressed.connect(func(): back_pressed.emit())
 	add_child(back_btn)
 	
 	var cont_btn := Button.new()
 	cont_btn.text = "Fight! →"
-	cont_btn.position = Vector2(1050, 650)
-	cont_btn.size = Vector2(200, 50)
+	cont_btn.position = Vector2(1050, 680)
+	cont_btn.size = Vector2(200, 40)
 	cont_btn.add_theme_font_size_override("font_size", 18)
 	cont_btn.pressed.connect(func(): continue_pressed.emit())
 	add_child(cont_btn)
@@ -219,18 +239,21 @@ func _draw_card(index: int, y: int) -> int:
 	var td: Array = TRIGGER_DISPLAY[card.trigger]
 	var ad: Array = ACTION_DISPLAY[card.action]
 	
-	# Card background panel
+	# Card background panel — AC1: tracked so selection can tint it.
 	var panel := Panel.new()
 	panel.position = Vector2(30, y)
-	panel.size = Vector2(640, 50)
+	panel.size = Vector2(640, CARD_PANEL_HEIGHT)
+	panel.modulate = (SELECTED_MODULATE if index == selected_card_index else Color(1, 1, 1, 1))
+	panel.set_meta("card_index", index)
 	add_child(panel)
+	_card_panels.append(panel)
 	
 	# Priority number
 	var num_lbl := Label.new()
 	num_lbl.text = "%d." % (index + 1)
 	num_lbl.add_theme_font_size_override("font_size", 14)
-	num_lbl.position = Vector2(35, y + 5)
-	num_lbl.size = Vector2(25, 40)
+	num_lbl.position = Vector2(35, y + 4)
+	num_lbl.size = Vector2(25, 36)
 	add_child(num_lbl)
 	
 	# Trigger side: [emoji] "When..." + param
@@ -242,16 +265,16 @@ func _draw_card(index: int, y: int) -> int:
 	var trig_lbl := Label.new()
 	trig_lbl.text = trig_text
 	trig_lbl.add_theme_font_size_override("font_size", 12)
-	trig_lbl.position = Vector2(60, y + 5)
-	trig_lbl.size = Vector2(260, 20)
+	trig_lbl.position = Vector2(60, y + 4)
+	trig_lbl.size = Vector2(260, 18)
 	add_child(trig_lbl)
 	
 	# Arrow
 	var arrow := Label.new()
 	arrow.text = "→"
-	arrow.add_theme_font_size_override("font_size", 18)
-	arrow.position = Vector2(320, y + 8)
-	arrow.size = Vector2(30, 30)
+	arrow.add_theme_font_size_override("font_size", 16)
+	arrow.position = Vector2(320, y + 6)
+	arrow.size = Vector2(30, 28)
 	add_child(arrow)
 	
 	# Action side: [emoji] "Then..." + param
@@ -263,8 +286,8 @@ func _draw_card(index: int, y: int) -> int:
 	var act_lbl := Label.new()
 	act_lbl.text = act_text
 	act_lbl.add_theme_font_size_override("font_size", 12)
-	act_lbl.position = Vector2(355, y + 5)
-	act_lbl.size = Vector2(260, 20)
+	act_lbl.position = Vector2(355, y + 4)
+	act_lbl.size = Vector2(220, 18)
 	add_child(act_lbl)
 	
 	# Param edit hint (smaller text)
@@ -272,29 +295,35 @@ func _draw_card(index: int, y: int) -> int:
 	hint.text = "tap to edit params"
 	hint.add_theme_font_size_override("font_size", 9)
 	hint.add_theme_color_override("font_color", Color(0.5, 0.5, 0.5))
-	hint.position = Vector2(60, y + 28)
-	hint.size = Vector2(200, 15)
+	hint.position = Vector2(60, y + 22)
+	hint.size = Vector2(200, 14)
 	add_child(hint)
 	
-	# Delete button
-	var del_btn := Button.new()
-	del_btn.text = "✕"
-	del_btn.position = Vector2(625, y + 10)
-	del_btn.size = Vector2(35, 28)
-	del_btn.pressed.connect(_remove_card.bind(index))
-	add_child(del_btn)
-	
-	# Select for reorder on click
+	# AC3 — Select overlay is narrower and sits BEHIND the delete button so clicks
+	# on ✕ don't bubble into a select. Overlay ends before the delete button starts.
 	var select_btn := Button.new()
 	select_btn.text = ""
 	select_btn.flat = true
 	select_btn.position = Vector2(30, y)
-	select_btn.size = Vector2(590, 50)
+	select_btn.size = Vector2(570, CARD_PANEL_HEIGHT)  # stops ~20px left of ✕ button
 	select_btn.modulate = Color(1, 1, 1, 0.01)  # nearly invisible overlay
-	select_btn.pressed.connect(func(): selected_card_index = index)
+	select_btn.set_meta("select_for_index", index)
+	select_btn.pressed.connect(_select_card.bind(index))
 	add_child(select_btn)
 	
-	return y + 55
+	# AC3 — Delete button: red tint, wider hit area, added AFTER the overlay so
+	# Godot's top-most-control-wins hit-testing lets clicks reach ✕ without also
+	# triggering the select overlay behind it.
+	var del_btn := Button.new()
+	del_btn.text = "✕"
+	del_btn.modulate = DELETE_BTN_MODULATE
+	del_btn.add_theme_font_size_override("font_size", 14)
+	del_btn.position = Vector2(610, y + 3)
+	del_btn.size = DELETE_BTN_SIZE
+	del_btn.pressed.connect(_remove_card.bind(index))
+	add_child(del_btn)
+	
+	return y + CARD_ROW_HEIGHT
 
 func _format_trigger_param(trigger: int, param: Variant) -> String:
 	var td: Array = TRIGGER_DISPLAY[trigger]
@@ -326,6 +355,27 @@ func _format_action_param(action: int, param: Variant) -> String:
 
 var _pending_trigger: int = -1
 
+# AC1 — click handler for the per-row select overlay. Separated so tests can
+# drive selection without simulating button presses.
+func _select_card(index: int) -> void:
+	selected_card_index = index
+	_repaint_card_selection()
+	_refresh_reorder_buttons()
+
+# AC1 — repaint card row modulates without rebuilding the whole UI.
+func _repaint_card_selection() -> void:
+	for p in _card_panels:
+		if not is_instance_valid(p): continue
+		var idx: int = p.get_meta("card_index", -1)
+		p.modulate = (SELECTED_MODULATE if idx == selected_card_index else Color(1, 1, 1, 1))
+
+# AC2 — keep ▲ Up / ▼ Down honest: disabled unless the move makes sense.
+func _refresh_reorder_buttons() -> void:
+	if _move_up_btn != null:
+		_move_up_btn.disabled = (selected_card_index <= 0 or selected_card_index >= brain.cards.size())
+	if _move_down_btn != null:
+		_move_down_btn.disabled = (selected_card_index < 0 or selected_card_index >= brain.cards.size() - 1)
+
 func _start_add_trigger(trigger_idx: int) -> void:
 	if brain.cards.size() >= BrottBrain.MAX_CARDS:
 		return
@@ -356,8 +406,12 @@ func _start_add_action(action_idx: int) -> void:
 
 func _remove_card(index: int) -> void:
 	brain.cards.remove_at(index)
-	if selected_card_index >= brain.cards.size():
-		selected_card_index = brain.cards.size() - 1
+	# AC3 — ✕ must not quietly re-select the freed slot. Clear selection when the
+	# removed row was selected (or when removal makes the selection out-of-range).
+	if selected_card_index == index or selected_card_index >= brain.cards.size():
+		selected_card_index = -1
+	elif selected_card_index > index:
+		selected_card_index -= 1  # keep the logically-same row selected after shift
 	_build_ui()
 
 func _move_card_up() -> void:
@@ -401,7 +455,9 @@ func _show_tutorial() -> void:
 	add_child(step2)
 	
 	var step3 := Label.new()
-	step3.text = "3️⃣ Click a WHEN card, then a THEN card to add new rules.\n   You can have up to 8!"
+	# AC5 — copy still reads true under the button-reorder model: tap selects,
+	# ▲ Up / ▼ Down reorder, ✕ removes.
+	step3.text = "3️⃣ Tap a WHEN card, then a THEN card to add a rule.\n   Tap a rule to select it, then use ▲ Up / ▼ Down to reorder or ✕ to remove."
 	step3.add_theme_font_size_override("font_size", 13)
 	step3.position = Vector2(170, 310)
 	step3.size = Vector2(460, 40)


### PR DESCRIPTION
## [S14.2-A] BrottBrain UI polish

Spec: `docs/design/sprint14.2-brottbrain-aggression.md` §2 (AC1–AC5).
Scope: single-file edit to `godot/ui/brottbrain_screen.gd` + new headless test `godot/tests/test_sprint14_2_ui.gd`.

### AC status

| AC | Bar | Status | How |
|---|---|---|---|
| **AC1** selected row distinct | hard | ✅ | `_repaint_card_selection()` tints selected panel with `SELECTED_MODULATE` (light blue `Color(0.55, 0.85, 1.0)`); unselected rows stay default white. Each row panel carries a `card_index` meta so repaint is in-place (no full rebuild on select). |
| **AC2** reorder buttons honest | hard | ✅ | Deleted the `drag-to-reorder` claim from the file header. `_move_up_btn` / `_move_down_btn` are stored as refs and `_refresh_reorder_buttons()` sets `disabled` based on selection: disabled when no selection; `▲ Up` disabled at top; `▼ Down` disabled at bottom. Called on every select and every UI rebuild. |
| **AC3** delete distinct + non-colliding | hard | ✅ | `✕` now 48×34 (was 35×28), tinted red via `DELETE_BTN_MODULATE = Color(1.0, 0.55, 0.55)`, with larger font. Select overlay shortened from 590px → 570px so it ends at x=600, and the delete button sits at x=610 → no hit overlap. `_remove_card()` clears `selected_card_index` when the deleted row was selected (previously it silently slid to the adjacent row). |
| **AC4** no tray/card overlap at 8 cards | hard | ✅ | Card rows compacted from 55px to 44px pitch (panel 40px). Tray pinned to fixed `TRAY_TOP = CARD_LIST_TOP + CARD_ROW_HEIGHT * MAX_CARDS + 12 = 496`, removing the float-above-y logic that used to collide with long card lists. Nav buttons moved to y=680 to accommodate. Test `_test_ac4_tray_does_not_overlap_card_list_at_8_cards` renders 8 cards, walks every tray child, and asserts zero rect intersections. |
| **AC5** tutorial copy still true | soft | ✅ | Step 3 now reads: *"Tap a WHEN card, then a THEN card to add a rule. Tap a rule to select it, then use ▲ Up / ▼ Down to reorder or ✕ to remove."* No more implicit drag claim. |

### Tests

- **New:** `godot/tests/test_sprint14_2_ui.gd` — 30 asserts across 9 cases covering AC1–AC5. Follows the `test_sprint14_1_nav.gd` pattern (direct class instantiation, `_assert` helper, `quit(1 if fail_count > 0 else 0)`).
- **Run:** `godot --headless --script tests/test_sprint14_2_ui.gd` → **30 passed, 0 failed**.
- **Regression:** `tests/test_runner.gd` → **72/72 green**. `tests/test_sprint14_1_nav.gd` → **5/5 green**.

### Out of scope (per slice constraints)

- `brottbrain.gd` untouched — Slice B territory.
- `combat_sim.gd` untouched — Slice B territory.
- No `.tscn` changes, no schema changes.
- Reorder-by-buttons kept as the design call; I did not rebuild drag-and-drop.

### Notes for review

- The select overlay was previously `modulate.a = 0.01` and sat on top of the delete button, which is why the bug brief flagged ambiguous clicks near the right edge. Fix is structural (shorten overlay, add delete button after it so Z-order + hit area are both correct), not just cosmetic.
- Consider whether `_repaint_card_selection()` should also adjust panel `theme_override.panel.border_color` for a stronger visual — I stayed with modulate for LoC discipline and because it's already clearly visible against the default panel background. Happy to swap if Boltz prefers a real border.

Do not merge — lead will coordinate review with Boltz.
