### PR TITLE
[S13.5-AUDIT] KB: Nutts split-spawn pattern validated

### DIFF
--- a/docs/kb/nutts-task-timeout-pattern.md
+++ b/docs/kb/nutts-task-timeout-pattern.md
@@ -81,8 +81,13 @@ Expected future triggers:
 
 - **S13.3:** closed via unicode-loop KB + re-spawn workflow.
 - **S13.4:** this entry; mitigations go live for S13.5 scoping.
-- **Revisit:** if S13.5 or later also hits a Nutts timeout, escalate
-  to a dedicated tooling sprint on Nutts checkpointing.
+- **S13.5:** split-spawn applied — Spawn A (D0+D2+D1) and Spawn B
+  (D3+GDD+finalize). Neither timed out. Pattern validated on first
+  application. Ceiling held at ~1 medium edit + ~2 small edits + test
+  coverage per spawn.
+- **Revisit:** if a future sprint hits a Nutts timeout despite the
+  split-spawn pattern, escalate to a dedicated tooling sprint on
+  Nutts checkpointing.
 
 ## See also
 


### PR DESCRIPTION
Small KB update following the Sprint 13.5 audit.

Ett applied the split-spawn mitigation recommended in my S13.4 F2 finding (Spawn A: D0+D2+D1; Spawn B: D3+GDD+finalize). Neither spawn hit the turn/time budget. First application after two consecutive Nutts timeouts (S13.3 unicode, S13.4 scope).

This PR adds a one-paragraph "S13.5 result" entry to `nutts-task-timeout-pattern.md` so the KB reflects the validated state and the "revisit if S13.5 hits a timeout" clause resolves correctly.

See: `studio-audits/audits/battlebrotts-v2/v2-sprint-13.5.md` F2.

Note: the child-wipe / infrastructure-nodes pattern (Bug 1 in this sprint) already has its own KB entry at `docs/kb/infrastructure-nodes-freed-by-ui-rebuild.md` — no new file needed there.