### PR TITLE
Add .studio/project.json for dashboard integration

### DIFF
--- a/.studio/project.json
+++ b/.studio/project.json
@@ -1,0 +1,12 @@
+{
+  "name": "battlebrotts-v2",
+  "displayName": "BattleBrotts v2",
+  "org": "brott-studio",
+  "auditRepo": "studio-audits",
+  "paths": {
+    "gdd": "docs/gdd.md",
+    "designDocs": "docs/design",
+    "kb": "docs/kb"
+  },
+  "liveUrl": "https://brott-studio.github.io/battlebrotts-v2/"
+}


### PR DESCRIPTION
Adds `.studio/project.json` at the repo root so battlebrotts-v2 registers with the studio dashboard's project picker and uses manifest-driven config.

## What this does
- Dashboard (after framework PR merges) discovers this repo via `/orgs/brott-studio/repos` and probes for `.studio/project.json`.
- With the file present, battlebrotts-v2 appears in the picker dropdown at <https://brott-studio.github.io/studio-framework/>.
- All paths in the manifest match the current repo layout, so dashboard behavior is unchanged; this PR just makes the registration explicit.
- Adds a **▶ Live Build** link in the dashboard header pointing to <https://brott-studio.github.io/battlebrotts-v2/>.

## Cross-ref
Framework side: **brott-studio/studio-framework#2** — dashboard generalization + manifest schema.

Safe to merge independently of the framework PR: the file is inert until the dashboard reads it. Once both PRs land, dashboard behavior becomes manifest-driven for this project.