### PR TITLE
[SN-101] Fix juke away-branch to clamp against backup_distance

### DIFF
--- a/docs/kb/juke-bypass-movement-caps.md
+++ b/docs/kb/juke-bypass-movement-caps.md
@@ -1,9 +1,24 @@
 # KB: Juke/Burst Movement Can Bypass Movement Caps
 
-**Sprint:** 11.1  
+**Sprint:** 11.1 (discovered), 15 (follow-up: juke branch gone, new bypass sources found)  
 **Discovered by:** Optic (verification), Specc (root cause)  
 **Severity:** Low  
-**Status:** Open
+**Status:** Partially mitigated (S15 per-path clamps); root-cause Option 2 refactor still deferred
+
+## Update — Sprint 15 (2026-04-17)
+
+The original `juke_type == "away"` branch **no longer exists** in `combat_sim.gd` (`git grep 'juke'` in `godot/combat/combat_sim.gd` is empty; only vestigial `BrottState.juke_type` state remains). The `backup_distance` budget is now respected everywhere inside `_do_combat_movement()`.
+
+However, `test_sprint11_2.gd::test_away_juke_cap_across_seeds` still fails on `main` (8/100 violations on Scout vs Scout close-quarters). Investigation (PR #80, Nutts + Boltz) found **two new unclamped bypass paths** matching the exact same anti-pattern:
+
+1. **Bot-bot separation force** in `_move_brott` (~L535): `b.position += sep.normalized() * repulsion_speed` — when `sep` is anti-parallel to `to_target`, this is unclamped backward movement at up to 11.5 px/tick.
+2. **Unstick nudge** in `_check_and_handle_stuck` (~L613): `b.position += nudge * UNSTICK_NUDGE_PX_PER_TICK` — `_wall_escape_direction` can resolve to a backward vector away from target when no clear wall/pillar signal exists, at 7 px/tick for 8 ticks.
+
+PR #80 applies per-path clamps to both (gating the backward component against the shared `backup_distance` budget, passing lateral/forward through untouched). This closes the two bypass paths Ett scoped without a refactor.
+
+**Remaining failure mode (not fixed by S15):** the test metric `movement.normalized().dot(to_target.normalized()) < -0.7` uses *post-tick* `to_target`. When two bots both COMMIT toward each other at close range, they can swap positions in a single tick — and forward COMMIT push then reads as "backward" in the new post-tick frame. This produces test-metric-registered backward runs of 40–100+ px even though no path retreats in its own reference frame. Reaching `violations == 0` requires either (a) preventing bot-to-bot crossover during COMMIT (a movement-pipeline change) or (b) Option 2 below (post-processing clamp at the tick boundary). Both are refactors; deferred to a follow-up sprint.
+
+**Don't re-chase the juke branch — it's gone. Future moonwalk bugs live in: separation force, unstick nudge, and COMMIT-crossover geometry.**
 
 ## Problem
 

--- a/godot/combat/combat_sim.gd
+++ b/godot/combat/combat_sim.gd
@@ -642,7 +642,28 @@ func _check_and_handle_stuck(b: BrottState) -> void:
 		b._unstick_timer -= 1.0
 		var nudge: Vector2 = _wall_escape_direction(b)
 		if nudge != Vector2.ZERO:
-			b.position += nudge * UNSTICK_NUDGE_PX_PER_TICK
+			# S15 moonwalk fix: clamp the backward component of the unstick nudge
+			# against the shared `backup_distance` budget (TILE_SIZE). The escape
+			# direction can resolve to a backward vector when no clear wall/pillar
+			# signal is available; without this gate, the nudge is a 7px/tick
+			# unclamped retreat source. Forward/lateral components pass through
+			# untouched — the unstick maneuver's job is to escape geometry, not to
+			# out-retreat the moonwalk invariant. See docs/kb/juke-bypass-movement-caps.md.
+			var push: Vector2 = nudge * UNSTICK_NUDGE_PX_PER_TICK
+			var to_target_u: Vector2 = b.target.position - b.position
+			if to_target_u.length_squared() > 0.0001:
+				var to_target_n: Vector2 = to_target_u.normalized()
+				var along: float = push.dot(to_target_n)
+				var perp_push: Vector2 = push - to_target_n * along
+				if along < 0.0:
+					var remaining_budget: float = maxf(0.0, TILE_SIZE - b.backup_distance)
+					var backward_mag: float = minf(-along, remaining_budget)
+					b.backup_distance += backward_mag
+					b.position += perp_push + to_target_n * (-backward_mag)
+				else:
+					b.position += push
+			else:
+				b.position += push
 			var arena_px2: float = 16.0 * TILE_SIZE
 			b.position.x = clampf(b.position.x, BOT_HITBOX_RADIUS, arena_px2 - BOT_HITBOX_RADIUS)
 			b.position.y = clampf(b.position.y, BOT_HITBOX_RADIUS, arena_px2 - BOT_HITBOX_RADIUS)

--- a/godot/combat/combat_sim.gd
+++ b/godot/combat/combat_sim.gd
@@ -532,8 +532,19 @@ func _move_brott(b: BrottState) -> void:
 			b.facing_angle += signf(angle_diff) * max_turn
 		b.facing_angle = fmod(b.facing_angle + 360.0, 360.0)
 	
-	# Bot-bot separation force (S11.1: 32px threshold, 60% base speed)
+	# Bot-bot separation force (S11.1: 32px threshold, 60% base speed).
+	# S15 moonwalk fix: the separation push can have a component opposing
+	# `to_target` (backward). Cap the backward component against the shared
+	# `backup_distance` budget (TILE_SIZE = 1 tile), same budget the TCR retreats
+	# use. Forward/lateral components pass through untouched so overlap resolution
+	# still works. See docs/kb/juke-bypass-movement-caps.md.
 	var sep_threshold: float = TILE_SIZE  # 32px = 1 tile
+	var has_target: bool = b.target != null and b.target.alive
+	var to_target_n: Vector2 = Vector2.ZERO
+	if has_target:
+		var to_target_sep: Vector2 = b.target.position - b.position
+		if to_target_sep.length_squared() > 0.0001:
+			to_target_n = to_target_sep.normalized()
 	for other in brotts:
 		if other == b or not other.alive:
 			continue
@@ -541,7 +552,26 @@ func _move_brott(b: BrottState) -> void:
 		var sep_dist: float = sep.length()
 		if sep_dist < sep_threshold and sep_dist > 0.01:
 			var repulsion_speed: float = b.base_speed * 0.6 * TICK_DELTA
-			b.position += sep.normalized() * repulsion_speed
+			var push: Vector2 = sep.normalized() * repulsion_speed
+			# Only gate the backward component when bots are NOT overlapping hitboxes.
+			# If `sep_dist < 2 * BOT_HITBOX_RADIUS`, we're in actual overlap — the
+			# separation push needs full authority to resolve the overlap (otherwise
+			# overlapping bots linger, the `sep_dist <= 0.01` explosion branch fires,
+			# and commit crossovers happen more often). Once bots are merely "close"
+			# (e.g., 24–32px), gate the backward component against `backup_distance`.
+			var overlap: bool = sep_dist < 2.0 * BOT_HITBOX_RADIUS
+			if not overlap and to_target_n != Vector2.ZERO:
+				var along: float = push.dot(to_target_n)  # <0 means backward
+				var perp_push: Vector2 = push - to_target_n * along
+				if along < 0.0:
+					var remaining_budget: float = maxf(0.0, TILE_SIZE - b.backup_distance)
+					var backward_mag: float = minf(-along, remaining_budget)
+					b.backup_distance += backward_mag
+					b.position += perp_push + to_target_n * (-backward_mag)
+				else:
+					b.position += push
+			else:
+				b.position += push
 		elif sep_dist <= 0.01:
 			b.position += Vector2(TILE_SIZE * 0.5, 0)
 	

--- a/godot/tests/harness/debug_moonwalk.gd
+++ b/godot/tests/harness/debug_moonwalk.gd
@@ -1,0 +1,107 @@
+## Debug harness: per-seed moonwalk trace for Scout vs Scout close-quarters.
+##
+## Usage:
+##   godot --headless --path godot --script tests/harness/debug_moonwalk.gd [-- seed=N]
+##
+## Prints one line per simulated tick for the requested seed (default: scan all
+## 100 seeds and report which ones violate the `test_away_juke_cap_across_seeds`
+## bar). Each line shows: tick, b0 position, movement length, dot(movement,
+## to_target), rolling backup_run, TCR phase, `backup_distance` budget,
+## `_unstick_timer`. Violation threshold matches the test: `backup_run >
+## 32.0 * 1.2` with `dot < -0.7` as the backward-tick gate.
+##
+## Intended as a turnkey repro for future moonwalk regressions. See
+## docs/kb/juke-bypass-movement-caps.md and PR #80 for context.
+extends SceneTree
+
+func _make_scout(team: int) -> BrottState:
+	var b := BrottState.new()
+	b.team = team
+	b.bot_name = "Scout_%d" % team
+	b.chassis_type = ChassisData.ChassisType.SCOUT
+	b.weapon_types = [WeaponData.WeaponType.PLASMA_CUTTER]
+	b.armor_type = ArmorData.ArmorType.NONE
+	b.module_types = []
+	b.stance = 0
+	b.setup()
+	return b
+
+func _scan_all_seeds() -> void:
+	print("=== Moonwalk seed scan (0..99) ===")
+	var violation_count := 0
+	for seed_val in range(100):
+		var b0 := _make_scout(0)
+		var b1 := _make_scout(1)
+		var sim := CombatSim.new(seed_val)
+		b0.position = Vector2(200, 256)
+		b1.position = Vector2(220, 256)
+		sim.add_brott(b0)
+		sim.add_brott(b1)
+		var prev_pos := b0.position
+		var backup_run := 0.0
+		var max_run := 0.0
+		var violated_tick := -1
+		for t in range(300):
+			if sim.match_over:
+				break
+			sim.simulate_tick()
+			if b0.alive and b0.target != null:
+				var tt: Vector2 = b0.target.position - b0.position
+				var mv: Vector2 = b0.position - prev_pos
+				if tt.length() > 0.1 and mv.length() > 0.1:
+					var dot: float = mv.normalized().dot(tt.normalized())
+					if dot < -0.7:
+						backup_run += mv.length()
+						if backup_run > max_run: max_run = backup_run
+					else:
+						backup_run = 0.0
+				prev_pos = b0.position
+				if backup_run > 32.0 * 1.2 and violated_tick < 0:
+					violated_tick = t
+		if violated_tick >= 0:
+			violation_count += 1
+			print("seed=%d violated_at_tick=%d max_run=%.1f" % [seed_val, violated_tick, max_run])
+	print("=== Total violations: %d/100 ===" % violation_count)
+
+func _trace_seed(seed_val: int) -> void:
+	print("=== Moonwalk trace seed=%d ===" % seed_val)
+	var b0 := _make_scout(0)
+	var b1 := _make_scout(1)
+	var sim := CombatSim.new(seed_val)
+	b0.position = Vector2(200, 256)
+	b1.position = Vector2(220, 256)
+	sim.add_brott(b0)
+	sim.add_brott(b1)
+	var prev_pos := b0.position
+	var backup_run := 0.0
+	for t in range(120):
+		if sim.match_over:
+			break
+		sim.simulate_tick()
+		if not (b0.alive and b0.target != null):
+			continue
+		var tt: Vector2 = b0.target.position - b0.position
+		var mv: Vector2 = b0.position - prev_pos
+		var dot := 0.0
+		if tt.length() > 0.1 and mv.length() > 0.1:
+			dot = mv.normalized().dot(tt.normalized())
+			if dot < -0.7:
+				backup_run += mv.length()
+			else:
+				backup_run = 0.0
+		print("t=%d b0=(%.1f,%.1f) b1=(%.1f,%.1f) mv=%.2f dot=%.2f run=%.1f phase=%d bd=%.1f unstick=%.1f" % [
+			t, b0.position.x, b0.position.y, b0.target.position.x, b0.target.position.y,
+			mv.length(), dot, backup_run, b0.combat_phase, b0.backup_distance, b0._unstick_timer])
+		prev_pos = b0.position
+
+func _init() -> void:
+	var args: PackedStringArray = OS.get_cmdline_user_args()
+	var seed_arg: int = -1
+	for a in args:
+		if a.begins_with("seed="):
+			seed_arg = int(a.substr(5))
+	if seed_arg >= 0:
+		_trace_seed(seed_arg)
+	else:
+		_scan_all_seeds()
+	quit()

--- a/sprints/sprint-15.md
+++ b/sprints/sprint-15.md
@@ -1,0 +1,33 @@
+# Sprint 15 — CI Health (Moonwalk Regression Fix)
+
+## Goal
+Restore CI green by fixing the moonwalk invariant regression surfaced by `test_away_juke_cap_across_seeds`.
+
+## Context
+- GDD moonwalk invariant is canonical — design bar is `violations == 0`.
+- KB entry `docs/kb/juke-bypass-movement-caps.md` identifies the failure mode: the juke "away" branch in `_do_combat_movement()` moves backward without clamping against `backup_distance`.
+- Stale `≤9` threshold references in `docs/design/sprint14.2-brottbrain-aggression.md` should be ignored; the test at HEAD is authoritative.
+
+## Tasks
+
+### [SN-101] Fix juke away-branch to clamp against `backup_distance`
+- Locate the juke "away" branch inside `_do_combat_movement()`.
+- Mirror the clamp logic already used by the normal backup-movement path.
+- Keep the diff narrow — per-path clamp, no refactor into a post-processing clamp.
+- Do NOT fix other movement paths (toward/lateral/dash/knockback) in this PR; note observations in PR body for a follow-up.
+
+### [SN-102] Verify locally + in CI
+- Run the Godot test suite locally if a `godot` binary is available; otherwise rely on the CI `Godot Unit Tests` job.
+- Confirm `test_away_juke_cap_across_seeds` reports `violations == 0`.
+- Confirm `test_away_juke_capped_at_one_tile` remains green.
+- Confirm the full Godot suite is green.
+
+## Acceptance
+- [ ] `test_away_juke_cap_across_seeds` violations == 0
+- [ ] `test_away_juke_capped_at_one_tile` still green
+- [ ] Full Godot suite green
+- [ ] CI `Godot Unit Tests` job green on PR branch
+
+## Notes
+- Establishes the `sprints/` directory convention per CONVENTIONS.md.
+- Plan authored by Ett (PM), executed by Nutts on branch `sprint-15-fix-moonwalk-regression`.


### PR DESCRIPTION
## Summary

**Boltz approved Option 1: per-path clamps on separation force + unstick nudge.** Landed on this PR across 3 commits:

- `dc0e49d` — clamp separation-force backward component against `backup_distance` budget
- `1e60bb6` — clamp unstick-nudge backward component against `backup_distance` budget
- `4cf20ed` — KB update (`docs/kb/juke-bypass-movement-caps.md`) + debug harness (`godot/tests/harness/debug_moonwalk.gd`)

## What landed

### Separation clamp (`_move_brott`, ~L535)
Decompose the separation push `sep.normalized() * repulsion_speed` into an along-target component (signed; negative = backward) and a perpendicular component. When the along-target component is backward, cap its magnitude against the remaining `backup_distance` budget (`TILE_SIZE - b.backup_distance`) and add that amount into `backup_distance`. Lateral/forward pass through untouched.

**Exception:** when `sep_dist < 2 * BOT_HITBOX_RADIUS` (actual hitbox overlap), the clamp is skipped so the push has full authority to resolve overlap. Without this, overlapping bots linger, the `sep_dist <= 0.01` explosion-push branch fires more often, and COMMIT crossovers multiply.

### Unstick clamp (`_check_and_handle_stuck`, ~L613)
Same pattern on the unstick nudge. Decompose `nudge * UNSTICK_NUDGE_PX_PER_TICK` against `to_target`, clamp the backward component, pass lateral/forward through. Preserves the early-exit and `backup_distance = TILE_SIZE` reset at L641 (the "skip backup budget; go to lateral" signal from the stuck-handler trigger path).

### KB + harness
- `docs/kb/juke-bypass-movement-caps.md` appended with S15 findings so the next person doesn't re-chase the dead juke branch. Lists the three live sources (separation, unstick, COMMIT-crossover) and the status of each.
- `godot/tests/harness/debug_moonwalk.gd` — turnkey per-seed trace for future moonwalk regressions. `scan` mode (default) reports violating seeds; `seed=N` mode dumps per-tick trace (pos, mv, dot, run, phase, bd, unstick).

## Local test results

| Test | Result |
|---|---|
| `test_sprint11_2::test_away_juke_capped_at_one_tile` | **PASS** (direct test: `backup_distance capped: 0.0 px (max 32)`) |
| `test_sprint11_2::test_away_juke_cap_across_seeds` | **FAIL: 7/100** (down from baseline 8/100) |
| `test_sprint11_2` remaining tests (hit-rate, TTK, regression) | PASS |
| `test_sprint11` (9 tests) | PASS |
| `test_sprint13_2` (11 tests) | PASS |
| `test_sprint14_1` (19 tests) | PASS |
| `test_sprint14_1_nav` (5 tests) | PASS |

## The honest bar-miss — residual 7 violations are not from the two clamped paths

Per-tick traces of all 7 remaining violators show the backward-run accumulation comes from **COMMIT-crossover**, not separation or unstick:

- At close range both bots enter COMMIT simultaneously and dash at each other. In a single tick they can swap positions.
- COMMIT applies `b.position += to_target.normalized() * commit_spd` — a strictly *forward* push in the bot's own reference frame at top-of-tick.
- The test metric computes `movement.normalized().dot(to_target.normalized())` using **post-tick** `to_target`. When the two bots have swapped sides, the post-tick `to_target` vector flips sign — and the bot's forward COMMIT push now reads as a backward movement of ~20 px at dot ≈ −1.0.
- Seed 80 trace (harness output, `-- seed=80`): at t=29 `phase=1 bd=0.0 mv=13.2 dot=-1.0`; at t=30 `phase=1 bd=0.0 mv=33.2 dot=-1.0`. Neither tick touches the separation or unstick paths. The backward-run accumulates to 85.2 px before the bots settle.

This failure mode is:
- **Not fixable by the per-path separation/unstick clamps** — the contributing movement is the COMMIT dash itself.
- **Fixable by Option 2 (post-processing clamp)** — aggregate per-tick movement, project against the starting-frame `to_target`, cap the backward component at the tick boundary. This is the long-term answer the KB already calls out.
- **Also fixable by preventing bot-to-bot crossover during COMMIT** — e.g., reducing `commit_spd` when `dist < BOT_HITBOX_RADIUS * 2`, or adding a swap-detection step at tick end. That's a movement-pipeline change.

Either of those is a refactor, not a narrow per-path clamp. Routing back for a call on whether to (a) merge this as-is (real improvement on the two paths Boltz identified, clean KB note so future work has a map) and schedule a follow-up sprint for COMMIT-crossover / Option 2, or (b) expand S15 scope to cover COMMIT-crossover now. Ready for re-review either way.

## Files changed
- `godot/combat/combat_sim.gd` (+54, -3)
- `docs/kb/juke-bypass-movement-caps.md` (+20, -2)
- `godot/tests/harness/debug_moonwalk.gd` (new, +106)
