### PR TITLE
[S16.1-001] Fix stale Plating weight in test_sprint12_2.gd

### DIFF
--- a/godot/tests/test_sprint12_2.gd
+++ b/godot/tests/test_sprint12_2.gd
@@ -70,7 +70,7 @@ func test_unequipped_card_styling() -> void:
 func test_weight_bar_updates() -> void:
 	print("\n[Test] Weight bar updates correctly")
 	var state := GameState.new()
-	# Scout with Plasma Cutter (8kg) + Plating (5kg) = 13kg, cap 30
+	# Scout with Plasma Cutter (8kg) + Plating (15kg) = 23kg, cap 30
 	state.equipped_chassis = ChassisData.ChassisType.SCOUT
 	state.equipped_weapons = [WeaponData.WeaponType.PLASMA_CUTTER]
 	state.equipped_armor = ArmorData.ArmorType.PLATING
@@ -81,7 +81,7 @@ func test_weight_bar_updates() -> void:
 	var cap: int = validation["weight_cap"]
 
 	_assert(cap == 30, "Scout weight cap is 30")
-	_assert(total == 13, "Plasma Cutter (8) + Plating (5) = 13 kg")
+	_assert(total == 23, "Plasma Cutter (8) + Plating (15) = 23 kg")
 
 	# Now equip Minigun too
 	state.owned_weapons.append(WeaponData.WeaponType.MINIGUN)


### PR DESCRIPTION
## Task
[S16.1-001] Fix `test_sprint12_2.gd` Plasma Cutter + Plating weight stale test data.

## Source of truth
- **GDD line 63:** Plating = 15 kg
- **`godot/data/armor_data.gd`:** `PLATING.weight = 15`
- **`godot/data/weapon_data.gd`:** `PLASMA_CUTTER.weight = 8`
- **`godot/data/chassis_data.gd`:** `SCOUT.weight_cap = 30`

_Note: spawn prompt referenced `godot/combat/armor_data.gd` — in this repo the data files live under `godot/data/`. Scope gate verified against both paths; neither touched._

## Change
Single file: `godot/tests/test_sprint12_2.gd` — `test_weight_bar_updates()` only.

| | Before | After |
|---|---|---|
| Plating weight (comment) | 5 kg | **15 kg** |
| Expected total | 13 kg | **23 kg** |
| Scout cap | 30 | 30 (unchanged — verified vs `chassis_data.gd`) |

## Scope gate
✅ **No `godot/combat/**` changes.** `armor_data.gd` diff is empty. Only `godot/tests/test_sprint12_2.gd` modified — 2 lines changed (1 comment + 1 assertion).

## Verification
Ran locally:
```
godot --headless --path godot --script res://tests/test_sprint12_2.gd
```
Result: **33 passed, 0 failed out of 33.** Target assertion now passes:
```
[Test] Weight bar updates correctly
  PASS: Scout weight cap is 30
  PASS: Plasma Cutter (8) + Plating (15) = 23 kg
  PASS: Weight increases after equipping Minigun
```

## Not in scope (separate task IDs)
- Other assertions in `test_sprint12_2.gd` (untouched)
- `test_sprint12_1.gd`, `test_sprint10.gd`, `test_runner.gd`

Ready for Boltz review.