### PR TITLE
[S16.1-003] Triage Plasma Cutter fire-at-range (test-side fix)

### DIFF
--- a/godot/tests/test_sprint12_1.gd
+++ b/godot/tests/test_sprint12_1.gd
@@ -163,7 +163,17 @@ func test_plasma_cutter_no_fire_2_6() -> void:
 	sim.add_brott(attacker)
 	sim.add_brott(target)
 
-	sim.simulate_tick()
+	# S16.1-003: isolate the `fire_at_range` check from movement.
+	# Running `simulate_tick()` runs `_move_brott` before `_fire_weapons`, and
+	# the Scout (speed=220 px/s, 0.1s tick) closes ~22px per tick when
+	# aggressive — enough to move 83.2px (2.6 tiles) into the 80px range gate
+	# before the fire check. That's test-scaffolding drift against the current
+	# tick ordering + TICKS_PER_SEC=10, not a `fire_at_range` regression
+	# (the `if dist > range_px: continue` guard in `_fire_weapons` is intact).
+	# Assign the target directly and invoke `_fire_weapons` so the assertion
+	# genuinely exercises the range gate.
+	attacker.target = target
+	sim._fire_weapons(attacker)
 	_assert(sim.shots_fired.size() == 0, "Plasma Cutter does NOT fire at 2.6 tiles")
 
 # --- Overtime threshold tests ---


### PR DESCRIPTION
## Triage verdict
**test-side fix** — test-scaffolding drift, not a `fire_at_range` regression.

## Evidence

### Failure output before fix
```
[Test] Plasma Cutter does NOT fire at 2.6 tiles
  FAIL: Plasma Cutter does NOT fire at 2.6 tiles
```

### Analysis
- `weapon_data.gd` says Plasma Cutter `range_tiles = 2.5` → `range_px = 80.0`.
- Test places attacker at `(0,0)` and target at `(2.6 * 32, 0) = (83.2, 0)`.
- `_fire_weapons` in `godot/combat/combat_sim.gd` has the range gate intact:
  ```gdscript
  var dist: float = b.position.distance_to(b.target.position)
  var range_px: float = float(wd["range_tiles"]) * TILE_SIZE
  if dist > range_px:
      continue
  ```
  At the initial positions `83.2 > 80.0`, so the guard would correctly skip firing.
- **Root cause:** `simulate_tick()` runs `_move_brott` **before** `_fire_weapons`. The Scout is Aggressive by default (stance=0) and closes toward target at ~220 px/s. With `TICKS_PER_SEC = 10` (0.1s tick), that's ~22 px/tick, which drags the attacker from 83.2 px down to ~61 px — well inside the 80 px range gate — before the fire check runs.
- The `fire_at_range` logic itself is fine; the test scenario just doesn't isolate the range check from movement. This is test-scaffolding drift against the current tick-ordering + tick-rate, not a combat-side regression.
- The passing 2.5-tile test passes by coincidence: `dist == range_px` at t=0, so `if dist > range_px` is false regardless of any subsequent movement. That assertion was always dominated by the `==` edge, not the movement timing.

### Why not quarantine?
`fire_at_range` behaves correctly given a correctly-constructed scenario. No carry-forward gameplay fix is needed; the test just needs to stop conflating "movement in one tick" with "range-gate check."

## Action taken
Assign `attacker.target = target` directly and call `sim._fire_weapons(attacker)` instead of `sim.simulate_tick()`. This exercises the range gate in isolation, which is what the assertion is actually intended to test.

`godot/tests/test_sprint12_1.gd` only. No other files touched.

## Scope gate confirmation
- `godot/combat/**` diff: **empty** ✅
- `godot/data/**` diff: **empty** ✅
- Only `godot/tests/test_sprint12_1.gd` touched ✅
- No `.studio/` sweep-ins ✅

## Diff stat
```
 godot/tests/test_sprint12_1.gd | 12 +++++++++++-
 1 file changed, 11 insertions(+), 1 deletion(-)
```
File list matches summary.

## Local headless result
Ran `godot --headless --path godot/ --script res://tests/test_sprint12_1.gd`:
```
[Test] Plasma Cutter fires at 2.5 tiles
  PASS: Plasma Cutter fires at 2.5 tiles

[Test] Plasma Cutter does NOT fire at 2.6 tiles
  PASS: Plasma Cutter does NOT fire at 2.6 tiles
```
Both Plasma Cutter range assertions pass. (Other pre-existing failures in this file — Scout decel timing and 2v2 timeout — are S16.1-004 quarantine territory, untouched here.)
