### PR TITLE
[S16.1-004] Quarantine 3 combat-side regressions in test_sprint12_1.gd

### DIFF
--- a/godot/tests/test_sprint12_1.gd
+++ b/godot/tests/test_sprint12_1.gd
@@ -72,6 +72,9 @@ func _make_brott(chassis_type: ChassisData.ChassisType, team: int = 0) -> BrottS
 
 func test_scout_time_to_max() -> void:
 	print("\n[Test] Scout reaches max speed in ~0.33s")
+	if TestUtil.skip_with_reason("test_scout_time_to_max",
+		"real regression: brott_state.accelerate_toward_speed — Scout 0→max expected ~0.33s, currently ~0.40s (out-of-scope for S16, see godot/combat/brott_state.gd)"):
+		return
 	var b := _make_brott(ChassisData.ChassisType.SCOUT)
 	# Simulate acceleration ticks: accel=660, max=220, so time=220/660=0.333s
 	var dt := 1.0 / 10.0  # TICK_DELTA
@@ -116,6 +119,9 @@ func test_afterburner_accel_multiplier() -> void:
 
 func test_decel_to_stop() -> void:
 	print("\n[Test] Deceleration stops bot correctly")
+	if TestUtil.skip_with_reason("test_decel_to_stop",
+		"real regression: brott_state.accelerate_toward_speed — Scout decel-to-stop expected ~0.25s, currently ~0.30s (out-of-scope for S16, see godot/combat/brott_state.gd)"):
+		return
 	var b := _make_brott(ChassisData.ChassisType.SCOUT)
 	b.current_speed = 220.0  # at max
 	var dt := 1.0 / 10.0
@@ -275,6 +281,9 @@ func test_timeout_1v1_at_100s() -> void:
 
 func test_timeout_2v2_at_120s() -> void:
 	print("\n[Test] 2v2 timeout at 120s")
+	if TestUtil.skip_with_reason("test_timeout_2v2_at_120s",
+		"real regression: combat_sim.gd overtime/SD plumbing — 2v2 match ends at 100s instead of running to 120s timeout (out-of-scope for S16, see godot/combat/combat_sim.gd)"):
+		return
 	var sim := CombatSim.new(1)
 	sim.match_mode = "2v2"
 	var a := _make_brott(ChassisData.ChassisType.FORTRESS, 0)

--- a/godot/tests/test_util.gd
+++ b/godot/tests/test_util.gd
@@ -1,0 +1,13 @@
+## Test utilities for BattleBrotts test suite.
+## Added in S16.1-004 to support `skip-with-reason` quarantines of
+## out-of-scope combat regressions (see sprints/sprint-16.md carry-forward).
+class_name TestUtil
+extends Object
+
+## Prints a standardized SKIP line and returns true so the caller can
+## `if TestUtil.skip_with_reason(...): return` before running the assertions.
+## Does NOT touch the caller's pass/fail counters — quarantined cases
+## are simply not executed.
+static func skip_with_reason(test_name: String, reason: String) -> bool:
+	print("  SKIP: %s — %s — carry-forward to future gameplay sprint (see sprints/sprint-16.md)" % [test_name, reason])
+	return true

--- a/godot/tests/test_util.gd.uid
+++ b/godot/tests/test_util.gd.uid
@@ -1,0 +1,1 @@
+uid://p8koc5dx1b4u


### PR DESCRIPTION
## Summary

Three failing assertions in `test_sprint12_1.gd` are real combat-side regressions classified as out-of-scope for S16 per the `sprint-16.md` scope gate. Quarantined via a new `skip-with-reason` helper so the canaries remain in source (readable by Gizmo, still discoverable in the tree), but CI stops red-lighting them.

**Carry-forward:** a future gameplay sprint should fix these. See the Carry-Forward Backlog in `sprints/sprint-16.md`.

## Quarantined assertions

Each test body's assertions are preserved verbatim; the quarantine is a runtime skip at the top of the function via `if TestUtil.skip_with_reason(...): return`.

1. **`test_scout_time_to_max`** — *Scout 0→max expected ~0.33s, currently ~0.40s.*
   Code path: `godot/combat/brott_state.gd :: accelerate_toward_speed`.
2. **`test_decel_to_stop`** — *Scout decel-to-stop expected ~0.25s, currently ~0.30s.*
   Code path: `godot/combat/brott_state.gd :: accelerate_toward_speed` (same routine handles decel).
3. **`test_timeout_2v2_at_120s`** — *2v2 match ends at 100s instead of running to the 120s timeout.*
   Code path: `godot/combat/combat_sim.gd` overtime/SD/timeout plumbing.

Note: `test_overtime_2v2_at_60s` and `test_sudden_death_2v2_at_75s` currently **pass** and are NOT quarantined. The 3rd task-description bullet ("2v2 overtime 60s / SD 75s / timeout 120s — currently ending at 100s") maps 1:1 to `test_timeout_2v2_at_120s`; the task's count of three failing assertions matches what headless reports.

No 4th unexpected failure surfaced. Scope not expanded.

## Helper

**Newly added** — no pre-existing skip helper in `godot/tests/` (verified via `grep -r "skip_with_reason\|skip_with\|# SKIP:" godot/tests/` → no hits).

- **Location:** `godot/tests/test_util.gd` (new file, 13 lines of code).
- **API:** `TestUtil.skip_with_reason(test_name: String, reason: String) -> bool`
- **Behavior:** prints `  SKIP: <test name> — <reason> — carry-forward to future gameplay sprint (see sprints/sprint-16.md)` and returns `true`. Does **not** touch `pass_count` / `fail_count` / `test_count` in the caller — quarantined cases are simply not executed.
- **Why a new file vs. inlining in `test_runner.gd`:** keeping it as `class_name TestUtil` makes it reusable by every `test_sprint*.gd` (which are standalone `SceneTree` scripts invoked directly, not from `test_runner.gd`).

No S16.1-003 TODO was present in `test_sprint12_1.gd` — nothing to retire.

## Diff stat (matches file list exactly)

```
 godot/tests/test_sprint12_1.gd |  9 +++++++++
 godot/tests/test_util.gd       | 13 +++++++++++++
 godot/tests/test_util.gd.uid   |  1 +
 3 files changed, 23 insertions(+)
```

- `test_sprint12_1.gd`: +9 lines (three 3-line `if TestUtil.skip_with_reason(...): return` blocks). No deletions, no loosened thresholds.
- `test_util.gd`: new helper (listed above).
- `test_util.gd.uid`: Godot-generated sibling UID for the new script. Every `.gd` in `godot/tests/` has a `.uid` companion (this is just Godot's editor metadata). Listed explicitly so it's not "swept in" a la PR #90's `.studio/project.json`.

## Scope gate

✅ `godot/combat/**` diff: **empty**
✅ `godot/data/**` diff: **empty**

Verified:
```
$ git diff --stat origin/main -- 'godot/combat/**' 'godot/data/**'
(empty)
```

## Local headless result

```
$ godot --headless --path godot/ --script res://tests/test_sprint12_1.gd
...
  SKIP: test_scout_time_to_max — real regression: brott_state.accelerate_toward_speed — Scout 0→max expected ~0.33s, currently ~0.40s ... — carry-forward to future gameplay sprint (see sprints/sprint-16.md)
  SKIP: test_decel_to_stop — real regression: brott_state.accelerate_toward_speed — Scout decel-to-stop expected ~0.25s, currently ~0.30s ... — carry-forward to future gameplay sprint (see sprints/sprint-16.md)
  SKIP: test_timeout_2v2_at_120s — real regression: combat_sim.gd overtime/SD plumbing — 2v2 match ends at 100s instead of running to 120s timeout ... — carry-forward to future gameplay sprint (see sprints/sprint-16.md)
--- Results ---
24 passed, 0 failed out of 24
$ echo $?
0
```

- 3 SKIP lines printed verbatim.
- 0 failures from the three quarantined cases.
- All other assertions (including the S16.1-003 Plasma Cutter range tests at 2.5/2.6 tiles) still pass.

## Task ref

S16.1-004 — Quarantine combat-side regressions in `test_sprint12_1.gd`.
