### PR TITLE
[S16.1-005] Explicit enumeration in test_runner.gd; drop verify.yml glob loop

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -29,14 +29,10 @@ jobs:
         run: |
           set -e
           godot --headless --path godot/ --script res://tests/test_runner.gd
-          # Glob-based discovery: picks up test_sprint*.gd automatically (S13.8).
-          # Pattern excludes fixture/helper files (combat_batch.gd, pacing_verify.gd, etc.).
-          for f in godot/tests/test_sprint1[0-9]_*.gd godot/tests/test_sprint1[0-9].gd; do
-            [ -e "$f" ] || continue
-            name="$(basename "$f")"
-            echo "Running $name"
-            godot --headless --path godot/ --script "res://tests/$name" || exit 1
-          done
+          # S16.1-005: test_runner.gd now explicitly enumerates every
+          # test_sprint*.gd file internally and aggregates per-file exit
+          # codes (non-short-circuit). The previous shell-glob loop with
+          # `|| exit 1` bail-on-first-failure has been removed.
 
   playwright:
     name: Playwright Smoke Tests

--- a/godot/tests/test_runner.gd
+++ b/godot/tests/test_runner.gd
@@ -6,9 +6,50 @@ var pass_count := 0
 var fail_count := 0
 var test_count := 0
 
+# Explicit enumeration of every test_sprint*.gd file covered by the
+# previous CI glob (sprints 10-19 / 1[0-9] pattern). See [S16.1-005]:
+# this replaces the shell-glob loop that used to live in
+# .github/workflows/verify.yml. Each file is invoked in a child Godot
+# process; per-file exit codes are aggregated so a failure in one file
+# does NOT short-circuit the rest of the suite.
+#
+# Note: godot/tests/test_sprint{3,4,5,6}.gd exist in the tree but have
+# never been wired into CI (the old glob only matched 1[0-9]) and carry
+# real pre-existing failures against current game data. They are NOT
+# enumerated here because S16.1-005 is plumbing-only (must not change
+# which tests pass/fail) and S16 scope-gate forbids editing test files
+# to fix them. Separate backlog task required to triage + quarantine.
+const SPRINT_TEST_FILES := [
+	"res://tests/test_sprint10.gd",
+	"res://tests/test_sprint11.gd",
+	"res://tests/test_sprint11_2.gd",
+	"res://tests/test_sprint12_1.gd",
+	"res://tests/test_sprint12_2.gd",
+	"res://tests/test_sprint12_3.gd",
+	"res://tests/test_sprint12_4.gd",
+	"res://tests/test_sprint12_5.gd",
+	"res://tests/test_sprint13_2.gd",
+	"res://tests/test_sprint13_3.gd",
+	"res://tests/test_sprint13_4.gd",
+	"res://tests/test_sprint13_5.gd",
+	"res://tests/test_sprint13_6.gd",
+	"res://tests/test_sprint13_7.gd",
+	"res://tests/test_sprint13_8_modal_hardening.gd",
+	"res://tests/test_sprint13_8_toast.gd",
+	"res://tests/test_sprint13_9.gd",
+	"res://tests/test_sprint13_10.gd",
+	"res://tests/test_sprint14_1.gd",
+	"res://tests/test_sprint14_1_nav.gd",
+]
+
+var file_pass_count := 0
+var file_fail_count := 0
+var failed_files: Array[String] = []
+
 func _init() -> void:
 	print("=== BattleBrotts Test Suite ===\n")
 	
+	print("--- Core inline suite (data/damage/combat/module/movement + sprint10 stalemate) ---")
 	_run_data_tests()
 	_run_damage_tests()
 	_run_combat_tests()
@@ -16,12 +57,60 @@ func _init() -> void:
 	_run_movement_tests()
 	_run_sprint10_tests()
 	
-	print("\n=== Results: %d passed, %d failed, %d total ===" % [pass_count, fail_count, test_count])
+	print("\n=== Inline results: %d passed, %d failed, %d total ===" % [pass_count, fail_count, test_count])
 	
-	if fail_count > 0:
-		quit(1)
-	else:
+	# Aggregate all sprint test files via subprocess. Never short-circuit:
+	# every file runs even if an earlier one failed, so CI logs surface
+	# every failure rather than just the first.
+	print("\n=== Sprint test files (explicit enumeration — S16.1-005) ===")
+	for test_path in SPRINT_TEST_FILES:
+		_run_sprint_test_file(test_path)
+	
+	print("\n=== Sprint-file results: %d files passed, %d files failed ===" % [file_pass_count, file_fail_count])
+	if file_fail_count > 0:
+		print("Failed files:")
+		for f in failed_files:
+			print("  - %s" % f)
+	
+	var inline_ok := fail_count == 0
+	var files_ok := file_fail_count == 0
+	print("\n=== OVERALL: inline %s | sprint files %s ===" % [
+		"PASS" if inline_ok else "FAIL",
+		"PASS" if files_ok else "FAIL",
+	])
+	
+	if inline_ok and files_ok:
 		quit(0)
+	else:
+		quit(1)
+
+func _run_sprint_test_file(res_path: String) -> void:
+	var file_name := res_path.get_file()
+	print("\n--- [FILE] %s ---" % file_name)
+	# Resolve res:// to an absolute path on disk so OS.execute can invoke
+	# the Godot binary against it with --path pointing at the project root.
+	var abs_path := ProjectSettings.globalize_path(res_path)
+	if not FileAccess.file_exists(abs_path):
+		print("  MISSING: %s (expected at %s)" % [res_path, abs_path])
+		file_fail_count += 1
+		failed_files.append(file_name)
+		return
+	var godot_bin := OS.get_executable_path()
+	var project_dir := ProjectSettings.globalize_path("res://")
+	var args := ["--headless", "--path", project_dir, "--script", res_path]
+	var out: Array = []
+	var exit_code := OS.execute(godot_bin, args, out, true)
+	if out.size() > 0:
+		# out[0] is a single concatenated string of stdout+stderr when
+		# read_stderr=true. Print verbatim so CI logs remain readable.
+		print(out[0])
+	if exit_code == 0:
+		file_pass_count += 1
+		print("  [PASS] %s (exit 0)" % file_name)
+	else:
+		file_fail_count += 1
+		failed_files.append(file_name)
+		print("  [FAIL] %s (exit %d)" % [file_name, exit_code])
 
 func assert_eq(a: Variant, b: Variant, msg: String) -> void:
 	test_count += 1


### PR DESCRIPTION
## Summary

Replaces the shell-glob `for f in godot/tests/test_sprint1[0-9]*.gd ... || exit 1` bail-on-first-failure loop in `.github/workflows/verify.yml` with explicit per-file enumeration inside `godot/tests/test_runner.gd`. Aggregates per-file exit codes so one failing file no longer short-circuits the rest of the suite — every failure surfaces in a single CI run instead of just the first.

## Runner changes

Each `test_sprint*.gd` file is a standalone `extends SceneTree` script with its own `_init()` / `_initialize()` that calls `quit(N)`. They are NOT callable as classes from another SceneTree. The runner therefore invokes each one as a child Godot process via `OS.execute(OS.get_executable_path(), ["--headless", "--path", project_dir, "--script", res_path], out, true)`, captures its stdout+stderr, prints it verbatim for CI log readability, and records the per-file exit code. The inline suite (`_run_data_tests` / `_run_damage_tests` / `_run_combat_tests` / `_run_module_tests` / `_run_movement_tests` / `_run_sprint10_tests`) is preserved and runs first. Final runner exit is `0` iff inline passed AND every enumerated sprint file exited `0`.

## Workflow change

`.github/workflows/verify.yml` — `Godot Unit Tests` job's `Run Godot tests` step:
- Before: run `test_runner.gd`, then a shell `for ... do godot ... || exit 1; done` glob loop.
- After: single command `godot --headless --path godot/ --script res://tests/test_runner.gd`. Exit-code propagation gates the job. `Install Godot` and `Import Godot resources` steps unchanged. No other workflow fields touched (matrix, paths-ignore, Playwright job, etc.).

## Enumerated sprint test files (20)

Every file in `godot/tests/test_sprint*.gd` previously caught by the old glob (sprints 10–19, `1[0-9]` pattern):

- test_sprint10.gd
- test_sprint11.gd
- test_sprint11_2.gd
- test_sprint12_1.gd
- test_sprint12_2.gd
- test_sprint12_3.gd
- test_sprint12_4.gd
- test_sprint12_5.gd
- test_sprint13_2.gd
- test_sprint13_3.gd
- test_sprint13_4.gd
- test_sprint13_5.gd
- test_sprint13_6.gd
- test_sprint13_7.gd
- test_sprint13_8_modal_hardening.gd
- test_sprint13_8_toast.gd
- test_sprint13_9.gd
- test_sprint13_10.gd
- test_sprint14_1.gd
- test_sprint14_1_nav.gd

### Not enumerated (intentional, surfaced as follow-up)

`test_sprint3.gd`, `test_sprint4.gd`, `test_sprint5.gd`, `test_sprint6.gd` exist in the tree but were **never** wired into CI — the old glob only matched `1[0-9]`. When enumerated they fail against current game data (e.g. `test_sprint4.gd`: 72 passed / 15 failed — overtime/sudden-death tick constants, arena shrink rate). S16.1-005 is plumbing-only (must not change which tests pass/fail in CI) and the S16 scope-gate forbids editing `test_sprint*.gd` to quarantine them. Triage + quarantine belongs in a separate backlog task. This is documented in a comment above `SPRINT_TEST_FILES`.

## Non-short-circuit failure aggregation — validated locally

Validation protocol before opening PR:

1. Clean run: `godot --headless --path godot/ --script res://tests/test_runner.gd` → exit 0. 20/20 sprint files PASS. Inline PASS. The 3 quarantined cases (`test_scout_time_to_max`, `test_decel_to_stop`, `test_timeout_2v2_at_120s`) print their SKIP reasons verbatim in the CI log.
2. Non-short-circuit smoke: temporarily patched `test_sprint12_3.gd` so its terminal `quit(...)` always returns 1. Re-ran runner → every file from `test_sprint12_4.gd` through `test_sprint14_1_nav.gd` still executed (confirmed via `[FILE]` headers), final runner exit was 1, failure summary listed `test_sprint12_3.gd`. Injection reverted before commit; `git diff` on `test_sprint12_3.gd` is empty.

## Diff stat

```
 .github/workflows/verify.yml | 12 ++----
 godot/tests/test_runner.gd   | 97 ++++++++++++++++++++++++++++++++++++++++----
 2 files changed, 97 insertions(+), 12 deletions(-)
```

No tool-generated sibling files regenerated (`test_runner.gd.uid` unchanged — verified via `git status`).

## Scope gate confirmation

- `git diff origin/main -- godot/combat/` → **empty** ✅
- `git diff origin/main -- godot/data/` → **empty** ✅
- `git diff origin/main -- godot/tests/test_sprint*.gd` → **empty** ✅ (only `test_runner.gd` in `godot/tests/` was modified)
- Only `godot/tests/test_runner.gd` and `.github/workflows/verify.yml` changed.

## How to verify

```bash
godot --headless --path godot/ --import
godot --headless --path godot/ --script res://tests/test_runner.gd
# Expect: exit 0; "=== Sprint-file results: 20 files passed, 0 files failed ==="
# Expect: 3 SKIP lines printed verbatim (Scout accel/decel, 2v2 overtime).
```

Implements [S16.1-005].