### PR TITLE
[S16.1-006] GDD §3.2 sync (Plasma Cutter range) + arena_renderer warning fix + Minigun audit

### DIFF
--- a/docs/gdd.md
+++ b/docs/gdd.md
@@ -50,7 +50,7 @@ Base chassis weight is excluded from the weight budget — only equipped items c
 | **Railgun** | 45 | 12 | 0.6 | 0 | 16 | 15 |
 | **Shotgun** | 6×5 pellets | 3 | 1.5 | 30 | 8 | 12 |
 | **Missile Pod** | 30 (splash r=1 tile) | 8 | 0.8 | 5 | 12 | 18 |
-| **Plasma Cutter** | 14 | 1.5 | 3 | 0 | 4 | 8 |
+| **Plasma Cutter** | 14 | 2.5 | 3 | 0 | 4 | 8 |
 | **Arc Emitter** | 8 (chains to 1 extra target within 2 tiles) | 4 | 2 | 10 | 6 | 11 |
 | **Flak Cannon** | 15 | 6 | 1.2 | 20 | 7 | 13 |
 

--- a/godot/arena/arena_renderer.gd
+++ b/godot/arena/arena_renderer.gd
@@ -460,7 +460,10 @@ func _tick_charm_anims() -> void:
 				if b.spin_anim_timer <= 0:
 					b.charm_rotation = 0.0
 			elif is_moving and prev_vel.length() > 5.0:
-				var angle_diff := abs(cur_vel.angle_to(prev_vel))
+				# cur_vel is Variant (sim is untyped in this scope, so b.velocity is Variant),
+				# which propagates through angle_to() and abs(). Explicit annotation keeps the
+				# warnings-as-errors parser happy — same pattern as the S16.1-002 test_sprint10 fix.
+				var angle_diff: float = abs(cur_vel.angle_to(prev_vel))
 				if angle_diff > 0.5:  # ~30° threshold
 					if CharmAnims.should_scout_spin(charm_rng):
 						b.spin_anim_timer = 0.25


### PR DESCRIPTION
## Summary
Final S16.1 task — three independent cosmetics, one PR.

### Item 1: GDD §3.2 Plasma Cutter range (docs) ✅
Canon (`godot/data/weapon_data.gd` → `range_tiles: 2.5`) and the S12 design spec agree on 2.5 tiles; GDD §3.2 showed 1.5. Synced the GDD row.

**Before:**
```
| **Plasma Cutter** | 14 | 1.5 | 3 | 0 | 4 | 8 |
```
**After:**
```
| **Plasma Cutter** | 14 | 2.5 | 3 | 0 | 4 | 8 |
```

### Item 2: Minigun fire rate audit (surface-only) ✅ — no conflict
- `godot/data/weapon_data.gd` Minigun entry: **`fire_rate: 6.0`** (line 15).
- GDD §3.2 Minigun row already shows `6` (line 49).
- GDD Balance v2 (line 709) targets 6 shots/s.
- **All three agree.** Canon, §3.2 table, and Balance v2 are in sync. No doc edit needed, no 🟡 to raise. This item is closed without action.

### Item 3: `arena/arena_renderer.gd` warnings-as-errors parse warning ✅
**Root cause:** Line 463 — `var angle_diff := abs(cur_vel.angle_to(prev_vel))`. In this scope `sim` is untyped, so `b` (from `for b in sim.brotts`) and therefore `cur_vel := b.velocity` are `Variant`. That propagates through `angle_to()` and `abs()`, so type inference yields `Variant` and the warnings-as-errors parser rejects it. Same flavor as the S16.1-002 `test_sprint10.gd` fix.

**Fix:** Explicit `: float` annotation (preferred path, matches S16.1-002 approach — no `@warning_ignore` needed, no behavior change).

**Diff:**
```gdscript
-			elif is_moving and prev_vel.length() > 5.0:
-				var angle_diff := abs(cur_vel.angle_to(prev_vel))
-				if angle_diff > 0.5:  # ~30° threshold
+			elif is_moving and prev_vel.length() > 5.0:
+				# cur_vel is Variant (sim is untyped in this scope, so b.velocity is Variant),
+				# which propagates through angle_to() and abs(). Explicit annotation keeps the
+				# warnings-as-errors parser happy — same pattern as the S16.1-002 test_sprint10 fix.
+				var angle_diff: float = abs(cur_vel.angle_to(prev_vel))
+				if angle_diff > 0.5:  # ~30° threshold
```

**Headless verification** — `godot --headless --path godot/ --import`:

_Before fix (reproduced on pre-change tree):_
```
SCRIPT ERROR: Parse Error: The variable type is being inferred from a Variant value, so it will be typed as Variant. (Warning treated as error.)
          at: GDScript::reload (res://arena/arena_renderer.gd:463)
ERROR: Failed to load script "res://arena/arena_renderer.gd" with error "Parse error".
```

_After fix:_
```
Godot Engine v4.4.1.stable.official.49a5bc7b6 - https://godotengine.org
first_scan_filesystem: begin: Project initialization steps: 5
...
loading_editor_layout: end
```
No `arena_renderer.gd` parse error, no warnings-as-errors.

## Diff stat
```
 docs/gdd.md                   | 2 +-
 godot/arena/arena_renderer.gd | 5 ++++-
 2 files changed, 5 insertions(+), 2 deletions(-)
```

## Scope gate ✅
- `godot/combat/**` diff: **empty**
- `godot/data/**` diff: **empty** (including `weapon_data.gd` — untouched)
- No workflow / test / runner changes
- No `.uid` or tool-generated sibling files

## Task
Closes [S16.1-006].
