### PR TITLE
feat(readme): self-updating status block

### DIFF
--- a/.github/workflows/readme-status.yml
+++ b/.github/workflows/readme-status.yml
@@ -1,0 +1,51 @@
+name: readme-status
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    # 12:00 UTC daily = 08:00 EST / 07:00 EDT — morning coffee refresh.
+    - cron: "0 12 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: readme-status
+  cancel-in-progress: false
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    # Belt: skip self-made commits (the [skip ci] convention is the suspenders).
+    if: github.actor != 'github-actions[bot]'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Regenerate README status block
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BROTT_STUDIO_PAT: ${{ secrets.BROTT_STUDIO_PAT }}
+        run: python3 scripts/update-readme-status.py
+
+      - name: Commit & push if changed
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- README.md; then
+            echo "No README changes — nothing to commit."
+            exit 0
+          fi
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add README.md
+          git commit -m "chore(readme): auto-update status block [skip ci]"
+          git push

--- a/README.md
+++ b/README.md
@@ -6,6 +6,31 @@ Build autonomous combat Brotts, teach them how to fight with drag-and-drop Behav
 
 **Engine:** Godot 4 | **Platform:** Web (HTML5) | **Genre:** Auto-battler / Strategy
 
+<!-- STATUS-START -->
+## 📊 Status
+
+<img alt="ci" src="https://img.shields.io/github/actions/workflow/status/brott-studio/battlebrotts-v2/verify.yml?branch=main&label=CI"> <img alt="prs" src="https://img.shields.io/github/issues-pr/brott-studio/battlebrotts-v2?label=open%20PRs"> <img alt="backlog" src="https://img.shields.io/github/issues-search/brott-studio/battlebrotts-v2?query=label%3Abacklog+is%3Aopen&label=backlog">
+
+**Current sprint:** [Sprint 16 — Tech Debt Cleanup + Infrastructure Health](./sprints/sprint-16.md)
+
+**Backlog** (31 total · [view all](https://github.com/brott-studio/battlebrotts-v2/issues?q=is%3Aissue+label%3Abacklog+is%3Aopen))
+- 🎵 Audio 0 · 🎨 Art 0 · ✨ UX 0 · 🎮 Gameplay 0 · 🔧 Tech-Debt 0 · 🏗️ Framework 0
+- 🔴 High 0 · 🟡 Mid 0 · 🔵 Low 0
+
+**Open PRs** (4)
+- [#127](https://github.com/brott-studio/battlebrotts-v2/pull/127) [S16.1] Close-out: mark tasks complete, update carry-forward table
+- [#93](https://github.com/brott-studio/battlebrotts-v2/pull/93) kb: S15.2 scope-gate enforcement pattern
+- [#77](https://github.com/brott-studio/battlebrotts-v2/pull/77) [S14.2-B+C] aggression cards + card library audit
+- [#76](https://github.com/brott-studio/battlebrotts-v2/pull/76) [S14.2-A] BrottBrain UI polish
+
+**Recent audits** (from [studio-audits](https://github.com/brott-studio/studio-audits))
+- _Audits unavailable (configure `BROTT_STUDIO_PAT` secret)_
+
+**Docs:** [GDD](./docs/gdd.md) · [Audio Vision](./docs/kb/audio-vision.md) · [UX Vision](./docs/kb/ux-vision.md) · [Pipeline](https://github.com/blor-inc/studio-framework/blob/main/PIPELINE.md)
+
+_Last updated: 2026-04-17 19:52 UTC · [update log](../../actions/workflows/readme-status.yml)_
+<!-- STATUS-END -->
+
 ## Links
 - [Game Design Document](docs/gdd.md)
 - [Studio Framework](https://github.com/blor-inc/studio-framework)

--- a/README.md
+++ b/README.md
@@ -24,11 +24,13 @@ Build autonomous combat Brotts, teach them how to fight with drag-and-drop Behav
 - [#76](https://github.com/brott-studio/battlebrotts-v2/pull/76) [S14.2-A] BrottBrain UI polish
 
 **Recent audits** (from [studio-audits](https://github.com/brott-studio/studio-audits))
-- _Audits unavailable (configure `BROTT_STUDIO_PAT` secret)_
+- S15.2 — B+ · [audit](https://github.com/brott-studio/studio-audits/blob/main/audits/battlebrotts-v2/v2-sprint-15.2.md)
+- S15.1 — B · [audit](https://github.com/brott-studio/studio-audits/blob/main/audits/battlebrotts-v2/v2-sprint-15.1.md)
+- S14.1 — ? · [audit](https://github.com/brott-studio/studio-audits/blob/main/audits/battlebrotts-v2/v2-sprint-14.1.md)
 
 **Docs:** [GDD](./docs/gdd.md) · [Audio Vision](./docs/kb/audio-vision.md) · [UX Vision](./docs/kb/ux-vision.md) · [Pipeline](https://github.com/blor-inc/studio-framework/blob/main/PIPELINE.md)
 
-_Last updated: 2026-04-17 19:57 UTC · [update log](../../actions/workflows/readme-status.yml)_
+_Last updated: 2026-04-17 20:03 UTC · [update log](../../actions/workflows/readme-status.yml)_
 <!-- STATUS-END -->
 
 ## Links

--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ Build autonomous combat Brotts, teach them how to fight with drag-and-drop Behav
 **Current sprint:** [Sprint 16 — Tech Debt Cleanup + Infrastructure Health](./sprints/sprint-16.md)
 
 **Backlog** (31 total · [view all](https://github.com/brott-studio/battlebrotts-v2/issues?q=is%3Aissue+label%3Abacklog+is%3Aopen))
-- 🎵 Audio 0 · 🎨 Art 0 · ✨ UX 0 · 🎮 Gameplay 0 · 🔧 Tech-Debt 0 · 🏗️ Framework 0
-- 🔴 High 0 · 🟡 Mid 0 · 🔵 Low 0
+- 🎵 Audio 4 · 🎨 Art 5 · ✨ UX 8 · 🎮 Gameplay 7 · 🔧 Tech-Debt 5 · 🏗️ Framework 2
+- 🔴 High 4 · 🟡 Mid 16 · 🔵 Low 11
 
 **Open PRs** (4)
-- [#127](https://github.com/brott-studio/battlebrotts-v2/pull/127) [S16.1] Close-out: mark tasks complete, update carry-forward table
+- [#128](https://github.com/brott-studio/battlebrotts-v2/pull/128) feat(readme): self-updating status block
 - [#93](https://github.com/brott-studio/battlebrotts-v2/pull/93) kb: S15.2 scope-gate enforcement pattern
 - [#77](https://github.com/brott-studio/battlebrotts-v2/pull/77) [S14.2-B+C] aggression cards + card library audit
 - [#76](https://github.com/brott-studio/battlebrotts-v2/pull/76) [S14.2-A] BrottBrain UI polish
@@ -28,7 +28,7 @@ Build autonomous combat Brotts, teach them how to fight with drag-and-drop Behav
 
 **Docs:** [GDD](./docs/gdd.md) · [Audio Vision](./docs/kb/audio-vision.md) · [UX Vision](./docs/kb/ux-vision.md) · [Pipeline](https://github.com/blor-inc/studio-framework/blob/main/PIPELINE.md)
 
-_Last updated: 2026-04-17 19:52 UTC · [update log](../../actions/workflows/readme-status.yml)_
+_Last updated: 2026-04-17 19:57 UTC · [update log](../../actions/workflows/readme-status.yml)_
 <!-- STATUS-END -->
 
 ## Links

--- a/scripts/update-readme-status.py
+++ b/scripts/update-readme-status.py
@@ -1,0 +1,370 @@
+#!/usr/bin/env python3
+"""Regenerate the 📊 Status block in README.md from live GitHub data.
+
+Pure stdlib. Idempotent. Graceful on missing auth / API errors.
+
+Run locally:
+    python3 scripts/update-readme-status.py
+
+In CI:
+    GITHUB_TOKEN=...            # same-repo reads (auto-provided)
+    BROTT_STUDIO_PAT=...        # cross-repo read of brott-studio/studio-audits
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import urllib.parse
+import urllib.request
+import urllib.error
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO = "brott-studio/battlebrotts-v2"
+AUDITS_REPO = "brott-studio/studio-audits"
+AUDITS_SUBDIR = "battlebrotts-v2"
+DEFAULT_BRANCH = "main"
+VERIFY_WORKFLOW_FILE = "verify.yml"
+
+START = "<!-- STATUS-START -->"
+END = "<!-- STATUS-END -->"
+
+AREA_LABELS = [
+    ("audio", "🎵 Audio"),
+    ("art", "🎨 Art"),
+    ("ux", "✨ UX"),
+    ("gameplay", "🎮 Gameplay"),
+    ("tech-debt", "🔧 Tech-Debt"),
+    ("framework", "🏗️ Framework"),
+]
+PRIO_LABELS = [
+    ("high", "🔴 High"),
+    ("mid", "🟡 Mid"),
+    ("low", "🔵 Low"),
+]
+
+ROOT = Path(__file__).resolve().parent.parent
+README = ROOT / "README.md"
+
+
+def _token_for(repo: str) -> str | None:
+    """Pick the best token available for a given repo.
+
+    - Same repo: prefer GITHUB_TOKEN (CI default), else BROTT_STUDIO_PAT.
+    - Cross repo: require BROTT_STUDIO_PAT.
+    """
+    if repo == REPO:
+        return os.environ.get("GITHUB_TOKEN") or os.environ.get("BROTT_STUDIO_PAT")
+    return os.environ.get("BROTT_STUDIO_PAT")
+
+
+def gh(path: str, *, repo: str = REPO, params: dict | None = None, accept: str = "application/vnd.github+json"):
+    """Minimal GitHub REST v3 GET. Returns parsed JSON or None on soft failure."""
+    url = f"https://api.github.com{path}"
+    if params:
+        url += "?" + urllib.parse.urlencode(params)
+    req = urllib.request.Request(url)
+    req.add_header("Accept", accept)
+    req.add_header("User-Agent", "bb2-readme-status/1.0")
+    tok = _token_for(repo)
+    if tok:
+        req.add_header("Authorization", f"Bearer {tok}")
+    try:
+        with urllib.request.urlopen(req, timeout=20) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as e:
+        sys.stderr.write(f"[warn] HTTP {e.code} for {url}\n")
+        return None
+    except (urllib.error.URLError, TimeoutError, OSError) as e:
+        sys.stderr.write(f"[warn] {e} for {url}\n")
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Data collection
+# ---------------------------------------------------------------------------
+
+def fetch_ci_status() -> str:
+    """Return 'success', 'failure', or '' for most recent workflow run on default branch."""
+    data = gh(
+        f"/repos/{REPO}/actions/runs",
+        params={"branch": DEFAULT_BRANCH, "per_page": 1, "event": "push"},
+    )
+    if not data or not data.get("workflow_runs"):
+        return ""
+    run = data["workflow_runs"][0]
+    return run.get("conclusion") or run.get("status") or ""
+
+
+def fetch_open_prs() -> list[dict]:
+    data = gh(f"/repos/{REPO}/pulls", params={"state": "open", "per_page": 5, "sort": "created", "direction": "desc"})
+    return data or []
+
+
+def _search_issue_count(q: str) -> int:
+    data = gh("/search/issues", params={"q": q, "per_page": 1})
+    if not data:
+        return 0
+    return int(data.get("total_count", 0))
+
+
+def fetch_backlog_counts() -> dict:
+    base = f'repo:{REPO} is:issue is:open label:backlog'
+    out: dict = {
+        "total": _search_issue_count(base),
+        "areas": {},
+        "prios": {},
+    }
+    for key, _label in AREA_LABELS:
+        out["areas"][key] = _search_issue_count(f'{base} label:{key}')
+    for key, _label in PRIO_LABELS:
+        out["prios"][key] = _search_issue_count(f'{base} label:{key}')
+    return out
+
+
+_SPRINT_NAME_RE = re.compile(r"sprint[-_]?(\d+)(?:[._-](\d+))?", re.IGNORECASE)
+
+
+def _sprint_sort_key(name: str) -> tuple[int, int]:
+    m = _SPRINT_NAME_RE.search(name)
+    if not m:
+        return (-1, -1)
+    major = int(m.group(1))
+    minor = int(m.group(2)) if m.group(2) else 0
+    return (major, minor)
+
+
+def find_current_sprint() -> tuple[str, str] | None:
+    """Return (title, relative_path) of the highest-versioned sprint doc, or None."""
+    candidates: list[Path] = []
+    for d in (ROOT / "docs" / "design", ROOT / "sprints"):
+        if d.is_dir():
+            candidates.extend(p for p in d.glob("sprint*.md") if p.is_file())
+    if not candidates:
+        return None
+    candidates.sort(key=lambda p: _sprint_sort_key(p.name), reverse=True)
+    best = candidates[0]
+    title = ""
+    try:
+        for line in best.read_text(encoding="utf-8").splitlines():
+            s = line.strip()
+            if s.startswith("# "):
+                title = s[2:].strip()
+                break
+    except OSError:
+        pass
+    if not title:
+        title = best.stem
+    rel = best.relative_to(ROOT).as_posix()
+    return title, rel
+
+
+_GRADE_RE = re.compile(r"\b(?:grade|final grade|overall)\s*[:\-–]\s*([A-F][+\-−–]?)", re.IGNORECASE)
+_GRADE_FM_RE = re.compile(r"^grade\s*:\s*([A-F][+\-−–]?)\s*$", re.IGNORECASE | re.MULTILINE)
+
+
+def _parse_grade(text: str) -> str:
+    m = _GRADE_FM_RE.search(text) or _GRADE_RE.search(text)
+    if not m:
+        return "?"
+    g = m.group(1).replace("-", "−")  # prettier unicode minus
+    return g
+
+
+def fetch_recent_audits() -> list[dict] | None:
+    """Return list of {sprint,label,grade,url} for up to 3 most recent audits.
+
+    Returns None if auth unavailable or repo unreachable -> caller renders graceful message.
+    """
+    if not _token_for(AUDITS_REPO):
+        return None
+    listing = gh(f"/repos/{AUDITS_REPO}/contents/{AUDITS_SUBDIR}", repo=AUDITS_REPO)
+    if listing is None:
+        return None
+    if not isinstance(listing, list):
+        return []
+    files = [f for f in listing if f.get("type") == "file" and re.match(r"sprint.*-audit\.md$", f.get("name", ""), re.I)]
+    files.sort(key=lambda f: _sprint_sort_key(f["name"]), reverse=True)
+    top = files[:3]
+    out = []
+    for f in top:
+        name = f["name"]
+        m = _SPRINT_NAME_RE.search(name)
+        if m:
+            major = m.group(1)
+            minor = m.group(2)
+            label = f"S{major}.{minor}" if minor else f"S{major}"
+        else:
+            label = name
+        # Fetch raw content for grade parsing
+        grade = "?"
+        dl = f.get("download_url")
+        if dl:
+            try:
+                req = urllib.request.Request(dl, headers={"User-Agent": "bb2-readme-status/1.0"})
+                tok = _token_for(AUDITS_REPO)
+                if tok:
+                    req.add_header("Authorization", f"Bearer {tok}")
+                with urllib.request.urlopen(req, timeout=20) as resp:
+                    body = resp.read().decode("utf-8", errors="replace")
+                grade = _parse_grade(body[:4000])
+            except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError, OSError):
+                pass
+        out.append({"label": label, "grade": grade, "url": f.get("html_url", "")})
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Rendering
+# ---------------------------------------------------------------------------
+
+def render_block() -> str:
+    lines: list[str] = [START, "## 📊 Status", ""]
+
+    # Badges (shields.io — always renders, even offline)
+    badges = [
+        f'<img alt="ci" src="https://img.shields.io/github/actions/workflow/status/{REPO}/{VERIFY_WORKFLOW_FILE}?branch={DEFAULT_BRANCH}&label=CI">',
+        f'<img alt="prs" src="https://img.shields.io/github/issues-pr/{REPO}?label=open%20PRs">',
+        f'<img alt="backlog" src="https://img.shields.io/github/issues-search/{REPO}?query=label%3Abacklog+is%3Aopen&label=backlog">',
+    ]
+    lines.append(" ".join(badges))
+    lines.append("")
+
+    # Current sprint
+    sprint = find_current_sprint()
+    if sprint:
+        title, rel = sprint
+        lines.append(f"**Current sprint:** [{title}](./{rel})")
+    else:
+        lines.append("**Current sprint:** _(no sprint docs found)_")
+    lines.append("")
+
+    # Backlog
+    bl = fetch_backlog_counts()
+    view_all = f"https://github.com/{REPO}/issues?q=is%3Aissue+label%3Abacklog+is%3Aopen"
+    lines.append(f"**Backlog** ({bl['total']} total · [view all]({view_all}))")
+    area_bits = [f"{label} {bl['areas'].get(k, 0)}" for k, label in AREA_LABELS]
+    prio_bits = [f"{label} {bl['prios'].get(k, 0)}" for k, label in PRIO_LABELS]
+    lines.append("- " + " · ".join(area_bits))
+    lines.append("- " + " · ".join(prio_bits))
+    lines.append("")
+
+    # Open PRs (compact list)
+    prs = fetch_open_prs()
+    if prs:
+        lines.append(f"**Open PRs** ({len(prs)})")
+        for pr in prs[:5]:
+            num = pr.get("number")
+            title = (pr.get("title") or "").strip()
+            url = pr.get("html_url") or f"https://github.com/{REPO}/pull/{num}"
+            lines.append(f"- [#{num}]({url}) {title}")
+        lines.append("")
+
+    # Audits
+    audits = fetch_recent_audits()
+    lines.append(f"**Recent audits** (from [studio-audits](https://github.com/{AUDITS_REPO}))")
+    if audits is None:
+        lines.append("- _Audits unavailable (configure `BROTT_STUDIO_PAT` secret)_")
+    elif not audits:
+        lines.append("- _No audits yet_")
+    else:
+        for a in audits:
+            lines.append(f"- {a['label']} — {a['grade']} · [audit]({a['url']})")
+    lines.append("")
+
+    # Docs row
+    doc_links = []
+    if (ROOT / "docs" / "gdd.md").exists():
+        doc_links.append("[GDD](./docs/gdd.md)")
+    if (ROOT / "docs" / "kb" / "audio-vision.md").exists():
+        doc_links.append("[Audio Vision](./docs/kb/audio-vision.md)")
+    if (ROOT / "docs" / "kb" / "ux-vision.md").exists():
+        doc_links.append("[UX Vision](./docs/kb/ux-vision.md)")
+    if (ROOT / "docs" / "kb" / "pipeline.md").exists():
+        doc_links.append("[Pipeline](./docs/kb/pipeline.md)")
+    else:
+        doc_links.append("[Pipeline](https://github.com/blor-inc/studio-framework/blob/main/PIPELINE.md)")
+    if doc_links:
+        lines.append("**Docs:** " + " · ".join(doc_links))
+        lines.append("")
+
+    # Footer
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    lines.append(f"_Last updated: {now} · [update log](../../actions/workflows/readme-status.yml)_")
+    lines.append(END)
+    return "\n".join(lines) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# README splice
+# ---------------------------------------------------------------------------
+
+_TS_RE = re.compile(r"_Last updated: \d{4}-\d{2}-\d{2} \d{2}:\d{2} UTC")
+
+
+def _strip_timestamp(block: str) -> str:
+    return _TS_RE.sub("_Last updated: <TS>", block)
+
+
+def splice(readme_text: str, block: str) -> str:
+    if START in readme_text and END in readme_text:
+        pre, rest = readme_text.split(START, 1)
+        _old, post = rest.split(END, 1)
+        # Ensure exactly one blank line around the block for readability.
+        pre = pre.rstrip() + "\n\n"
+        post = post.lstrip("\n")
+        if post and not post.startswith("\n"):
+            post = "\n" + post
+        return pre + block.rstrip() + "\n" + post
+    # Insert after h1 + intro paragraph
+    lines = readme_text.splitlines(keepends=True)
+    insert_at = 0
+    seen_h1 = False
+    for i, ln in enumerate(lines):
+        if not seen_h1 and ln.startswith("# "):
+            seen_h1 = True
+            insert_at = i + 1
+            continue
+        if seen_h1:
+            # Skip blockquote/intro lines until we hit a section header or double blank.
+            if ln.startswith("## "):
+                insert_at = i
+                break
+            insert_at = i + 1
+    before = "".join(lines[:insert_at])
+    after = "".join(lines[insert_at:])
+    if before and not before.endswith("\n"):
+        before += "\n"
+    if before and not before.endswith("\n\n"):
+        before += "\n"
+    if after and not after.startswith("\n"):
+        after = "\n" + after
+    return before + block.rstrip() + "\n" + after
+
+
+def main() -> int:
+    readme_text = README.read_text(encoding="utf-8") if README.exists() else "# BattleBrotts v2\n"
+    block = render_block()
+    candidate = splice(readme_text, block)
+
+    # Idempotence: if nothing but the timestamp would change, keep the old
+    # timestamp so back-to-back runs produce zero diff.
+    if _strip_timestamp(candidate) == _strip_timestamp(readme_text) and readme_text:
+        # Preserve previous timestamp (or carry over if block just didn't exist yet).
+        old_ts = _TS_RE.search(readme_text)
+        new_ts = _TS_RE.search(candidate)
+        if old_ts and new_ts:
+            candidate = candidate[:new_ts.start()] + old_ts.group(0) + candidate[new_ts.end():]
+
+    if candidate == readme_text:
+        print("README status block unchanged.")
+        return 0
+    README.write_text(candidate, encoding="utf-8")
+    print(f"README.md updated ({len(candidate)} bytes).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/update-readme-status.py
+++ b/scripts/update-readme-status.py
@@ -24,7 +24,7 @@ from pathlib import Path
 
 REPO = "brott-studio/battlebrotts-v2"
 AUDITS_REPO = "brott-studio/studio-audits"
-AUDITS_SUBDIR = "battlebrotts-v2"
+AUDITS_SUBDIR = "audits/battlebrotts-v2"
 DEFAULT_BRANCH = "main"
 VERIFY_WORKFLOW_FILE = "verify.yml"
 
@@ -199,7 +199,7 @@ def fetch_recent_audits() -> list[dict] | None:
         return None
     if not isinstance(listing, list):
         return []
-    files = [f for f in listing if f.get("type") == "file" and re.match(r"sprint.*-audit\.md$", f.get("name", ""), re.I)]
+    files = [f for f in listing if f.get("type") == "file" and re.match(r"(?:v2-)?sprint.*\.md$", f.get("name", ""), re.I)]
     files.sort(key=lambda f: _sprint_sort_key(f["name"]), reverse=True)
     top = files[:3]
     out = []

--- a/scripts/update-readme-status.py
+++ b/scripts/update-readme-status.py
@@ -32,17 +32,17 @@ START = "<!-- STATUS-START -->"
 END = "<!-- STATUS-END -->"
 
 AREA_LABELS = [
-    ("audio", "🎵 Audio"),
-    ("art", "🎨 Art"),
-    ("ux", "✨ UX"),
-    ("gameplay", "🎮 Gameplay"),
-    ("tech-debt", "🔧 Tech-Debt"),
-    ("framework", "🏗️ Framework"),
+    ("area:audio", "🎵 Audio"),
+    ("area:art", "🎨 Art"),
+    ("area:ux", "✨ UX"),
+    ("area:gameplay", "🎮 Gameplay"),
+    ("area:tech-debt", "🔧 Tech-Debt"),
+    ("area:framework", "🏗️ Framework"),
 ]
 PRIO_LABELS = [
-    ("high", "🔴 High"),
-    ("mid", "🟡 Mid"),
-    ("low", "🔵 Low"),
+    ("prio:high", "🔴 High"),
+    ("prio:mid", "🟡 Mid"),
+    ("prio:low", "🔵 Low"),
 ]
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -110,17 +110,31 @@ def _search_issue_count(q: str) -> int:
     return int(data.get("total_count", 0))
 
 
+def _list_issue_count(labels: list[str]) -> int:
+    # Use /repos/{owner}/{repo}/issues with comma-joined labels — handles
+    # labels containing ':' (e.g. area:audio) which the search API requires
+    # to be quoted. Cap at 100; backlog is not expected to exceed that soon.
+    data = gh(f"/repos/{REPO}/issues", params={
+        "state": "open",
+        "labels": ",".join(labels),
+        "per_page": 100,
+    })
+    if not isinstance(data, list):
+        return 0
+    # Filter out PRs (the issues endpoint returns PRs too, they have 'pull_request' key).
+    return sum(1 for i in data if "pull_request" not in i)
+
+
 def fetch_backlog_counts() -> dict:
-    base = f'repo:{REPO} is:issue is:open label:backlog'
     out: dict = {
-        "total": _search_issue_count(base),
+        "total": _list_issue_count(["backlog"]),
         "areas": {},
         "prios": {},
     }
     for key, _label in AREA_LABELS:
-        out["areas"][key] = _search_issue_count(f'{base} label:{key}')
+        out["areas"][key] = _list_issue_count(["backlog", key])
     for key, _label in PRIO_LABELS:
-        out["prios"][key] = _search_issue_count(f'{base} label:{key}')
+        out["prios"][key] = _list_issue_count(["backlog", key])
     return out
 
 


### PR DESCRIPTION
## Summary

Adds a self-updating **📊 Status** block to `README.md` so the repo home page shows live project state without needing the hand-maintained dashboard site.

### Files

- `.github/workflows/readme-status.yml` — runs on push-to-main, daily cron at 12:00 UTC (08:00 EST), and manual dispatch. Commits with `[skip ci]` and guards on `github.actor` so self-commits never loop.
- `scripts/update-readme-status.py` — pure-stdlib Python, idempotent regenerator. Queries GitHub REST for CI status, open PRs, backlog label counts, recent audits; scans `docs/design/` and `sprints/` for the latest sprint doc.
- `README.md` — inserts `<!-- STATUS-START -->` / `<!-- STATUS-END -->` markers and the initial populated block.

### Behavior

- **Idempotent:** back-to-back runs with no upstream change produce zero diff (timestamp is only rewritten when real content changes).
- **Graceful degradation:** if `BROTT_STUDIO_PAT` is missing or `studio-audits` is unreachable, the audits section renders `_Audits unavailable (configure BROTT_STUDIO_PAT secret)_` instead of failing the workflow.
- **Sprint detection:** picks the highest-versioned `sprint*.md` across `docs/design/` and `sprints/` (natural `major.minor` sort).

### 🔑 Action required from HCD

Add a repo secret named **`BROTT_STUDIO_PAT`** (a PAT with `repo:read` on `brott-studio/studio-audits`) via **Settings → Secrets and variables → Actions**. Until then the audits row degrades gracefully.

### Validation

- ✅ `python3 scripts/update-readme-status.py` runs clean locally
- ✅ Second run right after first produces zero diff
- ✅ No errors on missing PAT
- ✅ Workflow YAML parses cleanly (no `actionlint` available in sandbox; manual review done)

### Out of scope

- Dashboard deprecation (separate conversation)
- Rolling this pattern out to other project repos (this is the pilot)

Leaving unmerged for Boltz review.