### PR TITLE
fix: readme-status follow-ups (commit identity + stale org links)

### DIFF
--- a/.github/workflows/readme-status.yml
+++ b/.github/workflows/readme-status.yml
@@ -62,8 +62,8 @@ jobs:
             exit 0
           fi
 
-          git config user.name  "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name  "The Bott"
+          git config user.email "thebott@brott-studio.studio"
 
           # Stash the regenerated README, reset to a clean branch rooted at
           # base, then re-apply. This keeps the PR branch a single-commit,

--- a/README.md
+++ b/README.md
@@ -27,15 +27,15 @@ Build autonomous combat Brotts, teach them how to fight with drag-and-drop Behav
 - S15.1 — B · [audit](https://github.com/brott-studio/studio-audits/blob/main/audits/battlebrotts-v2/v2-sprint-15.1.md)
 - S14.1 — ? · [audit](https://github.com/brott-studio/studio-audits/blob/main/audits/battlebrotts-v2/v2-sprint-14.1.md)
 
-**Docs:** [GDD](./docs/gdd.md) · [Audio Vision](./docs/kb/audio-vision.md) · [UX Vision](./docs/kb/ux-vision.md) · [Pipeline](https://github.com/blor-inc/studio-framework/blob/main/PIPELINE.md)
+**Docs:** [GDD](./docs/gdd.md) · [Audio Vision](./docs/kb/audio-vision.md) · [UX Vision](./docs/kb/ux-vision.md) · [Pipeline](https://github.com/brott-studio/studio-framework/blob/main/PIPELINE.md)
 
 _Last updated: 2026-04-18 05:06 UTC · [update log](../../actions/workflows/readme-status.yml)_
 <!-- STATUS-END -->
 
 ## Links
 - [Game Design Document](docs/gdd.md)
-- [Studio Framework](https://github.com/blor-inc/studio-framework)
-- [v1 Archive](https://github.com/blor-inc/battlebrotts) (16 sprints of history)
+- [Studio Framework](https://github.com/brott-studio/studio-framework)
+- [v1 Archive](https://github.com/brott-studio/battlebrotts) (16 sprints of history)
 
 ## Status
 🚧 v2 — Starting fresh with pipeline-driven development

--- a/scripts/update-readme-status.py
+++ b/scripts/update-readme-status.py
@@ -299,7 +299,7 @@ def render_block() -> str:
     if (ROOT / "docs" / "kb" / "pipeline.md").exists():
         doc_links.append("[Pipeline](./docs/kb/pipeline.md)")
     else:
-        doc_links.append("[Pipeline](https://github.com/blor-inc/studio-framework/blob/main/PIPELINE.md)")
+        doc_links.append("[Pipeline](https://github.com/brott-studio/studio-framework/blob/main/PIPELINE.md)")
     if doc_links:
         lines.append("**Docs:** " + " · ".join(doc_links))
         lines.append("")


### PR DESCRIPTION
Two follow-ups from PR #129:

1. **Workflow commits as `The Bott`** (not `github-actions[bot]`) so verify.yml gets triggered on auto-update PRs. GitHub suppresses downstream workflows for commits authored by `github-actions[bot]` — using a non-bot identity lets required status checks fire automatically.

2. **Fix stale `blor-inc/` org references** in `scripts/update-readme-status.py` (Pipeline link) and `README.md` (Studio Framework + v1 Archive links). All now point to `brott-studio/`.

After this merges, the next auto-update PR should run verify.yml unassisted and auto-merge end-to-end with no human or manual intervention.