### PR TITLE
fix(readme-status): backlog counts populate correctly

### DIFF
--- a/.github/workflows/readme-status.yml
+++ b/.github/workflows/readme-status.yml
@@ -17,6 +17,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  issues: read
 
 concurrency:
   group: readme-status

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ Build autonomous combat Brotts, teach them how to fight with drag-and-drop Behav
 
 **Current sprint:** [Sprint 16 — Tech Debt Cleanup + Infrastructure Health](./sprints/sprint-16.md)
 
-**Backlog** (0 total · [view all](https://github.com/brott-studio/battlebrotts-v2/issues?q=is%3Aissue+label%3Abacklog+is%3Aopen))
-- 🎵 Audio 0 · 🎨 Art 0 · ✨ UX 0 · 🎮 Gameplay 0 · 🔧 Tech-Debt 0 · 🏗️ Framework 0
-- 🔴 High 0 · 🟡 Mid 0 · 🔵 Low 0
+**Backlog** (31 total · [view all](https://github.com/brott-studio/battlebrotts-v2/issues?q=is%3Aissue+label%3Abacklog+is%3Aopen))
+- 🎵 Audio 4 · 🎨 Art 5 · ✨ UX 8 · 🎮 Gameplay 7 · 🔧 Tech-Debt 5 · 🏗️ Framework 2
+- 🔴 High 4 · 🟡 Mid 16 · 🔵 Low 11
 
 **Open PRs** (3)
 - [#93](https://github.com/brott-studio/battlebrotts-v2/pull/93) kb: S15.2 scope-gate enforcement pattern
@@ -29,7 +29,7 @@ Build autonomous combat Brotts, teach them how to fight with drag-and-drop Behav
 
 **Docs:** [GDD](./docs/gdd.md) · [Audio Vision](./docs/kb/audio-vision.md) · [UX Vision](./docs/kb/ux-vision.md) · [Pipeline](https://github.com/brott-studio/studio-framework/blob/main/PIPELINE.md)
 
-_Last updated: 2026-04-18 05:06 UTC · [update log](../../actions/workflows/readme-status.yml)_
+_Last updated: 2026-04-20 02:39 UTC · [update log](../../actions/workflows/readme-status.yml)_
 <!-- STATUS-END -->
 
 ## Links

--- a/scripts/update-readme-status.py
+++ b/scripts/update-readme-status.py
@@ -52,11 +52,15 @@ README = ROOT / "README.md"
 def _token_for(repo: str) -> str | None:
     """Pick the best token available for a given repo.
 
-    - Same repo: prefer GITHUB_TOKEN (CI default), else BROTT_STUDIO_PAT.
-    - Cross repo: require BROTT_STUDIO_PAT.
+    - Prefer BROTT_STUDIO_PAT when available: the fine-grained PAT has
+      `issues:read` + `pull-requests:read` across all studio repos, while
+      the workflow's `GITHUB_TOKEN` only has `contents:write` +
+      `pull-requests:write` declared and silently returns empty results
+      for `/repos/.../issues?labels=...` queries it can't authorize.
+    - Fall back to GITHUB_TOKEN (CI default) for same-repo calls.
     """
     if repo == REPO:
-        return os.environ.get("GITHUB_TOKEN") or os.environ.get("BROTT_STUDIO_PAT")
+        return os.environ.get("BROTT_STUDIO_PAT") or os.environ.get("GITHUB_TOKEN")
     return os.environ.get("BROTT_STUDIO_PAT")
 
 


### PR DESCRIPTION
## Bug
README shield showed `backlog 31` but the text breakdown said `0` for every area and priority:

```
**Backlog** (0 total · …)
- 🎵 Audio 0 · 🎨 Art 0 · ✨ UX 0 · 🎮 Gameplay 0 · 🔧 Tech-Debt 0 · 🏗️ Framework 0
- 🔴 High 0 · 🟡 Mid 0 · 🔵 Low 0
```

## Root cause
Workflow permissions block only declared `contents: write` + `pull-requests: write`. That caps the default `GITHUB_TOKEN` to those scopes. The script's `/repos/.../issues?labels=…` calls then returned empty lists silently (no exception, just `[]`).

`_token_for()` preferred `GITHUB_TOKEN` over `BROTT_STUDIO_PAT`, so the PAT — which *does* have issues:read across all studio repos — was never used.

Self-perpetuating: script produced 0s → README already had 0s → no diff → no PR → daily run looked healthy.

## Fix
- `scripts/update-readme-status.py`: prefer `BROTT_STUDIO_PAT` in `_token_for` (falls back to `GITHUB_TOKEN`).
- `.github/workflows/readme-status.yml`: add `issues: read` to permissions so `GITHUB_TOKEN` also works if PAT is ever missing.
- README.md regenerated with correct values (31 total, proper breakdown).

## Verified locally
```
**Backlog** (31 total · …)
- 🎵 Audio 4 · 🎨 Art 5 · ✨ UX 8 · 🎮 Gameplay 7 · 🔧 Tech-Debt 5 · 🏗️ Framework 2
- 🔴 High 4 · 🟡 Mid 16 · 🔵 Low 11
```