### PR TITLE
fix(readme-status): drop [skip ci] so verify.yml fires on auto-update PR

### DIFF
--- a/.github/workflows/readme-status.yml
+++ b/.github/workflows/readme-status.yml
@@ -80,7 +80,12 @@ jobs:
           fi
 
           git add README.md
-          git commit -m "${TITLE} [skip ci]"
+          # Note: no `[skip ci]` suffix. Loop prevention is handled by
+          # `paths-ignore: [README.md]` on the push trigger above. `[skip ci]`
+          # also suppresses `pull_request` triggers, which starves the required
+          # status checks (verify.yml short-circuits) and leaves auto-merge
+          # blocked forever.
+          git commit -m "${TITLE}"
           git push --force-with-lease origin "$BRANCH"
 
           # Idempotent: reuse an open PR from this branch if one exists.


### PR DESCRIPTION
## Bug
PR #133 (the auto-generated readme status update from earlier) stayed at `mergeable_state: blocked` indefinitely. No check runs posted on the head commit at all.

## Root cause
The auto-update commit message includes `[skip ci]`:
```
chore(readme): auto-update status block [skip ci]
```

GitHub Actions treats `[skip ci]` as a repo-wide workflow suppressor. It stops **all** triggers on that commit, including the `pull_request` event that should fire `verify.yml` (our required-status-checks provider).

With required checks now gated by branch protection on `main`, this leaves the auto-update PR deadlocked forever:
- verify.yml doesn't fire → Godot/Playwright checks don't post
- auto-merge is enabled but can't progress without required checks
- next scheduled run sees the PR still open and updates it, re-applying `[skip ci]`

This masked well until PR #132 (today) added `issues: read` and the `BROTT_STUDIO_PAT`-first token preference — those were enough to get accurate counts but not enough to unblock auto-merge.

## Fix
Drop `[skip ci]` from the auto-commit message. Loop prevention is already handled by:
```yaml
on:
  push:
    branches: [main]
    paths-ignore:
      - "README.md"
```
`[skip ci]` was a redundant belt that became harmful once required checks existed.

## Verify
After this merges:
1. Trigger readme-status workflow_dispatch
2. Expect: new PR created, verify.yml fires on PR-open, required checks post green (short-circuit for doc-only), auto-merge lands it
3. If PR #133 is still open, it needs a rebase onto main to pick up this fix (I'll handle)