### PR TITLE
chore(readme): auto-update status block

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,20 +11,20 @@ Build autonomous combat Brotts, teach them how to fight with drag-and-drop Behav
 
 <img alt="ci" src="https://img.shields.io/github/actions/workflow/status/brott-studio/battlebrotts-v2/verify.yml?branch=main&label=CI"> <img alt="prs" src="https://img.shields.io/github/issues-pr/brott-studio/battlebrotts-v2?label=open%20PRs"> <img alt="backlog" src="https://img.shields.io/github/issues-search/brott-studio/battlebrotts-v2?query=label%3Abacklog+is%3Aopen&label=backlog">
 
-**Current sprint:** [Sprint 16 — Tech Debt Cleanup + Infrastructure Health](./sprints/sprint-16.md)
+**Current sprint:** [Sprint 16.2 — Per-agent GitHub App for Specc + Test Hygiene Carry-Forwards](./sprints/sprint-16.2.md)
 
-**Backlog** (31 total · [view all](https://github.com/brott-studio/battlebrotts-v2/issues?q=is%3Aissue+label%3Abacklog+is%3Aopen))
+**Backlog** (36 total · [view all](https://github.com/brott-studio/battlebrotts-v2/issues?q=is%3Aissue+label%3Abacklog+is%3Aopen))
 - 🎵 Audio 4 · 🎨 Art 5 · ✨ UX 8 · 🎮 Gameplay 7 · 🔧 Tech-Debt 5 · 🏗️ Framework 2
-- 🔴 High 4 · 🟡 Mid 16 · 🔵 Low 11
+- 🔴 High 4 · 🟡 Mid 17 · 🔵 Low 15
 
 **Recent audits** (from [studio-audits](https://github.com/brott-studio/studio-audits))
+- S16.1 — ? · [audit](https://github.com/brott-studio/studio-audits/blob/main/audits/battlebrotts-v2/v2-sprint-16.1.md)
 - S15.2 — B+ · [audit](https://github.com/brott-studio/studio-audits/blob/main/audits/battlebrotts-v2/v2-sprint-15.2.md)
 - S15.1 — B · [audit](https://github.com/brott-studio/studio-audits/blob/main/audits/battlebrotts-v2/v2-sprint-15.1.md)
-- S14.1 — ? · [audit](https://github.com/brott-studio/studio-audits/blob/main/audits/battlebrotts-v2/v2-sprint-14.1.md)
 
 **Docs:** [GDD](./docs/gdd.md) · [Audio Vision](./docs/kb/audio-vision.md) · [UX Vision](./docs/kb/ux-vision.md) · [Pipeline](https://github.com/brott-studio/studio-framework/blob/main/PIPELINE.md)
 
-_Last updated: 2026-04-20 03:32 UTC · [update log](../../actions/workflows/readme-status.yml)_
+_Last updated: 2026-04-20 15:17 UTC · [update log](../../actions/workflows/readme-status.yml)_
 <!-- STATUS-END -->
 
 ## Links


### PR DESCRIPTION
Automated status-block refresh. See `.github/workflows/readme-status.yml`.

- Generated by `scripts/update-readme-status.py`
- Loop-guarded via `paths-ignore: [README.md]` on the push trigger
- Auto-merge (squash) is enabled; PR will merge itself once required checks pass