### PR TITLE
[S16.2-003 redo] Cross-actor identity validation

### DIFF
--- a/docs/kb/per-agent-github-apps.md
+++ b/docs/kb/per-agent-github-apps.md
@@ -7,3 +7,5 @@
 This line exists to validate that the `brott-studio-specc[bot]` App identity
 can author a commit, open a PR, self-approve, and merge end-to-end — proving
 the auth plumbing installed in S16.2-002 is functional.
+
+<!-- S16.2-003 redo: cross-actor plumbing marker added by Patch (PAT identity) -->


### PR DESCRIPTION
Redo of S16.2-003 with correct acceptance: validate Nutts-author -> Specc-reviewer cross-actor audit flow (the real pain-point from S15 PAT 422 KB). Original acceptance (self-approve) was spec-wrong; GitHub blocks self-approval at platform level for any identity.

Plumbing test:
- Commit author: `openclaw-patch` (PAT identity, NOT Specc App)
- PR open: PAT identity
- Review-approve: Specc App (`brott-studio-specc[bot]`)
- Merge: Specc App

If approve step 200s, full validation of the Nutts->Specc flow.