### PR TITLE
chore(readme): auto-update status block

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,20 +13,27 @@ Build autonomous combat Brotts, teach them how to fight with drag-and-drop Behav
 
 <img alt="ci" src="https://img.shields.io/github/actions/workflow/status/brott-studio/battlebrotts-v2/verify.yml?branch=main&label=CI"> <img alt="prs" src="https://img.shields.io/github/issues-pr/brott-studio/battlebrotts-v2?label=open%20PRs"> <img alt="backlog" src="https://img.shields.io/github/issues-search/brott-studio/battlebrotts-v2?query=label%3Abacklog+is%3Aopen&label=backlog">
 
-**Current sprint:** [Sprint 16.2 — Per-agent GitHub App for Specc + Test Hygiene Carry-Forwards](./sprints/sprint-16.2.md)
+**Current sprint:** [Sprint 27.1 — Arc I S(I).1: AutoDriver harness scaffold + chassis-pick flow](./sprints/sprint-27.1.md)
 
-**Backlog** (33 total · [view all](https://github.com/brott-studio/battlebrotts-v2/issues?q=is%3Aissue+label%3Abacklog+is%3Aopen))
-- 🎵 Audio 4 · 🎨 Art 5 · ✨ UX 8 · 🎮 Gameplay 7 · 🔧 Tech-Debt 5 · 🏗️ Framework 2
-- 🔴 High 4 · 🟡 Mid 16 · 🔵 Low 13
+**Backlog** (65 total · [view all](https://github.com/brott-studio/battlebrotts-v2/issues?q=is%3Aissue+label%3Abacklog+is%3Aopen))
+- 🎵 Audio 13 · 🎨 Art 5 · ✨ UX 9 · 🎮 Gameplay 7 · 🔧 Tech-Debt 5 · 🏗️ Framework 10
+- 🔴 High 3 · 🟡 Mid 0 · 🔵 Low 22
+
+**Open PRs** (5)
+- [#369](https://github.com/brott-studio/battlebrotts-v2/pull/369) chore: remove dashboard, serve game at root
+- [#367](https://github.com/brott-studio/battlebrotts-v2/pull/367) [O.3] Sprint plan — Swarm Death Freeze Fix (final sprint of Arc O)
+- [#318](https://github.com/brott-studio/battlebrotts-v2/pull/318) [kb] Arc F.5 learnings — starter-state, blank-screen, gdd-code-parity
+- [#299](https://github.com/brott-studio/battlebrotts-v2/pull/299) design: v1.0 roguelike GDD v2 (BrottBrain cut + Bot Arena control + encounter variety)
+- [#292](https://github.com/brott-studio/battlebrotts-v2/pull/292) [S24.4 KB] Cooldown-guard-before-yield + mutually-exclusive SFX branch patterns
 
 **Recent audits** (from [studio-audits](https://github.com/brott-studio/studio-audits))
-- S16.1 — ? · [audit](https://github.com/brott-studio/studio-audits/blob/main/audits/battlebrotts-v2/v2-sprint-16.1.md)
-- S15.2 — B+ · [audit](https://github.com/brott-studio/studio-audits/blob/main/audits/battlebrotts-v2/v2-sprint-15.2.md)
-- S15.1 — B · [audit](https://github.com/brott-studio/studio-audits/blob/main/audits/battlebrotts-v2/v2-sprint-15.1.md)
+- S28.8 — ? · [audit](https://github.com/brott-studio/studio-audits/blob/main/audits/battlebrotts-v2/v2-sprint-28.8.md)
+- S28.7 — ? · [audit](https://github.com/brott-studio/studio-audits/blob/main/audits/battlebrotts-v2/v2-sprint-28.7.md)
+- S28.6 — ? · [audit](https://github.com/brott-studio/studio-audits/blob/main/audits/battlebrotts-v2/v2-sprint-28.6.md)
 
 **Docs:** [GDD](./docs/gdd.md) · [Audio Vision](./docs/kb/audio-vision.md) · [UX Vision](./docs/kb/ux-vision.md) · [Pipeline](https://github.com/brott-studio/studio-framework/blob/main/PIPELINE.md)
 
-_Last updated: 2026-04-20 15:38 UTC · [update log](../../actions/workflows/readme-status.yml)_
+_Last updated: 2026-06-10 15:27 UTC · [update log](../../actions/workflows/readme-status.yml)_
 <!-- STATUS-END -->
 
 ## Links


### PR DESCRIPTION
Automated status-block refresh. See `.github/workflows/readme-status.yml`.

- Generated by `scripts/update-readme-status.py`
- Loop-guarded via `paths-ignore: [README.md]` on the push trigger
- Auto-merge (squash) is enabled; PR will merge itself once required checks pass