### PR TITLE
[S16.3-001] Add push: main trigger to verify.yml

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -3,6 +3,16 @@ name: Verify
 on:
   pull_request:
     branches: [main]
+  # S16.3-001: also fire on push to main so every merge commit produces a
+  # Verify run in the Actions tab (main-branch CI observability). DO NOT add
+  # `paths-ignore` here — mirror the PR trigger's pattern. The `changes` job
+  # below handles doc-only short-circuit at runtime, giving us a single source
+  # of truth for "what counts as doc-only" across both event types. Adding
+  # `paths-ignore` on push would also create asymmetry with the PR trigger
+  # and re-introduce the required-status-checks deadlock risk on any future
+  # push-scoped required check. See sprints/sprint-16.3.md §S16.3-001.
+  push:
+    branches: [main]
   # Note: paths-ignore removed intentionally. These jobs are required status
   # checks on main. If they don't run on doc-only PRs, auto-merge for those
   # PRs (e.g. the readme-status auto-update PR) will block forever. Instead
@@ -21,23 +31,60 @@ jobs:
           fetch-depth: 0
 
       - id: filter
-        name: Check if PR touches non-doc code
+        name: Check if event touches non-doc code
+        # S16.3-001: parameterize the diff range by event type.
+        # - pull_request: base.sha..head.sha (PR's merge base vs tip)
+        # - push (to main): github.event.before..github.sha (previous main tip
+        #   vs merge commit). If `before` is the zero SHA (first push after
+        #   branch creation / trigger activation) OR if the diff otherwise
+        #   fails, we force code=true so the full suite runs — safer to over-
+        #   run than to silently skip Godot on a main merge.
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PUSH_BEFORE_SHA: ${{ github.event.before }}
+          PUSH_HEAD_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
-          base_sha="${{ github.event.pull_request.base.sha }}"
-          head_sha="${{ github.event.pull_request.head.sha }}"
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            base_sha="$PR_BASE_SHA"
+            head_sha="$PR_HEAD_SHA"
+          elif [ "$EVENT_NAME" = "push" ]; then
+            base_sha="$PUSH_BEFORE_SHA"
+            head_sha="$PUSH_HEAD_SHA"
+            # Fallback: if `before` is the zero SHA (branch-creation push) or
+            # empty, we can't compute a diff — run the full suite.
+            if [ -z "$base_sha" ] || [ "$base_sha" = "0000000000000000000000000000000000000000" ]; then
+              echo "push event with no usable 'before' SHA — forcing code=true"
+              echo "code=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          else
+            # Unknown event (e.g. workflow_dispatch) — run the full suite.
+            echo "event=$EVENT_NAME — forcing code=true"
+            echo "code=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           # List changed files. Anything outside docs/**, sprints/**, and
           # markdown counts as "code" and must run the full verify suite.
           code_changed="false"
+          # If `git diff` itself fails (e.g. missing SHA after a force-push),
+          # fall back to code=true rather than crashing the job.
+          if ! diff_output=$(git diff --name-only "$base_sha" "$head_sha" 2>&1); then
+            echo "git diff failed ($diff_output) — forcing code=true"
+            echo "code=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           while IFS= read -r f; do
             case "$f" in
               docs/*|sprints/*|*.md) ;;
               "") ;;
               *) code_changed="true" ;;
             esac
-          done < <(git diff --name-only "$base_sha" "$head_sha")
+          done <<< "$diff_output"
           echo "code=$code_changed" >> "$GITHUB_OUTPUT"
-          echo "PR touches code: $code_changed"
+          echo "event=$EVENT_NAME touches code: $code_changed"
 
   godot-tests:
     name: Godot Unit Tests


### PR DESCRIPTION
## S16.3-001 — Add `push: main` trigger to `verify.yml`

Arc-closing CI observability change: fire Verify on every merge to `main`, so a merge-queue race or post-merge regression is visible in the Actions tab immediately instead of hiding until the next PR opens.

### What this PR does

1. **Adds `push: { branches: [main] }` trigger** alongside the existing `pull_request` trigger.
2. **No `paths-ignore` on the push trigger** — mirrors the current PR trigger's pattern. Doc-only filtering happens at runtime in the `changes` job, giving us a single source of truth. Inline YAML comment on the push trigger documents this so future agents don't re-propose `paths-ignore`. This deliberately overrides the arc-plan §S16.3-001 wording (which predates the S15/S16.1 required-status-checks deadlock lesson); see [`sprints/sprint-16.3.md` §S16.3-001](https://github.com/brott-studio/battlebrotts-v2/blob/main/sprints/sprint-16.3.md) for the rationale.
3. **Makes the `changes` job work for both event types** (implementation **(a)** from the sprint plan):
   - `pull_request` → `base.sha..head.sha` (unchanged).
   - `push` → `github.event.before..github.sha`.
   - **Fallbacks** (all set `code=true` — safer to over-run than silently skip Godot on main):
     - `github.event.before` is the zero SHA (branch-creation push / trigger-activation edge case).
     - `git diff` itself fails (e.g. missing SHA after a force-push).
     - Unknown event (e.g. `workflow_dispatch`).
   - Event-type dispatch uses a shell `if` on `$EVENT_NAME` with SHAs injected via `env:` — this avoids interpolating unset `pull_request.*.sha` expressions into shell strings on push events.

### Why implementation (a)

Ett's plan preferred (a) for symmetry: doc-only merges to main (e.g. the readme-status auto-update landing on main) still short-circuit to ✅ without spinning up Godot, matching PR behavior. (b) would always run Godot on every main merge — correct but wasteful. (a) is the cleaner match for the "single source of truth on what counts as doc-only" principle.

### Unblocks

This is the third HCD acceptance criterion for the S16 arc (`Verify` ✅ on `push: main`). Once this lands, Optic can run S16.3-003 end-to-end validation (two green runs: the merge-commit `push: main` run from this PR plus a `pull_request` run).

### Testing

- YAML parses cleanly (`python -m yaml`).
- PR-event path: unchanged from prior behavior.
- Push-event path: new logic, covered by expression guards + fallbacks. Real validation happens when this PR merges and the merge commit triggers its own `push: main` run — reporting that run's URL + result back to Riv as part of the S16.3-001 closeout.

---

Sprint: [S16.3](https://github.com/brott-studio/battlebrotts-v2/blob/main/sprints/sprint-16.3.md) · Task: S16.3-001 · Owner: Patch · Reviewer: Boltz
