### PR TITLE
[S16.3-002] Confirm warnings-as-errors consistency local vs CI

### DIFF
--- a/docs/kb/warnings-as-errors-policy-s16.3.md
+++ b/docs/kb/warnings-as-errors-policy-s16.3.md
@@ -1,0 +1,29 @@
+# Warnings-as-errors policy consistency (S16.3-002)
+
+**Status:** Confirmed aligned as of S16.3 (arc-close of S16).
+**Owner:** Nutts (build agent), per sprint-16.3 §S16.3-002.
+
+## What was checked
+
+Read-only comparison of the GDScript warnings-as-errors policy between:
+
+- **Local Godot 4.4.1 headless** — reads `godot/project.godot` directly.
+- **CI Godot 4.4.1 headless** — runs `godot --headless --path godot/ --script res://tests/test_runner.gd` in `.github/workflows/verify.yml`, which loads the same `godot/project.godot`.
+
+## Settings observed
+
+`godot/project.godot` contains **no** `debug/gdscript/warnings/*` entries and no `warnings_as_errors` override. The file is 23 lines, covering only `[application]`, `[display]`, and `[rendering]` sections. GDScript warning behavior therefore falls through to the Godot 4.4.1 engine defaults in both environments.
+
+## Verdict
+
+**Aligned by construction.** Local and CI load the same `project.godot`, and that file asserts no warnings policy — both resolve to identical engine-default behavior. No divergence is possible without editing `project.godot`, which is out of scope for S16.3.
+
+Spot-check of the most recent green Verify run on a code-path PR (S16.2-005, run `24675088337`, job `Godot Unit Tests`) confirms:
+
+- `PASS: arena_renderer.gd can be loaded` — the S16.1-006 fix has not re-surfaced.
+- No GDScript compile-time warnings promoted to errors in the test output.
+- Only runtime-shutdown artifacts (ObjectDB / RID leak messages on `--quit`) and test-asserted `SCRIPT ERROR` lines, both of which are orthogonal to `warnings_as_errors`.
+
+## Scope note
+
+This doc is a paper-trail artifact per Ett's tightening of the S16.3 arc-close requirements. No behavior change; no edits to `project.godot` or any `.gd` file.


### PR DESCRIPTION
## S16.3-002 — Warnings-as-errors consistency check (read-only)

**Verdict: ALIGNED.** No divergence between local and CI GDScript warnings-as-errors policy. No `project.godot` edits.

### Settings compared (verbatim)

**`godot/project.godot`** — full contents, 23 lines:

```
; Engine configuration file.
; It's best edited using the editor UI and not directly,
; but it can also be manually edited for project setup.

config_version=5

[application]

config/name="BattleBrotts"
config/description="Build. Program. Fight."
run/main_scene="res://game_main.tscn"
config/features=PackedStringArray("4.4")

[display]

window/size/viewport_width=1280
window/size/viewport_height=720
window/stretch/mode="canvas_items"
window/stretch/aspect="keep"

[rendering]

renderer/rendering_method="gl_compatibility"
```

- `grep -iE "warning|gdscript" godot/project.godot` → **no matches**.
- No `debug/gdscript/warnings/*` keys. No `warnings_as_errors` override.

**`.github/workflows/verify.yml` → `Run Godot tests` step:**

```yaml
- name: Run Godot tests
  if: needs.changes.outputs.code == 'true'
  run: |
    set -e
    bash godot/tests/quarantine_lint.sh
    godot --headless --path godot/ --script res://tests/test_runner.gd
```

CI loads the exact same `godot/project.godot` via `--path godot/`.

### Analysis

Both local Godot 4.4.1 headless and CI Godot 4.4.1 headless load the identical `project.godot` file. Because that file declares no warnings policy, GDScript warning behavior resolves to **Godot 4.4.1 engine defaults** in both environments. Settings parity is tautological — divergence is not possible without editing `project.godot`, which is out of scope for S16.3.

### Regression check: S16.1-006 `arena_renderer.gd` fix

Spot-checked the most recent green Verify run on a code-path PR (#146 / S16.2-005, run [`24675088337`](https://github.com/brott-studio/battlebrotts-v2/actions/runs/24675088337), job `Godot Unit Tests`):

- `PASS: arena_renderer.gd can be loaded` ✅
- `PASS: arena_renderer.tscn exists and loads` ✅
- No GDScript compile-time warnings in the test output.
- Observed runtime artifacts (`WARNING: ObjectDB instances leaked at exit`, `WARNING: N RIDs of type "CanvasItem" were leaked`) are **runtime-shutdown diagnostics from `--quit`**, not GDScript warnings subject to `warnings_as_errors`.
- Observed `SCRIPT ERROR` lines are **test-asserted expected errors** from negative-path test cases, not compile failures.

The S16.1-006 fix is intact; no re-surfacing.

### Verdict

✅ **Aligned.** No action required. No `project.godot` or `.gd` edits.

### Scope compliance

- `godot/project.godot` — not modified (read only).
- `.github/workflows/verify.yml` — not modified (read only; Patch owns S16.3-001 in parallel).
- No `godot/**`, `godot/data/**`, `godot/arena/**`, `godot/combat/**`, or `docs/gdd.md` changes.
- Single new file: `docs/kb/warnings-as-errors-policy-s16.3.md` (paper-trail doc note, per Ett's tightened requirement that S16.3-002 produce a PR artifact for arc-close).

**Paper trail only; policy unchanged.**

---

Closes S16.3-002.
