### PR TITLE
[S17.1-001] Design: shop scroll behavior

### DIFF
--- a/docs/design/s17.1-001-shop-scroll.md
+++ b/docs/design/s17.1-001-shop-scroll.md
@@ -1,0 +1,337 @@
+# [S17.1-001] Shop Scroll Behavior — Design
+
+**Status:** Design handoff — Gizmo → Nutts
+**Sub-sprint:** [S17.1](../../sprints/sprint-17.1.md) (Shop/Loadout/Event UX fixes)
+**Arc:** [S17 Eve Polish](../../sprints/sprint-17.md)
+**Complexity:** **S** (small, well-scoped UI fix)
+**Sacred paths (unchanged):** `godot/combat/**`, `godot/data/**`, `godot/arena/**`, `docs/gdd.md`
+
+---
+
+## 0. Scope discipline (read first)
+
+- **One file to change:** `godot/ui/shop_screen.gd`.
+- **One new test file:** `godot/tests/test_sprint17_1_shop_scroll.gd`.
+- **LoC budget:** ≤ ~40 lines added/changed in `shop_screen.gd` (excluding tests).
+- **No new nodes, no new scenes, no data changes, no signal contract changes.**
+- This is a polish fix, not a rewrite. If you find yourself touching more than the scroll-related paths in `_build_ui()` / `_toggle_expand()` / `_on_buy()`, stop and flag Riv.
+
+---
+
+## 1. Task restatement + cited complaints
+
+Fix two related Shop scroll bugs surfaced in the 2026-04-18 playtest:
+
+> "very hard to scroll in the shop - scrolls too fast"
+>
+> "whenever i click something in the shop it shoves me all the way back to the top of the screen"
+
+Backlog: [#105](https://github.com/brott-studio/battlebrotts-v2/issues/105) — *UX: Scroll behaviors respect user position* (prio:mid). Issue body: "No jump-to-top on click. Preserve user scroll position."
+
+---
+
+## 2. Root-cause analysis
+
+### 2.1 Where shop scroll is implemented
+
+`godot/ui/shop_screen.gd` — specifically `_build_ui()` (~line 233–277). The scroll structure is:
+
+```
+ShopScreen (Control)
+├── Header (title + bolts counter)
+├── ScrollContainer "ScrollArea"       ← the scroll surface
+│   └── VBoxContainer "Content" (_content_vbox)
+│       ├── Section_WEAPONS  (VBoxContainer of HBox rows + optional ExpandPanel)
+│       ├── Section_ARMOR
+│       ├── Section_CHASSIS
+│       └── Section_MODULES
+└── ContinueButton
+```
+
+The `ScrollContainer` is constructed with:
+
+```gdscript
+var scroll := ScrollContainer.new()
+scroll.horizontal_scroll_mode = ScrollContainer.SCROLL_MODE_DISABLED
+```
+
+No `scroll_vertical` value is ever read or written. No custom mouse-wheel input handler exists. Scroll behavior is therefore 100% Godot `ScrollContainer` default.
+
+### 2.2 Why clicking an item resets scroll-to-top — CONFIRMED root cause
+
+This is the primary defect. The offending control-flow:
+
+1. Player taps a card → `Button.pressed` fires → `_toggle_expand(it)` runs.
+2. `_toggle_expand()` mutates `_expanded_key` and calls `_build_ui()`.
+3. `_build_ui()` iterates all children, `remove_child()` + `queue_free()` on every one **including the `ScrollContainer`** (only `_shop_audio` is preserved).
+4. A brand-new `ScrollContainer` is constructed. Its `scroll_vertical` starts at `0`. The player is teleported to the top.
+
+Same pattern fires on `_on_buy()` (successful purchase → `_build_ui()`) and, indirectly, on any state change that triggers a rebuild.
+
+**Mechanism:** re-render / tree-rebuild wipes scroll state. Not a focus-steal, not a data issue.
+
+### 2.3 Why scroll "feels too fast"
+
+No custom multiplier — pure Godot 4 `ScrollContainer` wheel default. Two amplifying factors:
+
+- Each `InputEventMouseButton` wheel tick moves the container by the Godot default step.
+- Shop rows are relatively short (card height `CARD_H = 240` + section separation 12px + row separation 16px). A couple of wheel ticks can traverse an entire category.
+- The HCD's 2026-04-18 session was desktop (see arc brief — web/desktop target). Desktop mice often emit multiple wheel events per physical notch on high-DPI trackpads / free-spin wheels, compounding the jump.
+
+Godot does not automatically honor the host OS "lines per notch" setting. The result is a felt-too-fast scroll even though nothing in the project explicitly sets a multiplier.
+
+**Mechanism:** using the engine default verbatim, with no consideration for row height, yields scroll steps that feel aggressive relative to the shop's grid density.
+
+---
+
+## 3. Proposed design
+
+### 3.1 Preserve scroll position on rebuild (primary fix)
+
+Save `ScrollContainer.scroll_vertical` **before** the rebuild and restore it **after** the rebuild completes. Godot `ScrollContainer` is a `Container`, so scroll is clamped on layout; restoration must happen **after** the child tree has been laid out (next frame via `call_deferred`, or after a single `await get_tree().process_frame`).
+
+Concrete approach — add a field + guard around rebuilds:
+
+```gdscript
+var _saved_scroll_v: int = 0
+
+func _build_ui() -> void:
+    # Capture current scroll position BEFORE tearing down the tree.
+    var prior_scroll: ScrollContainer = get_node_or_null("ScrollArea") as ScrollContainer
+    if prior_scroll != null:
+        _saved_scroll_v = prior_scroll.scroll_vertical
+
+    # ... existing teardown + reconstruction ...
+
+    # After new ScrollContainer + content exist, restore scroll on next frame.
+    # Deferred so the VBox has performed minimum-size calc and the scroll
+    # container has clamped its max scroll value.
+    call_deferred("_restore_scroll")
+
+func _restore_scroll() -> void:
+    var scroll: ScrollContainer = get_node_or_null("ScrollArea") as ScrollContainer
+    if scroll == null:
+        return
+    scroll.scroll_vertical = _saved_scroll_v
+```
+
+This preserves scroll across:
+
+- Card tap (expand / collapse).
+- Successful purchase (`_on_buy` → `_build_ui`).
+- Any future caller that triggers a rebuild.
+
+**Why `call_deferred` + a separate method, not inline restore:** Godot's `ScrollContainer` clamps `scroll_vertical` to `[0, max_scroll]` and `max_scroll` is derived from the content VBox's minimum size, which isn't finalized until after layout. Restoring synchronously inside `_build_ui()` either no-ops (max_scroll still 0) or fights the engine. Deferred = one-frame delay = correct behavior with zero user-visible flicker at typical frame rates.
+
+**Why save before, not read from `_expanded_key` side-channel:** The saved value is authoritative regardless of what triggered the rebuild. No special-casing per caller.
+
+### 3.2 Scroll-speed tuning (secondary fix)
+
+**Recommendation: do NOT introduce a custom scroll multiplier.** Instead, tune Godot's built-in smooth scrolling via project settings:
+
+- Ensure `gui/common/swap_cancel_ok` is not relevant here (it isn't).
+- Godot 4's `ScrollContainer` has `follow_focus` and scroll-deadzone; neither addresses wheel step. The pragmatic lever is **ProjectSettings**: `gui/timers/incremental_search_max_interval_msec` is unrelated; **`input_devices/pointing/emulate_mouse_from_touch`** is unrelated.
+
+The cleanest fix without fighting the engine is to **let the default ride** for this task and accept that reducing wheel step is out of scope unless the playtest regresses. Rationale:
+
+- The felt-too-fast complaint is partially a consequence of scroll-to-top: each click reset the view, so every re-scroll happened from 0 and felt like a long journey. Once scroll position is preserved, the player scrolls much less, and "too fast" may stop being a complaint.
+- Introducing a custom wheel handler risks breaking trackpad-smooth-scroll, middle-click pan, and keyboard scroll, all of which currently work via Godot defaults.
+
+**Conservative tuning actually in scope for this PR:** enable smooth scrolling if not already default, via `scroll.scroll_deadzone = 0` (already default) and explicit settings that document intent:
+
+```gdscript
+scroll.horizontal_scroll_mode = ScrollContainer.SCROLL_MODE_DISABLED
+# S17.1-001: explicit — use engine defaults for wheel step, rely on OS
+# wheel-event cadence. No custom multiplier; match platform conventions.
+scroll.scroll_deadzone = 0
+```
+
+The comment is the design artifact — it tells future maintainers that "use engine defaults" is a deliberate choice after S17.1-001 weighed the alternatives.
+
+**If Optic/Boltz verification finds the post-fix scroll still feels too fast**, escalate to Riv for a follow-up task that introduces a project-wide smooth-scroll tuning in `project.godot` (`gui/common/scroll_speed`-equivalent or a shared scroll helper). That would be S17.1-001b or a carry-forward — not this task.
+
+### 3.3 Interaction summary (what the player experiences)
+
+| Action | Before | After |
+|---|---|---|
+| Scroll wheel tick | Godot default step | Godot default step (unchanged) |
+| Click card to expand | Jumps to top | Stays at current scroll position |
+| Click expanded card to collapse | Jumps to top | Stays at current scroll position |
+| Buy an item | Jumps to top | Stays at or near current scroll position¹ |
+| Collapse via ✕ button | Jumps to top | Stays at current scroll position |
+| Click section header (non-interactive) | n/a | n/a |
+| Click Continue button | Exits shop | Exits shop (unchanged) |
+
+¹ *After a buy, the purchased item's card changes (price → "Owned", card dims to 50% opacity). The card's vertical height is unchanged, so total content height is unchanged, so the saved scroll value remains valid. No edge-case handling needed for the buy case specifically.*
+
+---
+
+## 4. Files / symbols to change (concrete list for Nutts)
+
+| File | Change | Lines |
+|---|---|---|
+| `godot/ui/shop_screen.gd` | Add `_saved_scroll_v: int` field | +1 |
+| `godot/ui/shop_screen.gd` | `_build_ui()` prologue: read prior `ScrollArea.scroll_vertical` into `_saved_scroll_v` | +4 |
+| `godot/ui/shop_screen.gd` | `_build_ui()` epilogue: `call_deferred("_restore_scroll")` | +1 |
+| `godot/ui/shop_screen.gd` | New method `_restore_scroll()` | +5 |
+| `godot/ui/shop_screen.gd` | Comment on `ScrollArea` construction documenting "engine defaults intentional" | +2 |
+| `godot/tests/test_sprint17_1_shop_scroll.gd` | New test file (see §6) | +80–120 |
+
+**Estimated total delta in `shop_screen.gd`:** ~13 lines added, 0 removed. Well inside the hard cap (§0).
+
+**Do NOT touch:** `_build_card()`, `_build_expand_panel()`, `_on_buy()` (purchase logic), `_toggle_expand()` body (beyond what's implicit in `_build_ui()` prologue), any `GameState` call, any data or signal wiring.
+
+---
+
+## 5. Edge cases
+
+### 5.1 Scroll position exceeds new content max
+
+Possible in theory (e.g., if a future rebuild shortens the shop). Current S17.1 scope doesn't shrink the shop, but the restore path must be robust:
+
+- Godot `ScrollContainer.scroll_vertical = N` clamps to `[0, max_scroll_v]` automatically. No manual clamping needed; engine behavior is correct.
+- If `max_scroll_v == 0` at restore time (e.g., very short shop), the value resolves to `0` silently. Acceptable.
+
+### 5.2 Click while mid-scroll-bounce / mid-drag
+
+`ScrollContainer` in Godot 4 does not have scroll-bounce by default on desktop. Touch drag is possible but not in the current desktop playtest surface. If a rebuild fires during a drag:
+
+- Engine cancels in-flight pointer interactions on tree mutation of the target container.
+- Saved `scroll_vertical` at `_build_ui()` entry is the instantaneous value — close enough that the restored position feels continuous to the player.
+
+**No special-case code required.** If touch becomes a supported surface and this regresses, file a follow-up.
+
+### 5.3 Item purchased → inventory change
+
+Current shop layout is **static per shop phase** in terms of card slots: purchased items stay on the grid as "Owned" (dimmed + ✓ badge). The card's height is unchanged, so the total scrollable content height is unchanged. Saved scroll position remains valid.
+
+**No snap-to-purchased-item logic.** The design here is "preserve position" — not "jump to the item the player just bought." HCD's cited complaint is the reverse: they want the view to stay put.
+
+### 5.4 Keyboard / gamepad scroll
+
+`ScrollContainer` supports arrow-key / D-pad scroll when it has focus. This design does not change focus handling. Rebuild still wipes focus (since the button that was focused gets `queue_free`'d), which is a pre-existing issue and **out of scope for S17.1-001**. Flag for carry-forward if playtest surfaces it: *"after clicking a card with keyboard, focus returns to the top of the page instead of staying on the clicked card."* Not this PR.
+
+### 5.5 First build (no prior ScrollArea)
+
+`get_node_or_null("ScrollArea")` returns `null` on the very first `_build_ui()` call (fresh ShopScreen instance, no prior tree). `_saved_scroll_v` defaults to `0`. Restore sets `scroll_vertical = 0`, which is exactly the expected behavior on initial shop entry. Correct.
+
+### 5.6 Trick-choice modal rebuild path (Scrapyard)
+
+`_maybe_show_trick_then_build()` → awaits modal → calls `_build_ui()`. On the first entry there's no prior `ScrollArea`, so §5.5 applies (defaults to 0, correct). Subsequent rebuilds within the same shop visit inherit the saved value, correct.
+
+### 5.7 Concurrent rebuild races
+
+All rebuild triggers (`_toggle_expand`, `_on_buy`, trick modal resolution) run on the main thread and are non-reentrant. `call_deferred("_restore_scroll")` runs on the idle-frame boundary, after the tree has been mutated. No race.
+
+---
+
+## 6. Acceptance tests
+
+New test file: `godot/tests/test_sprint17_1_shop_scroll.gd`.
+
+**Test harness pattern:** follow `test_sprint13_5.gd` / `test_sprint13_8_toast.gd` — instantiate `ShopScreen`, use `setup_for_viewport(state, 1280)` to force deterministic layout, set `_skip_trick = true` if testing Scrapyard league, attach to a dummy `Node` parent.
+
+### 6.1 [AC-1] Scroll position preserved on card click (core case)
+
+```
+1. Build ShopScreen with enough inventory that ScrollContainer has scrollable content
+   (all 4 sections populated via GameState defaults already suffices).
+2. Await one frame for layout.
+3. Set scroll.scroll_vertical = 400 (mid-list).
+4. Locate a card in the middle section (e.g., an ARMOR card).
+5. Emit card.pressed (or call _toggle_expand directly with the card's item dict).
+6. Await two frames (one for _build_ui, one for _restore_scroll deferred call).
+7. Assert scroll.scroll_vertical == 400 (± a small tolerance ≤ 2px for layout
+   reflow from the inserted ExpandPanel — see note).
+```
+
+**Note on tolerance:** inserting an `ExpandPanel` below the clicked row increases total content height but the restore target is based on pre-rebuild `scroll_vertical`, which is a scroll offset from the top — that offset remains valid regardless of content-tail growth. Tolerance exists only for float/int rounding. Use `abs(after - before) <= 2`.
+
+### 6.2 [AC-2] Scroll position preserved on collapse
+
+```
+1. Build ShopScreen, expand a mid-list card (scroll position will jump if AC-1 fails,
+   so AC-1 must pass first).
+2. Manually set scroll.scroll_vertical = 400 after expand.
+3. Click the ✕ collapse button (or re-press the same card).
+4. Assert scroll.scroll_vertical == 400 (± 2).
+```
+
+### 6.3 [AC-3] Scroll position preserved across buy
+
+```
+1. Build ShopScreen with game_state.bolts high enough to afford any item.
+2. Set scroll.scroll_vertical = 300.
+3. Expand a mid-list card, press BuyButton.
+4. Await two frames.
+5. Assert scroll.scroll_vertical == 300 (± 2).
+6. Assert the item is now Owned (sanity — we haven't regressed buy logic).
+```
+
+### 6.4 [AC-4] Initial build starts at top
+
+```
+1. Build ShopScreen (first _build_ui call).
+2. Assert scroll.scroll_vertical == 0.
+```
+
+### 6.5 [AC-5] Restore clamps to max on short content (defensive)
+
+```
+1. Build ShopScreen.
+2. Manually set _saved_scroll_v = 999999 (absurd value).
+3. Call _restore_scroll() directly.
+4. Assert 0 <= scroll.scroll_vertical <= scroll.get_v_scroll_bar().max_value.
+```
+
+### 6.6 [Optional visual — Optic] Wheel scroll cadence
+
+Manual Playwright / in-engine check — not a unit test. Optic verifies by visiting the shop, scrolling with the wheel, and confirming the scroll feels appropriate relative to row height. Subjective pass/fail; documented in Optic's S17.1-001 verification doc, not in this test suite.
+
+**Per the arc brief:** S17.1 exit criteria require at least one automated test exercising "scroll to middle of Shop, click item, assert scroll position preserved." AC-1 is that test.
+
+---
+
+## 7. Coordination notes
+
+### 7.1 Adjacent tasks in S17.1
+
+- **[S17.1-002] Loadout UI overlap** — different screen (`godot/ui/loadout_*` or wherever the Loadout panel lives), no shared code with shop scroll. No coordination needed.
+- **[S17.1-003] Tooltips visible-by-default for Loadout** — Loadout screen, same story. No shared code.
+
+### 7.2 Shared scroll helper?
+
+**Decision: no shared helper in this task.** The "save-then-restore scroll_vertical around a rebuild" pattern is small enough (~7 lines + 1 field) that extracting it into a shared utility now is premature abstraction. If S17.3+ introduces another full-rebuild UI that hits the same bug (loadout detail pane, event history, etc.), file a carry-forward to extract a `ScrollStateKeeper` helper at that point.
+
+If Nutts disagrees and wants the helper now, that's a Nutts-discretion call — but keep it ≤ 20 lines and confined to `godot/ui/`.
+
+### 7.3 Depersonalization
+
+PR body and this doc use "HCD" / "Human Creative Director." Verbatim playtest quotes in §1 retain original wording ("i" lowercase, informal) per studio convention.
+
+---
+
+## 8. Complexity + effort estimate
+
+**Complexity: S (Small).**
+
+**Rationale:**
+- Single file change (`shop_screen.gd`), single root cause (rebuild wipes scroll state), well-understood fix (save/restore around rebuild).
+- One new test file with 4 required ACs + 1 defensive AC.
+- No data / signal / scene changes. Zero risk to combat, balance, or arena surfaces.
+- Estimated Nutts spawn budget: **1 spawn**, ≤ 30 min wall-clock at typical cadence. If Nutts exceeds 45 min or hits the LoC cap, escalate to Riv.
+
+**Risk tier: LOW.** The only non-obvious part is the `call_deferred` timing for restore. Pattern is standard Godot idiom; test 6.1 catches any mistake immediately.
+
+---
+
+## 9. Open questions
+
+None blocking. Two flagged for possible follow-up (NOT in this PR):
+
+- **🟢 Scroll wheel step tuning.** If the "too fast" complaint persists after scroll-preservation lands, file a follow-up. Section 3.2 hypothesizes that fixing scroll-reset will resolve most of the felt-fastness. Optic verification should explicitly check.
+- **🟢 Keyboard/gamepad focus preservation across rebuild.** Pre-existing issue, out of scope. Flag for carry-forward only if playtest surfaces it.
+
+---
+
+**Design authored by Gizmo, 2026-04-20. Handoff to Nutts via Riv.**


### PR DESCRIPTION
## Summary

Design doc for **[S17.1-001]** — shop scroll behavior fix. First task of sub-sprint S17.1 (Shop/Loadout/Event UX fixes) under the S17 Eve Polish Arc.

## Root cause (one-liner)

`_build_ui()` tears down and reconstructs the `ScrollContainer` on every card click / buy, which resets `scroll_vertical` to `0`. The "scrolls too fast" complaint is amplified by this — every re-scroll starts from the top, making the traversal feel long.

## Fix shape

- **Primary:** save `scroll_vertical` before rebuild, restore via `call_deferred` after layout finishes in a new `_restore_scroll()` method. ~13 LoC in `godot/ui/shop_screen.gd`.
- **Secondary (wheel speed):** do NOT introduce a custom wheel multiplier in this task. Hypothesis: fixing the scroll-reset will dissolve most of the felt-fastness. If Optic verification finds it still feels fast post-fix, file a follow-up. Rationale in §3.2.

## Scope gate

- No changes to `godot/combat/**`, `godot/data/**`, `godot/arena/**`, `docs/gdd.md`.
- One file changed by Nutts (`godot/ui/shop_screen.gd`) + one new test file (`godot/tests/test_sprint17_1_shop_scroll.gd`).
- LoC cap: ≤ ~40 lines in `shop_screen.gd` (design allows ~13; cap gives headroom).

## Test coverage (§6)

Five unit tests in the new test file — core AC ("scroll to middle, click item, scroll preserved") plus collapse, buy, initial-build, and defensive max-clamp. Matches arc-brief exit criterion.

## Complexity estimate for Nutts

**S** (small). Single file, single root cause, well-understood fix. Estimated 1 spawn, ≤ 30 min wall-clock. Escalate to Riv if it blows past 45 min.

## Coordination

- No overlap with S17.1-002 (Loadout) or S17.1-003 (tooltips) — different surfaces, different files.
- Explicit decision against a shared `ScrollStateKeeper` helper at this stage (premature abstraction; revisit in S17.3+ if pattern recurs).

## Carry-forward candidates (NOT in this PR)

- 🟢 Wheel-step tuning if "too fast" persists post-fix.
- 🟢 Keyboard/gamepad focus preservation across rebuild (pre-existing issue).

## Depersonalization

Doc + PR body use "HCD" / "Human Creative Director." Playtest quotes retained verbatim per convention.

---

Design-only doc. No code changes. Admin-merge after CI green is acceptable per S16 precedent for design-only PRs.
