### PR TITLE
[S17.1-002] Design: Loadout UI overlap fix

### DIFF
--- a/docs/design/s17.1-002-loadout-overlap.md
+++ b/docs/design/s17.1-002-loadout-overlap.md
@@ -1,0 +1,476 @@
+# [S17.1-002] Loadout UI Overlap — Design
+
+**Status:** Design handoff — Gizmo → Nutts
+**Sub-sprint:** [S17.1](../../sprints/sprint-17.1.md) (Shop/Loadout/Event UX fixes)
+**Arc:** [S17 Eve Polish](../../sprints/sprint-17.md)
+**Complexity:** **S** (small, layout-only fix)
+**Sacred paths (unchanged):** `godot/combat/**`, `godot/data/**`, `godot/arena/**`, `docs/gdd.md`
+
+---
+
+## 0. Scope discipline (read first)
+
+- **One file to change:** `godot/ui/loadout_screen.gd`.
+- **One new test file:** `godot/tests/test_sprint17_1_loadout_overlap.gd`.
+- **LoC budget:** ≤ ~80 lines added/changed in `loadout_screen.gd` (excluding tests). Larger than S17.1-001's budget because `_build_ui()` currently uses absolute `position` coordinates throughout and the fix wraps the scrollable section in a container.
+- **No new nodes beyond one `ScrollContainer` + one `VBoxContainer` inside it.** No new scenes, no data changes, no signal contract changes (`continue_pressed`, `back_pressed` unchanged).
+- This is a layout/anchoring fix, not a rewrite of the Loadout screen.
+
+---
+
+## 1. Task restatement + cited complaint
+
+Fix the Loadout UI overlap surfaced in the 2026-04-18 playtest:
+
+> "in loadout when i have a lot of stuff they cover the shop button"
+
+Backlog: [#104](https://github.com/brott-studio/battlebrotts-v2/issues/104) — *UX: No UI overlap at full inventory / loadout* (prio:high). Issue body: "UI elements overlap when inventory/loadout is full, masking critical buttons."
+
+The "shop button" the HCD refers to is the `← Shop` back button in `loadout_screen.gd` (`back_btn`, pinned at `Vector2(20, 650)`). The `Continue →` button at `Vector2(1050, 650)` is in the same row and is masked by the same mechanism; fixing one fixes both.
+
+---
+
+## 2. Root-cause analysis
+
+### 2.1 Where the Loadout UI is built
+
+`godot/ui/loadout_screen.gd` — `_build_ui()` (lines ~34–147). The screen is a plain `Control` with children added via `add_child()` and positioned with absolute `position: Vector2` coordinates. There is **no `ScrollContainer`, no `VBoxContainer`, no anchoring** — every child's position is set manually against viewport pixels.
+
+Layout today (top → bottom):
+
+```
+LoadoutScreen (Control, viewport = 1280×720)
+├── Header Label            @ (20, 10)      "🔧 LOADOUT — <chassis>"
+├── BotPreview              @ (620, 10)     96×96
+├── Weight Label            @ (20, 50)
+├── Weight ProgressBar      @ (20, 72)      400×24
+├── [absolute flow begins at y=120]
+│   ├── "CHASSIS" label     @ (20, y)       ─┐
+│   ├── chassis Button[]    @ (40, y)        │  every row consumes
+│   ├── "WEAPONS" label     @ (20, y)        │  ~32–36 px of y
+│   ├── empty slot panels[] @ (40, y)        │  and items stack
+│   ├── weapon cards[]      @ (40, y)        │  from y=120 to
+│   ├── "ARMOR" label       @ (20, y)        │  whatever y ends at
+│   ├── armor cards[]       @ (40, y)        │  (potentially > 720)
+│   ├── "MODULES" label     @ (20, y)        │
+│   ├── module cards[]      @ (40, y)        │
+│   └── error labels[]      @ (20, y)       ─┘
+├── back_btn "← Shop"       @ (20, 650)     150×50   ← FIXED POSITION
+└── _equip_button "Continue"@ (1050, 650)   200×50   ← FIXED POSITION
+```
+
+Key fact: `back_btn` and `_equip_button` are added to the `Control` **after** the scroll region, at fixed Y=650. Godot's default child z-order is additive — later children render on top — so at first glance you'd think the buttons would always be visible. **They are visible, but they are not reachable.** See §2.3.
+
+### 2.2 Why "shop button gets covered" at high inventory
+
+With `header/bars` ending at y≈96 and content starting at y=120, every chassis/empty-slot/weapon/armor/module row adds ~32–36 px. A realistic max inventory stress case:
+
+- Chassis: up to 3 owned = 3 × 32 ≈ 96 px
+- Weapons: up to weapon_slots (6 for heavy chassis) empty indicators + 10–20 owned weapons = 16 × 36 ≈ 576 px
+- Armor: 1 "None" + up to ~8 owned armors = 9 × 36 ≈ 324 px
+- Modules: similar = 300–500 px
+
+Totals can easily push the running `y` past **1500 px**, i.e. ~800 px past the viewport bottom (720). Everything between y≈650 and y≈1500 is off-screen or colliding with the buttons.
+
+
+### 2.3 Why it's not "just a z-order issue"
+
+The buttons are added **last** to the `Control`, so in Godot's default render order they draw **on top** of earlier children. Visually, the back/continue buttons are in front of the item cards — so the complaint "they cover the shop button" is in part a mis-attribution (the cards are *behind* the buttons visually).
+
+But the buttons are still effectively covered because:
+
+1. **Input priority in Godot 4 `Control` goes to the *front-most* sibling at the pointer position, BUT item-card `PanelContainer` instances contain a `Button` child (`get_node("Button")`) that does claim input at that pixel when it sits above the back/continue button in list-add order for that specific pixel.** In practice, Godot takes the *top-most* `Control` under the cursor that has `mouse_filter = STOP` (default for `Button`). When item-card buttons overflow past y=650, they land on top of `back_btn` in tree order and steal the click — because `Button` has `MOUSE_FILTER_STOP`, and the item-card Button's hit-rect extends past y=650 while the `back_btn` also has a hit-rect at the same coordinates.
+
+2. **Even visually**, oversized content makes the bottom region a forest of item labels bleeding *around* the buttons (the buttons are 150×50 and 200×50, so there's only 1050−20−150 = 880 px of empty horizontal space between them at y=650, and the item cards render at x=40 width=500, overlapping `back_btn`'s rect entirely).
+
+3. **Worst of all — there is no scrollbar.** The player has no affordance to scroll down to see what's past y=720. They see a crowded bottom, can't click "Shop," and have no path forward.
+
+So "covers the shop button" is a compound issue: visual crowding + input stealing by overflowing item-card buttons + zero scroll affordance. All three trace to one root cause: **no scroll container, everything absolute-positioned.**
+
+### 2.4 Why the shop (S17.1-001) doesn't have this problem
+
+`shop_screen.gd` wraps its content in a `ScrollContainer` + `VBoxContainer`, and places its "Continue" button as a *sibling of* the `ScrollContainer` (not inside it). That architecture is what Loadout needs. S17.1-001's design doc formalized scroll-position preservation on top of that structure; S17.1-002 is the prerequisite step of introducing the structure itself to Loadout.
+
+---
+
+## 3. Proposed design
+
+### 3.1 Target architecture (post-fix)
+
+```
+LoadoutScreen (Control, anchors=FULL_RECT)
+├── Header region (absolute, unchanged)
+│   ├── Header Label          @ (20, 10)
+│   ├── BotPreview            @ (620, 10)
+│   ├── Weight Label          @ (20, 50)
+│   └── Weight ProgressBar    @ (20, 72)
+├── ScrollContainer "ScrollArea"
+│   ├── anchor: top=left=0, right=1 (full viewport width minus padding)
+│   ├── position.y = 120       (unchanged — item region starts here)
+│   ├── size.y    = 520        (720 total − 120 top − 80 footer reserve)
+│   ├── horizontal_scroll_mode = SCROLL_MODE_DISABLED
+│   └── VBoxContainer "Content" (_content_vbox)
+│       ├── add_theme_constant_override("separation", 4)
+│       ├── (sections built as before, but appended as children of
+│       │   _content_vbox instead of placed at absolute y)
+│       ├── CHASSIS label + chassis buttons
+│       ├── WEAPONS label + empty slot panels + weapon cards
+│       ├── ARMOR label + armor cards
+│       ├── MODULES label + empty slot panels + module cards
+│       └── error labels (if any)
+└── Footer region (absolute, always on top)
+    ├── back_btn "← Shop"        @ (20, 650)     150×50
+    └── _equip_button "Continue" @ (1050, 650)   200×50
+```
+
+**Key invariant:** `back_btn` and `_equip_button` are **siblings of** `ScrollArea`, **not children of it**. The `ScrollArea` is bounded to `size.y = 520` so its content can never overlap the footer row. No matter how many items the player owns, the footer row stays visible, clickable, and at its original screen coordinates.
+
+### 3.2 Concrete changes to `_build_ui()`
+
+**Replace** the chunk of `_build_ui()` that currently does:
+
+```gdscript
+var y := 120
+# ... chassis/weapons/armor/modules/errors all add_child(...) at Vector2(40, y); y += 36
+# ...
+# Navigation (back_btn at 650, _equip_button at 650)
+```
+
+**With:**
+
+```gdscript
+# Scroll region for item lists (S17.1-002)
+var scroll := ScrollContainer.new()
+scroll.name = "ScrollArea"
+scroll.position = Vector2(0, 120)
+scroll.size = Vector2(1280, 520)     # viewport_width × (720 − 120 header − 80 footer)
+scroll.horizontal_scroll_mode = ScrollContainer.SCROLL_MODE_DISABLED
+add_child(scroll)
+
+var content := VBoxContainer.new()
+content.name = "Content"
+content.add_theme_constant_override("separation", 4)
+# Let the VBox fill the scroll container horizontally so its minimum_size
+# drives the scrollbar; vertical min_size grows with content.
+content.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+scroll.add_child(content)
+
+# -- Build sections into `content` instead of into `self` at absolute y --
+_build_chassis_section(content)
+_build_weapons_section(content, ch, validation)
+_build_armor_section(content)
+_build_modules_section(content, ch, validation)
+_build_error_section(content, validation)
+
+# Footer — UNCHANGED absolute positions so screen coordinates remain stable
+var back_btn := Button.new()
+back_btn.text = "← Shop"
+back_btn.position = Vector2(20, 650)
+back_btn.size = Vector2(150, 50)
+back_btn.pressed.connect(func(): back_pressed.emit())
+add_child(back_btn)
+
+_equip_button = Button.new()
+_equip_button.text = "Continue →"
+_equip_button.position = Vector2(1050, 650)
+_equip_button.size = Vector2(200, 50)
+_equip_button.disabled = not validation["valid"]
+_equip_button.pressed.connect(func(): continue_pressed.emit())
+add_child(_equip_button)
+```
+
+
+**Section builders** factor the existing inline loops into helpers that append to the passed `VBoxContainer`. They preserve the current card construction (`_create_item_card`, `_create_empty_slot_indicator`) 1:1 — only the parenting changes.
+
+Example for `_build_chassis_section`:
+
+```gdscript
+func _build_chassis_section(parent: VBoxContainer) -> void:
+    var lbl := _make_section_label("CHASSIS (select one):")
+    parent.add_child(lbl)
+    for ct in game_state.owned_chassis:
+        var cd := ChassisData.get_chassis(ct)
+        var selected := ct == game_state.equipped_chassis
+        var btn := Button.new()
+        btn.text = ("▶ " if selected else "  ") + cd["name"] + " (HP:%d Spd:%d W:%d/%d)" % [cd["hp"], int(cd["speed"]), cd["weapon_slots"], cd["module_slots"]]
+        btn.custom_minimum_size = Vector2(500, 30)
+        btn.pressed.connect(_select_chassis.bind(ct))
+        parent.add_child(btn)
+```
+
+(and similarly for weapons, armor, modules, errors — see §4).
+
+`_make_section_label(text)` is a tiny helper that replaces the old `_add_label` return-int-y pattern: it creates a label with the current style and returns the label node. The running-`y` plumbing goes away entirely — the `VBoxContainer` handles flow.
+
+### 3.3 Why this specific shape (not alternatives)
+
+**Considered alternatives:**
+
+| Option | Verdict | Why |
+|---|---|---|
+| Anchor back/continue to bottom-right / bottom-left, leave item flow as-is | ❌ | Doesn't fix the overflow — items still render past y=720 off-screen with no scrollbar. Player still can't see / reach overflow items. |
+| Raise the footer Y (e.g. shrink item region and push buttons to y=680) | ❌ | Cosmetic — pushes the overlap threshold up by 30 px, doesn't solve it. |
+| Use a `MarginContainer` + full-screen `VBoxContainer` with the footer as the last child | ❌ | Breaks existing fixed-position assumptions (header, BotPreview at absolute coords) and has higher refactor cost than this design's budget. |
+| Replace the whole screen with a `.tscn` scene | ❌ | Biggest refactor; out of scope for a polish fix. S17.1's scope gate explicitly says "layout/z-order/anchoring fix, not a rewrite." |
+| **ScrollContainer for the item region only, footer as sibling siblings of the scroll container** | ✅ | Minimum-viable Godot-idiomatic fix. Preserves every other layout decision. Matches `shop_screen.gd`'s precedent. |
+
+**Chosen option wins on:** smallest diff, matches shop precedent, leaves headroom for S17.1-003 tooltips without re-layout (see §7).
+
+### 3.4 Interaction summary (what the player experiences)
+
+| Scenario | Before | After |
+|---|---|---|
+| Inventory size 0 (fresh start) | Works fine | Works fine (scroll region has ~0 scroll range) |
+| Inventory size 5 | Works fine | Works fine (fits without scrolling) |
+| Inventory size 20 | Bottom items overflow, Shop button obscured | Item region scrolls, Shop button always clickable |
+| Inventory size 50 | Most items off-screen, entire footer obscured | Item region scrolls, footer unchanged |
+| Click item button near overlap region | Item button may steal click from footer | Footer isolated; no click-steal possible |
+| Equip/unequip triggers `_build_ui()` rebuild | Scroll N/A (no scroll) | Scroll resets to 0 — see §7.2 for coordination with S17.1-001 pattern |
+| Window resize (if supported) | Footer at absolute 650 regardless of window | Same — footer stays at 650 (see §5.3) |
+
+
+---
+
+## 4. Files / symbols to change (concrete list for Nutts)
+
+| File | Change | Approx LoC |
+|---|---|---|
+| `godot/ui/loadout_screen.gd` | In `_build_ui()`: remove the `var y := 120` running-y block that builds chassis/weapons/armor/modules/errors sections. Replace with `ScrollContainer` + `VBoxContainer` setup + calls to new section helpers. | −55 / +30 |
+| `godot/ui/loadout_screen.gd` | New private helpers: `_build_chassis_section(parent)`, `_build_weapons_section(parent, ch, validation)`, `_build_armor_section(parent)`, `_build_modules_section(parent, ch, validation)`, `_build_error_section(parent, validation)`. Each appends children to `parent: VBoxContainer`. Body of each helper is a copy-paste-adapt of the relevant chunk of the current `_build_ui()` — same `_create_item_card` / `_create_empty_slot_indicator` / `Button.new()` calls, but `add_child` targets `parent` instead of `self`, and fixed widths replace `position = Vector2(40, y)` layout. | +60 |
+| `godot/ui/loadout_screen.gd` | New helper `_make_section_label(text: String, color: Color = Color.WHITE) -> Label`. Replaces the `_add_label(text, y, color) -> int` pattern (the old one can be deleted — it's only called from `_build_ui()`). | +8 / −10 |
+| `godot/ui/loadout_screen.gd` | Footer (`back_btn`, `_equip_button`): keep absolute `Vector2(20, 650)` / `Vector2(1050, 650)` untouched. Ensure they are added to `self` AFTER `add_child(scroll)` so they render on top. | 0 (reorder only) |
+| `godot/tests/test_sprint17_1_loadout_overlap.gd` | New test file (see §6). | +120–160 |
+
+**Do NOT touch:**
+
+- `_create_item_card()`, `_create_empty_slot_indicator()` — rendering logic unchanged.
+- `_build_weight_bar()`, `_get_weight_color()`, `_has_weight_error()` — unchanged.
+- `_select_chassis`, `_toggle_weapon`, `_select_armor`, `_toggle_module` — signal/handler logic unchanged.
+- `_trigger_loadout_anims` and bot-preview integration — unchanged.
+- `game_state`, `GameState`, any data — sacred (`godot/data/**`).
+- Signal contract: `continue_pressed`, `back_pressed` — unchanged.
+
+**Estimated total delta in `loadout_screen.gd`:** ~75 net lines added, ~65 removed. Within the §0 cap. If Nutts trends past +90 lines, stop and flag Riv.
+
+---
+
+## 5. Edge cases
+
+### 5.1 Empty inventory (very few items)
+
+`VBoxContainer` inside `ScrollContainer` with content shorter than the scroll region: Godot behavior is correct — no scrollbar appears, content renders at the top of the scroll region. No awkward gap at the bottom of the scroll region because the `ScrollContainer` fills its 520-px rect but its *content* (the VBox) is short and left-aligned to the top. The space between the bottom of the content and the footer is the same empty vertical space that exists today at low inventory — unchanged visually.
+
+### 5.2 Max inventory stress (the target case)
+
+Per §2.2, realistic worst case produces ~1500 px of content. With the scroll region sized to 520 px, scroll range ≈ 1500 − 520 = 980 px. The vertical scrollbar handles this natively. Footer is fully reachable at all times.
+
+**Concrete stress fixture for tests:** `game_state` with 3 chassis owned, 15 weapons owned (across weapon_slots of the heaviest chassis for maximum empty-slot indicator count), 8 armors, 10 modules, and a chassis selection that produces 1–2 validation errors. This is the fixture for AC-2 in §6.
+
+### 5.3 Resize / aspect ratio
+
+`project.godot` sets `window/stretch/mode = "canvas_items"` and `window/stretch/aspect = "keep"` with viewport 1280×720. "Keep" aspect stretch means the viewport size the UI sees is constant (1280×720) regardless of the host window — letterboxing handles off-ratio windows. Therefore:
+
+- Absolute coordinates (footer at 650, scroll region sized to 520) remain correct at any window size.
+- No anchor-to-bottom machinery is needed for the current target surface.
+- **Future-proofing note:** if battlebrotts-v2 ever ships with dynamic viewport sizing or a mobile surface, the footer should switch to `anchor_bottom = 1.0` + negative offsets, and the scroll region's `size.y` should become `anchor_bottom = 1.0, offset_bottom = -80`. That's a future-arc change; not this task. Documented here so the carry-forward is explicit.
+
+### 5.4 Mobile / touch
+
+Not a current target surface (per `project.godot` — desktop-only). Godot 4 `ScrollContainer` supports touch-drag by default if/when touch input arrives. No extra handling needed now. If mobile becomes a target in a later arc, the only concern is that the footer buttons (150×50, 200×50) meet minimum touch-target guidelines (~48×48) — they already do.
+
+### 5.5 Focus navigation (keyboard / gamepad)
+
+`ScrollContainer` has `follow_focus = false` by default in Godot 4. For this fix we should set `scroll.follow_focus = true` so that keyboard/gamepad navigation through the item buttons auto-scrolls the region to keep the focused item visible. This is a one-line add. Without it, tab-navigation to an off-screen item would focus the item but not scroll to it, which is a worse-than-today experience for keyboard users.
+
+**Add to §3.2 setup:**
+
+```gdscript
+scroll.follow_focus = true
+```
+
+Footer buttons (`back_btn`, `_equip_button`) are outside the scroll container, so tab-order is: [items inside scroll] → [back_btn] → [_equip_button]. Godot's default focus-order by tree position handles this correctly.
+
+### 5.6 Rebuild-on-equip wipes scroll position
+
+Every `_toggle_weapon` / `_select_armor` / `_toggle_module` calls `_build_ui()`, which tears down the whole tree and rebuilds. Scroll position resets to 0 after every equip action. This is annoying but **not in scope for this PR** — this task is the overlap fix, not scroll preservation.
+
+S17.1-001 landed the save-before-rebuild / `call_deferred("_restore_scroll")` pattern for the shop. That pattern is directly portable to Loadout and should be filed as a carry-forward if the playtest regressions hit it. See §7.2 for explicit coordination note.
+
+
+### 5.7 First build timing
+
+`_build_ui()` is called from `setup(state)`. The `ScrollContainer` + `VBoxContainer` are constructed, children added, then returned. Godot computes minimum sizes on the next layout pass; the scroll max-value is correct by the first frame the screen is visible. No deferred restore is needed here (unlike S17.1-001) because there's no prior scroll state to restore — scroll always starts at 0.
+
+### 5.8 Overweight flash + `_process` behavior
+
+`_process(delta)` pulses `_weight_bar.modulate.a` when `_is_overweight` is true. `_weight_bar` is created in `_build_weight_bar()` and added as a child of `self` (outside the scroll container). Unchanged by this task. The flash still works.
+
+---
+
+## 6. Acceptance tests
+
+New test file: `godot/tests/test_sprint17_1_loadout_overlap.gd`. Pattern follows `test_sprint12_2.gd` (same-surface tests): `extends SceneTree`, `_init()` runs all tests, `screen := LoadoutScreen.new()` for unit-style tests, `screen.setup(state)` to trigger `_build_ui()`.
+
+### 6.1 [AC-1] ScrollContainer exists and is sized correctly
+
+```
+1. Build a LoadoutScreen with a GameState that has default minimal inventory.
+2. Call screen.setup(state).
+3. Assert screen.get_node_or_null("ScrollArea") != null.
+4. Assert ScrollArea is a ScrollContainer.
+5. Assert ScrollArea.size.y == 520 (or whatever §3.1 specifies).
+6. Assert ScrollArea.horizontal_scroll_mode == ScrollContainer.SCROLL_MODE_DISABLED.
+7. Assert ScrollArea.follow_focus == true.
+```
+
+### 6.2 [AC-2] Shop button reachable at inventory_size = 0, 5, 20, 50
+
+Parameterized test (or four near-duplicate test functions) with fixtures:
+
+```
+for inv_size in [0, 5, 20, 50]:
+    state = build_fixture_state(inv_size)
+    screen = LoadoutScreen.new()
+    screen.setup(state)
+    await_one_frame()
+
+    back_btn = screen.get_children().filter(lambda c: c is Button and c.text.begins_with("← Shop"))[0]
+
+    # Assertion 1: back_btn is present
+    assert back_btn != null
+
+    # Assertion 2: back_btn position is unchanged from baseline
+    assert back_btn.position == Vector2(20, 650)
+
+    # Assertion 3: back_btn's global rect does NOT overlap any descendant
+    #              of ScrollArea at the button's screen coordinates
+    scroll = screen.get_node("ScrollArea")
+    for child_of_scroll in scroll.get_node("Content").get_children():
+        assert not _global_rects_overlap(back_btn, child_of_scroll)
+```
+
+**Helper `_global_rects_overlap(a, b)`:** computes `Rect2(a.global_position, a.size)` vs `Rect2(b.global_position, b.size)` and returns `a_rect.intersects(b_rect)`.
+
+**`build_fixture_state(inv_size)`:** constructs a `GameState` with `owned_weapons.size() + owned_armor.size() + owned_modules.size() == inv_size`. Exact distribution doesn't matter for the overlap test; what matters is the total row count. Inventory size 50 pushes content height > 1500 px and is the canonical stress case.
+
+### 6.3 [AC-3] Continue button reachable at same inventory sizes
+
+Same as AC-2 but targets `_equip_button` (position `Vector2(1050, 650)`).
+
+### 6.4 [AC-4] Scroll range grows with inventory
+
+```
+1. Build screen with inv_size = 50.
+2. Await layout.
+3. scroll = screen.get_node("ScrollArea")
+4. v_scroll_bar = scroll.get_v_scroll_bar()
+5. Assert v_scroll_bar.max_value > 0   (i.e. scroll is actually needed)
+6. Assert v_scroll_bar.max_value >= 500 (sanity bound — stress case must produce
+                                         at least ~500 px of scroll range)
+```
+
+### 6.5 [AC-5] Signal contract preserved
+
+```
+1. Build screen with default state.
+2. Connect a test listener to back_pressed and continue_pressed.
+3. Simulate emit on back_btn.pressed → assert back_pressed listener fired.
+4. Simulate emit on _equip_button.pressed → assert continue_pressed listener fired.
+```
+
+(Regression gate — signal contract must not change.)
+
+### 6.6 [AC-6] Empty-state layout unchanged (no awkward gap)
+
+```
+1. Build screen with inv_size = 0 (bare chassis list only).
+2. Assert scroll.get_v_scroll_bar().max_value == 0   (no scrollbar needed).
+3. Assert Content vbox first child is the CHASSIS label.
+4. Assert Content vbox total min-height < ScrollArea.size.y
+   (content fits without scroll).
+```
+
+### 6.7 [AC-7 — Optic manual / visual] Playwright max-inventory screenshot
+
+Per arc brief: Optic takes a Playwright-style visual snapshot of the Loadout screen at max inventory and confirms:
+
+- `← Shop` button visible and clickable (non-occluded by any other Control).
+- `Continue →` button visible and clickable.
+- Vertical scrollbar visible on the right edge of the scroll region.
+- Scrolling the region does not move the footer.
+
+This is subjective pass/fail and lives in Optic's S17.1-002 verification doc, not the unit test suite.
+
+---
+
+## 7. Coordination notes
+
+### 7.1 S17.1-003 (visible-by-default tooltips) interaction
+
+**This is the single most important coordination point in S17.1.** Ett's plan flagged the risk that S17.1-003 will add visible-by-default tooltip text beneath each item card, which increases per-item vertical space. Without the fix in this task, that would guarantee overlap at even smaller inventory sizes. With this fix in place, S17.1-003 can add visible tooltip content freely — **the scroll region absorbs any amount of added height** without pushing the footer, without introducing new overlap, and without requiring re-layout work.
+
+**What S17.1-003 should and should not assume from this design:**
+
+- ✅ **Safe assumption:** "Items are children of `ScrollArea/Content: VBoxContainer`. I can make per-item rows taller (tooltip line, extra metadata, a stacked sub-label) without any footer impact."
+- ✅ **Safe assumption:** "If I need to show a hover-popup that extends *outside* the scroll region (e.g. a full stat readout overlay), I can add it as a sibling of `ScrollArea` in `LoadoutScreen`. Z-order will be correct as long as the popup is added last or uses `show_on_top()`."
+- ❌ **Do not assume:** "The footer has room above it to expand." It doesn't — footer is pinned at y=650. If S17.1-003 wants a secondary info strip (e.g. "hover any item for details"), put it *inside* the scroll region at the top of the VBox, not between the scroll region and the footer.
+- ❌ **Do not bypass the scroll region.** If S17.1-003 adds item info, that info lives *in the item card PanelContainer* (same pattern as today). It does not live in a separate panel outside the scroll region.
+
+**Architectural headroom this design leaves for S17.1-003:**
+
+1. Per-item row height can grow from 32 px to ~60–80 px (name + one-line description + stat summary) with zero layout impact — scroll absorbs it.
+2. Tooltip popovers can anchor to an item card's global_position and render as a sibling of `ScrollArea` (above the footer in z-order) via `add_child` + `show_on_top()`.
+3. If S17.1-003 needs a persistent "detail panel" alongside the scroll region (e.g. right-hand 300 px panel), the scroll region's `size.x` becomes 980 instead of 1280. Trivial adjustment. The footer stays where it is.
+
+**What S17.1-003's design should explicitly call out when it lands:** which of the three options above (in-card, floating popover, sibling detail panel) it chose, and confirm it did not move the footer or change the scroll region's height.
+
+### 7.2 S17.1-001 (scroll position preservation) reuse
+
+S17.1-001 landed the save-before / `call_deferred("_restore_scroll")` pattern for `shop_screen.gd`. The Loadout screen has the same "rebuild on every equip" behavior and would benefit from the same pattern — but it's explicitly **out of scope for S17.1-002**.
+
+If Optic verification of S17.1-002 finds that "equip item resets scroll to top" is a felt regression, file a carry-forward:
+
+- Title: "Loadout: preserve scroll position across `_build_ui()` rebuilds"
+- Scope: ~10 LoC in `loadout_screen.gd`, direct port of the S17.1-001 pattern
+- Priority: depends on playtest response; could be S17.1-007 or a later sub-sprint
+
+Not in this PR. Per scope-gate discipline: one task at a time.
+
+### 7.3 Cleaner architectural solution considered
+
+**Shared scroll+footer helper.** Both shop (S17.1-001) and loadout (S17.1-002) now share the "scroll region above a fixed footer" pattern. A shared `ScrollWithFixedFooter` helper Control could DRY the two screens.
+
+**Decision: not now.** The pattern is three lines of actual shared code (create ScrollContainer, set horizontal_scroll_mode, set follow_focus). Extracting a helper is premature abstraction at N=2. Reconsider at N=3 (e.g. if a future BrottBrain screen hits the same pattern in S17.3). Same disposition as S17.1-001's §7.2 call.
+
+### 7.4 Depersonalization
+
+PR body and this doc use "HCD" / "Human Creative Director." The verbatim playtest quote in §1 ("in loadout when i have a lot of stuff they cover the shop button") retains original wording per studio convention.
+
+---
+
+## 8. Complexity + effort estimate
+
+**Complexity: S (Small).**
+
+**Rationale:**
+- Single file change (`loadout_screen.gd`), single root cause (no scroll container + absolute-positioned footer), well-understood fix (wrap scrollable section, keep footer as sibling).
+- The new helpers (`_build_*_section`) are near-mechanical extractions of code that already exists in `_build_ui()`. No new logic.
+- One new test file with 6 required unit ACs + 1 manual Optic AC.
+- Zero risk to combat, balance, arena, or data surfaces.
+- Zero signal-contract changes.
+- Estimated Nutts spawn budget: **1 spawn**, ≤ 45 min wall-clock. Slightly longer than S17.1-001 because of the section-helper extraction. If Nutts exceeds 60 min or the LoC delta trends past +90 lines, escalate to Riv.
+
+**Risk tier: LOW.** The only non-obvious bit is ensuring section helpers produce the same visual as the current flow (same card widths, same spacing). Tests in §6 lock down the structural invariants; Optic visual diff catches cosmetic regressions.
+
+---
+
+## 9. Open questions
+
+None blocking. Two flagged for possible follow-up (NOT in this PR):
+
+- **🟢 Scroll preservation on rebuild for Loadout.** If playtest complains that equipping an item resets scroll, file a carry-forward that ports the S17.1-001 pattern. See §7.2.
+- **🟢 Shared scroll+footer helper.** Defer until N=3 usage sites. See §7.3.
+
+---
+
+**Design authored by Gizmo, 2026-04-20. Handoff to Nutts via Riv.**


### PR DESCRIPTION
## [S17.1-002] Design: Loadout UI overlap fix

**Sub-sprint:** [S17.1](../blob/main/sprints/sprint-17.1.md) — Shop/Loadout/Event UX fixes
**Arc:** [S17 Eve Polish](../blob/main/sprints/sprint-17.md)
**Role:** Gizmo (design only — no code)
**Complexity:** S

### Playtest complaint (cited verbatim)

> "in loadout when i have a lot of stuff they cover the shop button"

Backlog: #104.

### Root cause (one-liner)

`godot/ui/loadout_screen.gd` uses absolute positioning throughout with **no `ScrollContainer`**. Item rows stack from y=120 with ~36 px/row and can exceed 1500 px of content height, overflowing far past the 720-px viewport. The `← Shop` / `Continue →` buttons are pinned at y=650 with no protection from overflow; at high inventory they are visually crowded and, worse, overflowing item-card `Button`s steal their clicks.

### Proposed fix (one-liner)

Wrap the item region (chassis/weapons/armor/modules/errors) in a bounded `ScrollContainer` sized 1280×520 at y=120. Keep `back_btn` and `_equip_button` as **siblings of** the `ScrollContainer` at their current absolute positions (y=650). The footer becomes unreachable-proof regardless of inventory size. Matches the architecture already in `shop_screen.gd`.

### Scope

- **One file changes:** `godot/ui/loadout_screen.gd` (~75 LoC net)
- **One new test file:** `godot/tests/test_sprint17_1_loadout_overlap.gd`
- **No changes to:** `godot/combat/**`, `godot/data/**`, `godot/arena/**`, `docs/gdd.md`, any signal contract, any item render logic (`_create_item_card`, `_create_empty_slot_indicator`).

### Acceptance tests

6 unit ACs in `test_sprint17_1_loadout_overlap.gd`: ScrollContainer structural sanity, shop+continue button reachability at inventory_size = 0 / 5 / 20 / 50, scroll range sanity, signal contract preserved, empty-state layout unchanged. Plus 1 manual Optic visual AC for max-inventory screenshot.

### S17.1-003 (tooltips) coordination — explicit

This design **enables** S17.1-003. Visible-by-default tooltip content can grow per-item row height from 32 px to ~60–80 px with zero footer impact — the scroll region absorbs any added height. Doc §7.1 spells out what S17.1-003 can and cannot assume:
- ✅ Grow item rows freely inside the scroll region
- ✅ Float popovers as siblings of `ScrollArea` using `show_on_top()`
- ❌ Do NOT use the space between scroll region and footer (there is none — footer is pinned)
- ❌ Do NOT move or resize the footer

### Handoff

- **Next step:** Nutts builds per the concrete spec in doc §3–§4.
- **Depersonalization:** "HCD" / "Human Creative Director" throughout. Verbatim playtest quote retains original wording per studio convention.

Design doc: `docs/design/s17.1-002-loadout-overlap.md`.
