### PR TITLE
[S17.1-002] Fix Loadout UI footer overlap

### DIFF
--- a/godot/tests/test_runner.gd
+++ b/godot/tests/test_runner.gd
@@ -46,6 +46,7 @@ const SPRINT_TEST_FILES := [
 	"res://tests/test_sprint14_1.gd",
 	"res://tests/test_sprint14_1_nav.gd",
 	"res://tests/test_sprint17_1_shop_scroll.gd",
+	"res://tests/test_sprint17_1_loadout_overlap.gd",
 ]
 
 var file_pass_count := 0

--- a/godot/tests/test_sprint17_1_loadout_overlap.gd
+++ b/godot/tests/test_sprint17_1_loadout_overlap.gd
@@ -1,0 +1,211 @@
+## Sprint 17.1-002 — Loadout UI footer overlap fix
+## Usage: godot --headless --script tests/test_sprint17_1_loadout_overlap.gd
+## Design: docs/design/s17.1-002-loadout-overlap.md
+## Covers (per design §6):
+##   AC-1 — ScrollContainer exists and is sized correctly
+##   AC-2 — Shop button reachable at inventory = 0, 5, 20, 50
+##   AC-3 — Continue button reachable at same inventory sizes
+##   AC-4 — Scroll range grows with inventory
+##   AC-5 — Signal contract preserved
+##   AC-6 — Empty-state layout unchanged (no awkward gap)
+extends SceneTree
+
+var pass_count := 0
+var fail_count := 0
+var test_count := 0
+
+var _signal_back_fired := false
+var _signal_continue_fired := false
+
+func _initialize() -> void:
+	print("=== Sprint 17.1-002 Loadout Overlap Tests ===\n")
+	_run_all()
+	print("\n=== Results: %d passed, %d failed, %d total ===" % [pass_count, fail_count, test_count])
+	if fail_count > 0:
+		quit(1)
+	else:
+		quit(0)
+
+func assert_eq(a, b, msg: String) -> void:
+	test_count += 1
+	if a == b:
+		pass_count += 1
+	else:
+		fail_count += 1
+		print("  FAIL: %s (got %s, expected %s)" % [msg, str(a), str(b)])
+
+func assert_true(cond: bool, msg: String) -> void:
+	test_count += 1
+	if cond:
+		pass_count += 1
+	else:
+		fail_count += 1
+		print("  FAIL: %s" % msg)
+
+func _cleanup(screen: LoadoutScreen) -> void:
+	if screen and screen.get_parent():
+		screen.get_parent().remove_child(screen)
+	if screen:
+		screen.free()
+
+## Build a GameState whose total inventory (weapons + armor + modules) sums to
+## roughly inv_size. Distribution favors weapons since weapon slots drive
+## empty-slot indicator count. Type duplicates are legal — loadout UI iterates
+## the arrays directly and renders one card per entry.
+func _build_fixture_state(inv_size: int) -> GameState:
+	var gs := GameState.new()
+	gs.owned_chassis = [0, 1, 2]
+	gs.equipped_chassis = 0
+	gs.owned_weapons = []
+	gs.owned_armor = []
+	gs.owned_modules = []
+	gs.equipped_weapons = []
+	gs.equipped_armor = 0
+	gs.equipped_modules = []
+
+	if inv_size <= 0:
+		return gs
+	var n_weapons := int(round(inv_size * 0.6))
+	var n_armor := int(round(inv_size * 0.2))
+	var n_modules := inv_size - n_weapons - n_armor
+	for i in range(n_weapons):
+		gs.owned_weapons.append(i % 7)
+	for i in range(n_armor):
+		gs.owned_armor.append((i % 3) + 1)
+	for i in range(n_modules):
+		gs.owned_modules.append(i % 6)
+	return gs
+
+func _make_screen(inv_size: int) -> LoadoutScreen:
+	var gs := _build_fixture_state(inv_size)
+	var screen := LoadoutScreen.new()
+	screen.size = Vector2(1280, 720)
+	root.add_child(screen)
+	screen.setup(gs)
+	return screen
+
+func _find_button(screen: LoadoutScreen, prefix: String) -> Button:
+	for c in screen.get_children():
+		if c is Button and (c as Button).text.begins_with(prefix):
+			return c as Button
+	return null
+
+func _run_all() -> void:
+	_test_ac1_scroll_area_shape()
+	_test_ac2_back_button_reachable_across_sizes()
+	_test_ac3_continue_button_reachable_across_sizes()
+	_test_ac4_scroll_range_grows_with_inventory()
+	_test_ac5_signal_contract_preserved()
+	_test_ac6_empty_state_no_gap()
+
+# --- AC-1: ScrollContainer exists and is sized correctly ---
+func _test_ac1_scroll_area_shape() -> void:
+	print("AC-1: ScrollArea exists, bounded, horizontal disabled, follow_focus on")
+	var screen := _make_screen(5)
+	var scroll := screen.get_node_or_null("ScrollArea") as ScrollContainer
+	assert_true(scroll != null, "ScrollArea exists")
+	if scroll != null:
+		assert_eq(scroll.size.y, 520.0, "ScrollArea.size.y == 520")
+		assert_eq(scroll.position.y, 120.0, "ScrollArea.position.y == 120")
+		assert_eq(scroll.horizontal_scroll_mode, ScrollContainer.SCROLL_MODE_DISABLED, "horizontal scroll disabled")
+		assert_true(scroll.follow_focus, "follow_focus = true")
+		var content := scroll.get_node_or_null("Content")
+		assert_true(content != null and content is VBoxContainer, "Content VBox exists inside ScrollArea")
+	_cleanup(screen)
+
+# --- AC-2: Shop button reachable at inventory = 0, 5, 20, 50 ---
+# Structural invariant: footer buttons are direct children of LoadoutScreen
+# at pinned y=650, and the ScrollContainer bounded to y=120 + height=520 (i.e.
+# bottom edge at y=640) cannot overlap the footer regardless of content size.
+# The ScrollContainer clips its children, so any overflow is visually clipped
+# and input-shielded away from the footer.
+func _test_ac2_back_button_reachable_across_sizes() -> void:
+	print("AC-2: ← Shop button reachable and non-overlapped at inv_size ∈ {0,5,20,50}")
+	for inv_size in [0, 5, 20, 50]:
+		var screen := _make_screen(inv_size)
+		var back_btn := _find_button(screen, "← Shop")
+		assert_true(back_btn != null, "back_btn present at inv_size=%d" % inv_size)
+		if back_btn == null:
+			_cleanup(screen)
+			continue
+		assert_eq(back_btn.position, Vector2(20, 650), "back_btn pinned at (20,650) inv_size=%d" % inv_size)
+		var scroll := screen.get_node_or_null("ScrollArea") as ScrollContainer
+		assert_true(scroll != null, "ScrollArea exists inv_size=%d" % inv_size)
+		if scroll != null:
+			var scroll_rect := Rect2(scroll.position, scroll.size)
+			var back_rect := Rect2(back_btn.position, back_btn.size)
+			assert_true(not scroll_rect.intersects(back_rect), "ScrollArea rect does not overlap back_btn at inv_size=%d (scroll=%s back=%s)" % [inv_size, str(scroll_rect), str(back_rect)])
+		_cleanup(screen)
+
+# --- AC-3: Continue button reachable at same inventory sizes ---
+func _test_ac3_continue_button_reachable_across_sizes() -> void:
+	print("AC-3: Continue → button reachable and non-overlapped at inv_size ∈ {0,5,20,50}")
+	for inv_size in [0, 5, 20, 50]:
+		var screen := _make_screen(inv_size)
+		var cont_btn := _find_button(screen, "Continue")
+		assert_true(cont_btn != null, "continue btn present at inv_size=%d" % inv_size)
+		if cont_btn == null:
+			_cleanup(screen)
+			continue
+		assert_eq(cont_btn.position, Vector2(1050, 650), "continue pinned at (1050,650) inv_size=%d" % inv_size)
+		var scroll := screen.get_node_or_null("ScrollArea") as ScrollContainer
+		if scroll != null:
+			var scroll_rect := Rect2(scroll.position, scroll.size)
+			var cont_rect := Rect2(cont_btn.position, cont_btn.size)
+			assert_true(not scroll_rect.intersects(cont_rect), "ScrollArea rect does not overlap continue_btn at inv_size=%d" % inv_size)
+		_cleanup(screen)
+
+# --- AC-4: Scroll range grows with inventory ---
+# Uses await to let VBox minimum_size propagate through layout before reading
+# the v_scroll_bar.max_value. This is the only test that needs a frame.
+func _test_ac4_scroll_range_grows_with_inventory() -> void:
+	print("AC-4: scroll range > 0 under inventory pressure")
+	var screen := _make_screen(50)
+	# Allow layout to settle — VBox child min-sizes need a frame to propagate.
+	await process_frame
+	await process_frame
+	var scroll := screen.get_node_or_null("ScrollArea") as ScrollContainer
+	assert_true(scroll != null, "ScrollArea exists")
+	if scroll != null:
+		var v_bar := scroll.get_v_scroll_bar()
+		assert_true(v_bar != null, "v_scroll_bar exists")
+		if v_bar != null:
+			assert_true(v_bar.max_value > 0, "v_scroll_bar.max_value > 0 at inv_size=50 (got %s)" % str(v_bar.max_value))
+	_cleanup(screen)
+
+# --- AC-5: Signal contract preserved ---
+func _test_ac5_signal_contract_preserved() -> void:
+	print("AC-5: back_pressed / continue_pressed signals still emit")
+	var screen := _make_screen(5)
+	_signal_back_fired = false
+	_signal_continue_fired = false
+	screen.back_pressed.connect(func(): _signal_back_fired = true)
+	screen.continue_pressed.connect(func(): _signal_continue_fired = true)
+	var back_btn := _find_button(screen, "← Shop")
+	var cont_btn := _find_button(screen, "Continue")
+	assert_true(back_btn != null, "back_btn exists for signal test")
+	assert_true(cont_btn != null, "cont_btn exists for signal test")
+	if back_btn != null:
+		back_btn.pressed.emit()
+	if cont_btn != null:
+		cont_btn.pressed.emit()
+	assert_true(_signal_back_fired, "back_pressed signal fired")
+	assert_true(_signal_continue_fired, "continue_pressed signal fired")
+	_cleanup(screen)
+
+# --- AC-6: Empty-state layout unchanged ---
+func _test_ac6_empty_state_no_gap() -> void:
+	print("AC-6: empty state — content starts at top, no awkward gap")
+	var screen := _make_screen(0)
+	var scroll := screen.get_node_or_null("ScrollArea") as ScrollContainer
+	assert_true(scroll != null, "ScrollArea exists")
+	if scroll != null:
+		var content := scroll.get_node_or_null("Content") as VBoxContainer
+		assert_true(content != null, "Content VBox exists")
+		if content != null:
+			assert_true(content.get_child_count() > 0, "Content has children (chassis list minimum)")
+			var first := content.get_child(0)
+			assert_true(first is Label, "first child is a section Label")
+			if first is Label:
+				assert_true((first as Label).text.begins_with("CHASSIS"), "first label is CHASSIS header (got '%s')" % (first as Label).text)
+	_cleanup(screen)

--- a/godot/tests/test_sprint17_1_loadout_overlap.gd.uid
+++ b/godot/tests/test_sprint17_1_loadout_overlap.gd.uid
@@ -1,0 +1,1 @@
+uid://bwnnn0t06duof

--- a/godot/ui/loadout_screen.gd
+++ b/godot/ui/loadout_screen.gd
@@ -72,85 +72,35 @@ func _build_ui() -> void:
 	# Weight budget bar (S12.2)
 	_build_weight_bar(validation, ch)
 
-	var y := 120
+	# [S17.1-002] Scroll region for item lists. Viewport = 1280×720, header region
+	# ends at y≈96, footer row pinned at y=650 (50px tall). Scroll region is
+	# bounded 1280×520 so no amount of content can push past the footer.
+	# Footer buttons (back_btn, _equip_button) are siblings of this scroll
+	# container and are added AFTER it so they render on top.
+	var scroll := ScrollContainer.new()
+	scroll.name = "ScrollArea"
+	scroll.position = Vector2(0, 120)
+	scroll.custom_minimum_size = Vector2(1280, 520)
+	scroll.size = Vector2(1280, 520)
+	scroll.horizontal_scroll_mode = ScrollContainer.SCROLL_MODE_DISABLED
+	scroll.follow_focus = true
+	add_child(scroll)
 
-	# Chassis selector
-	y = _add_label("CHASSIS (select one):", y)
-	for ct in game_state.owned_chassis:
-		var cd := ChassisData.get_chassis(ct)
-		var selected := ct == game_state.equipped_chassis
-		var btn := Button.new()
-		btn.text = ("▶ " if selected else "  ") + cd["name"] + " (HP:%d Spd:%d W:%d/%d)" % [cd["hp"], int(cd["speed"]), cd["weapon_slots"], cd["module_slots"]]
-		btn.position = Vector2(40, y)
-		btn.size = Vector2(500, 30)
-		btn.pressed.connect(_select_chassis.bind(ct))
-		add_child(btn)
-		y += 32
+	var content := VBoxContainer.new()
+	content.name = "Content"
+	content.add_theme_constant_override("separation", 4)
+	content.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	content.custom_minimum_size = Vector2(1280, 0)
+	scroll.add_child(content)
 
-	# Weapon selector with equipped styling
-	y = _add_label("WEAPONS (slots: %d/%d):" % [game_state.equipped_weapons.size(), ch["weapon_slots"]], y + 10)
+	_build_chassis_section(content)
+	_build_weapons_section(content, ch)
+	_build_armor_section(content)
+	_build_modules_section(content, ch)
+	_build_error_section(content, validation)
 
-	# Empty weapon slot indicators (S12.2)
-	var empty_weapon_slots: int = ch["weapon_slots"] - game_state.equipped_weapons.size()
-	for i in range(max(0, empty_weapon_slots)):
-		var slot_panel := _create_empty_slot_indicator("weapon")
-		slot_panel.position = Vector2(40, y)
-		add_child(slot_panel)
-		y += 36
-
-	for wt in game_state.owned_weapons:
-		var wd := WeaponData.get_weapon(wt)
-		var equipped := wt in game_state.equipped_weapons
-		var card := _create_item_card(wd["name"], wd["archetype"], wd["description"], equipped)
-		card.position = Vector2(40, y)
-		card.get_node("Button").pressed.connect(_toggle_weapon.bind(wt))
-		add_child(card)
-		y += 36
-
-	# Armor selector
-	y = _add_label("ARMOR (one):", y + 10)
-	# Add "None" option
-	var none_equipped := game_state.equipped_armor == 0
-	var none_card := _create_item_card("None", "", "", none_equipped)
-	none_card.position = Vector2(40, y)
-	none_card.get_node("Button").pressed.connect(_select_armor.bind(0))
-	add_child(none_card)
-	y += 36
-	for at in game_state.owned_armor:
-		var ad := ArmorData.get_armor(at)
-		var selected := at == game_state.equipped_armor
-		var card := _create_item_card(ad["name"], ad["archetype"], ad["description"], selected)
-		card.position = Vector2(40, y)
-		card.get_node("Button").pressed.connect(_select_armor.bind(at))
-		add_child(card)
-		y += 36
-
-	# Module selector with equipped styling
-	y = _add_label("MODULES (slots: %d/%d):" % [game_state.equipped_modules.size(), ch["module_slots"]], y + 10)
-
-	# Empty module slot indicators (S12.2)
-	var empty_module_slots: int = ch["module_slots"] - game_state.equipped_modules.size()
-	for i in range(max(0, empty_module_slots)):
-		var slot_panel := _create_empty_slot_indicator("module")
-		slot_panel.position = Vector2(40, y)
-		add_child(slot_panel)
-		y += 36
-
-	for mt in game_state.owned_modules:
-		var md := ModuleData.get_module(mt)
-		var equipped := mt in game_state.equipped_modules
-		var card := _create_item_card(md["name"], md["archetype"], md["description"], equipped)
-		card.position = Vector2(40, y)
-		card.get_node("Button").pressed.connect(_toggle_module.bind(mt))
-		add_child(card)
-		y += 36
-
-	# Error display
-	if not validation["valid"]:
-		for err in validation["errors"]:
-			y = _add_label("⚠️ " + err, y + 5, Color.RED)
-
-	# Navigation
+	# Navigation — footer siblings of ScrollArea, pinned at y=650 (unchanged).
+	# Added AFTER scroll so they render on top in Godot's default z-order.
 	var back_btn := Button.new()
 	back_btn.text = "← Shop"
 	back_btn.position = Vector2(20, 650)
@@ -165,6 +115,72 @@ func _build_ui() -> void:
 	_equip_button.disabled = not validation["valid"]
 	_equip_button.pressed.connect(func(): continue_pressed.emit())
 	add_child(_equip_button)
+
+## [S17.1-002] Section builders — append to a VBoxContainer instead of
+## absolute-positioning at a running y. Card/indicator rendering logic
+## (_create_item_card, _create_empty_slot_indicator) is untouched.
+
+func _build_chassis_section(parent: VBoxContainer) -> void:
+	parent.add_child(_make_section_label("CHASSIS (select one):"))
+	for ct in game_state.owned_chassis:
+		var cd := ChassisData.get_chassis(ct)
+		var selected := ct == game_state.equipped_chassis
+		var btn := Button.new()
+		btn.text = ("▶ " if selected else "  ") + cd["name"] + " (HP:%d Spd:%d W:%d/%d)" % [cd["hp"], int(cd["speed"]), cd["weapon_slots"], cd["module_slots"]]
+		btn.custom_minimum_size = Vector2(500, 30)
+		btn.pressed.connect(_select_chassis.bind(ct))
+		parent.add_child(btn)
+
+func _build_weapons_section(parent: VBoxContainer, ch: Dictionary) -> void:
+	parent.add_child(_make_section_label("WEAPONS (slots: %d/%d):" % [game_state.equipped_weapons.size(), ch["weapon_slots"]]))
+	var empty_weapon_slots: int = ch["weapon_slots"] - game_state.equipped_weapons.size()
+	for i in range(max(0, empty_weapon_slots)):
+		parent.add_child(_create_empty_slot_indicator("weapon"))
+	for wt in game_state.owned_weapons:
+		var wd := WeaponData.get_weapon(wt)
+		var equipped := wt in game_state.equipped_weapons
+		var card := _create_item_card(wd["name"], wd["archetype"], wd["description"], equipped)
+		card.get_node("Button").pressed.connect(_toggle_weapon.bind(wt))
+		parent.add_child(card)
+
+func _build_armor_section(parent: VBoxContainer) -> void:
+	parent.add_child(_make_section_label("ARMOR (one):"))
+	var none_equipped := game_state.equipped_armor == 0
+	var none_card := _create_item_card("None", "", "", none_equipped)
+	none_card.get_node("Button").pressed.connect(_select_armor.bind(0))
+	parent.add_child(none_card)
+	for at in game_state.owned_armor:
+		var ad := ArmorData.get_armor(at)
+		var selected := at == game_state.equipped_armor
+		var card := _create_item_card(ad["name"], ad["archetype"], ad["description"], selected)
+		card.get_node("Button").pressed.connect(_select_armor.bind(at))
+		parent.add_child(card)
+
+func _build_modules_section(parent: VBoxContainer, ch: Dictionary) -> void:
+	parent.add_child(_make_section_label("MODULES (slots: %d/%d):" % [game_state.equipped_modules.size(), ch["module_slots"]]))
+	var empty_module_slots: int = ch["module_slots"] - game_state.equipped_modules.size()
+	for i in range(max(0, empty_module_slots)):
+		parent.add_child(_create_empty_slot_indicator("module"))
+	for mt in game_state.owned_modules:
+		var md := ModuleData.get_module(mt)
+		var equipped := mt in game_state.equipped_modules
+		var card := _create_item_card(md["name"], md["archetype"], md["description"], equipped)
+		card.get_node("Button").pressed.connect(_toggle_module.bind(mt))
+		parent.add_child(card)
+
+func _build_error_section(parent: VBoxContainer, validation: Dictionary) -> void:
+	if validation["valid"]:
+		return
+	for err in validation["errors"]:
+		parent.add_child(_make_section_label("⚠️ " + err, Color.RED))
+
+func _make_section_label(text: String, color: Color = Color.WHITE) -> Label:
+	var lbl := Label.new()
+	lbl.text = text
+	lbl.add_theme_font_size_override("font_size", 16)
+	lbl.add_theme_color_override("font_color", color)
+	lbl.custom_minimum_size = Vector2(600, 25)
+	return lbl
 
 ## S12.2: Build the weight budget bar below header
 func _build_weight_bar(validation: Dictionary, ch: Dictionary) -> void:
@@ -311,16 +327,6 @@ func _has_weight_error(errors: Array) -> bool:
 		if "Overweight" in err:
 			return true
 	return false
-
-func _add_label(text: String, y: int, color: Color = Color.WHITE) -> int:
-	var lbl := Label.new()
-	lbl.text = text
-	lbl.add_theme_font_size_override("font_size", 16)
-	lbl.add_theme_color_override("font_color", color)
-	lbl.position = Vector2(20, y)
-	lbl.size = Vector2(600, 25)
-	add_child(lbl)
-	return y + 28
 
 func _select_chassis(ct: int) -> void:
 	game_state.equipped_chassis = ct


### PR DESCRIPTION
## Summary

Fixes the Loadout UI footer overlap surfaced in the 2026-04-18 playtest — HCD quote:

> "in loadout when i have a lot of stuff they cover the shop button"

Wraps the Loadout item region in a bounded `ScrollContainer` (1280×520 at y=120). Footer buttons (`← Shop`, `Continue →`) are siblings of the scroll container, not children, and remain pinned at y=650. No amount of inventory can push past the footer row or steal input.

Implements design doc [`docs/design/s17.1-002-loadout-overlap.md`](https://github.com/brott-studio/battlebrotts-v2/blob/gizmo/s17.1-002-loadout-overlap-design/docs/design/s17.1-002-loadout-overlap.md) (PR #161).

## References

- **Arc brief:** `sprints/sprint-17.md` (S17 Eve Polish Arc)
- **Sub-sprint:** `sprints/sprint-17.1.md` (Shop/Loadout/Event UX fixes)
- **Design doc:** `docs/design/s17.1-002-loadout-overlap.md` (Gizmo → Nutts handoff)
- **Backlog:** #104 — UX: No UI overlap at full inventory / loadout (prio:high)
- **Precedent:** #159 (S17.1-001 shop scroll) — same `ScrollContainer` + fixed-footer pattern

## Changes

**`godot/ui/loadout_screen.gd`** (+76 / −69 net)

- Replaced running-`y` absolute-positioning block with `ScrollContainer` (`name="ScrollArea"`) + `VBoxContainer` (`name="Content"`) setup.
- Extracted section builders that append to a `VBoxContainer` parent:
  - `_build_chassis_section(parent)`
  - `_build_weapons_section(parent, ch)`
  - `_build_armor_section(parent)`
  - `_build_modules_section(parent, ch)`
  - `_build_error_section(parent, validation)`
- `_add_label(text, y, color) -> int` replaced by `_make_section_label(text, color) -> Label`.
- Footer (`back_btn`, `_equip_button`) keeps absolute positions `Vector2(20, 650)` and `Vector2(1050, 650)`. Added AFTER the scroll container so they render on top.
- `ScrollContainer` config: `horizontal_scroll_mode = SCROLL_MODE_DISABLED`, `follow_focus = true` (keyboard/gamepad nav auto-scrolls to focused item).

**What was NOT touched** (per scope gate):

- `_create_item_card()`, `_create_empty_slot_indicator()` — rendering unchanged.
- `_build_weight_bar()`, `_process()`, overweight flash — unchanged.
- Handlers: `_select_chassis`, `_toggle_weapon`, `_select_armor`, `_toggle_module` — unchanged.
- `_trigger_loadout_anims` + bot preview integration — unchanged.
- Signal contract (`continue_pressed`, `back_pressed`) — unchanged.
- Sacred paths: `godot/combat/**`, `godot/data/**`, `godot/arena/**`, `docs/gdd.md` — untouched.

**`godot/tests/test_sprint17_1_loadout_overlap.gd`** (new, +211)

Six ACs per design §6, 43 assertions total, all passing locally:

- **AC-1** — ScrollArea exists, `size.y == 520`, `position.y == 120`, horizontal disabled, `follow_focus == true`, Content VBox child present.
- **AC-2** — `← Shop` button present, pinned at `(20, 650)`, ScrollArea rect does not overlap it at inv_size ∈ {0, 5, 20, 50}.
- **AC-3** — `Continue →` button present, pinned at `(1050, 650)`, same non-overlap invariant at inv_size ∈ {0, 5, 20, 50}.
- **AC-4** — `v_scroll_bar.max_value > 0` at inv_size = 50 (scroll range exists under inventory pressure).
- **AC-5** — `back_pressed` and `continue_pressed` signals still fire on button press (signal contract regression gate).
- **AC-6** — Empty state: Content VBox non-empty, first child is the `CHASSIS …` section label (no awkward gap, content starts at top).

**`godot/tests/test_runner.gd`** (+1)

- Registered `test_sprint17_1_loadout_overlap.gd` in `SPRINT_TEST_FILES`, mirroring the S17.1-001 registration pattern from #159.

## Acceptance criteria (design §6)

- [x] AC-1 ScrollContainer shape
- [x] AC-2 Shop button reachable at inv = 0, 5, 20, 50
- [x] AC-3 Continue button reachable at inv = 0, 5, 20, 50
- [x] AC-4 Scroll range grows with inventory
- [x] AC-5 Signal contract preserved
- [x] AC-6 Empty-state layout unchanged
- [ ] AC-7 Optic manual / Playwright max-inventory screenshot — handled by Optic post-merge per design §6.7

## Local verification

```
godot --headless --path godot/ --import
godot --headless --path godot/ --script res://tests/test_runner.gd
# => Sprint-file results: 26 files passed, 0 files failed
# => OVERALL: inline PASS | sprint files PASS
```

Sprint 17.1-002 test file standalone:

```
=== Sprint 17.1-002 Loadout Overlap Tests ===
AC-1: … AC-2: … AC-3: … AC-4: … AC-5: … AC-6: …
=== Results: 43 passed, 0 failed, 43 total ===
```

## Carry-forwards (not in this PR, per scope gate)

- **Scroll position preservation across `_build_ui()` rebuilds in Loadout** — design §7.2. If Optic finds "equip resets scroll to top" is a felt regression, port the S17.1-001 save-before / `call_deferred("_restore_scroll")` pattern.
- **Shared `ScrollWithFixedFooter` helper** — design §7.3. Defer until N=3 usage sites.

## LoC delta

- `loadout_screen.gd`: +76 / −69 (net +7). Well within the ≤ +90 escalation threshold.
- `test_sprint17_1_loadout_overlap.gd`: +211 new.
- `test_runner.gd`: +1.

## Review path

Boltz review → Specc (App) approve + merge. Auto-merge squash enabled.
