### PR TITLE
[S17.1-003] Design: visible-by-default tooltips

### DIFF
--- a/docs/design/s17.1-003-visible-tooltips.md
+++ b/docs/design/s17.1-003-visible-tooltips.md
@@ -1,0 +1,233 @@
+# [S17.1-003] Visible-by-Default Tooltips — Design
+
+**Author:** Gizmo (design)
+**Sprint:** S17.1 (S17 Eve Polish Arc)
+**Task:** [S17.1-003] — Tooltips visible by default for critical Loadout info; energy bar labeled
+**Scope:** UI presentation only
+**Backlog refs:** [#103](https://github.com/brott-studio/battlebrotts-v2/issues/103), [#107](https://github.com/brott-studio/battlebrotts-v2/issues/107)
+
+---
+
+## 0. Scope discipline (read first)
+
+Per S17.1 scope gate: **no changes to `godot/combat/**`, `godot/data/**`, `godot/arena/**`, or `docs/gdd.md`.** This task is UI presentation only. All new text is rendered from **existing** data fields (item `description`, weapon `energy_cost`, module stat fields already present in `godot/data/` catalogs). No new balance fields, no schema additions.
+
+Specifically:
+
+- ❌ We do **not** touch `arena_renderer.gd` (sacred — `godot/arena/**`). The per-bot blue energy bar that the playtester asked about is drawn there. We cannot annotate it in place.
+- ✅ We **do** add a HUD-side legend label in `godot/main.gd` (not sacred) that tells the player what the blue bar is and what it's for. This solves #107 without touching the arena renderer.
+- ✅ We **do** change how Loadout and Shop item rows render their name + summary — inline, always-visible — by editing `godot/ui/loadout_screen.gd` and `godot/ui/shop_screen.gd` only.
+- ❌ We do **not** remove the existing richer hover/tooltip surface. Hover still works; we just stop gating the essentials behind it.
+
+S17.1-004 (first-run HUD overlay/explainer) is a **separate task**. This doc deliberately does not design an overlay — only always-visible inline text + a persistent HUD legend. The overlay in S17.1-004 can layer on top of what we build here without conflict.
+
+---
+
+## 1. Task restatement + cited complaints
+
+Playtest (2026-04-18) produced two complaints this task addresses:
+
+> "in loadout view there's no way to double check what an item is or does" *(later found hover works)* — #103
+
+> "i'm confused what the blue bar is — is that energy? What is energy for?" — #107
+
+Goal: make item critical info and the energy bar meaning **discoverable without hover**. "Visible by default" means discoverability, not popup overload.
+
+---
+
+## 2. Root-cause analysis
+
+### 2.1 Loadout tooltips — current mechanism
+
+In `godot/ui/loadout_screen.gd` the per-item row is built by `_create_loadout_item_panel()` (around L250–290). The row is a `PanelContainer` containing a single `Button` whose visible text is `"✓ " + item_name + " — " + archetype` (or without the check for unequipped). The item **description is attached as `btn.tooltip_text`** (L281, L286). Godot's default tooltip only appears after a hover delay — if the player doesn't know hover is a thing, the description is effectively invisible.
+
+The button is sized `Vector2(500, 32)` — one line of text, no room for anything else.
+
+### 2.2 Shop tooltips — current mechanism
+
+`godot/ui/shop_screen.gd` (around L576–586) reads the same `description` field from the item data and attaches it as tooltip text on the shop card, with a similar hover-gated discoverability problem, though the shop card has more vertical room than the loadout row.
+
+### 2.3 Energy bar — current rendering
+
+The blue bar the playtester saw is drawn per-bot in `godot/arena/arena_renderer.gd`:
+
+- `const ENERGY_BAR_HEIGHT := 3.0` (L11)
+- `const COLOR_ENERGY := Color(0.2, 0.7, 1.0)` (L23) — this is the "blue bar"
+- Drawn at L770–772 directly below the HP bar on each brott during combat
+
+There is no label, no legend, and no HUD affordance explaining what it represents. The text HUD in `main.gd::_update_ui()` shows `"EN: %d"` but doesn't visually connect to the on-arena bar.
+
+### 2.4 Why the design has to respect S17.1-002's architecture
+
+S17.1-002 §7.1 is the controlling coordination note for this task. It explicitly allocates headroom for visible-by-default tooltip content:
+
+- Per-item row height can grow from 32 px to ~60–80 px — the Loadout scroll region absorbs it.
+- Floating popovers, if needed, anchor as siblings of `ScrollArea` via `show_on_top()`.
+- The footer is pinned at y=650 — no expansion into footer space.
+- The scroll region's height must not change.
+
+Our design must fit inside those constraints.
+
+---
+
+## 3. Chosen approach: **(a) Inline descriptors**
+
+**Approach (a) — small always-rendered descriptor text under the item name — is the simplest option that solves both complaints without introducing new UI surfaces.** It uses existing `description` data, fits cleanly inside the Loadout `VBoxContainer` rows (whose height S17.1-002 already freed us to grow), needs no popup/popover state machine, and leaves the existing hover tooltip in place as a richer fallback. Icon-stat rows (b) would require an icon set we don't have and normalized stat schemas across heterogeneous item types; a persistent summary card (c) adds a new UI region and selection-state plumbing. Inline descriptors are the lowest-risk, lowest-new-surface choice.
+
+---
+
+## 4. Proposed design
+
+### 4.1 Loadout item rows — inline name + one-line summary
+
+Replace the single-line `Button`-only row with a structured row inside the existing `PanelContainer`:
+
+- **Row container:** `VBoxContainer` (replaces the raw Button layout; Button becomes the click target wrapping or siblinged with the labels).
+- **Line 1 (name line, always visible):** `"✓ " + item_name + " — " + archetype` (unchanged content, same equipped checkmark + archetype). Font size unchanged. Equipped color override unchanged.
+- **Line 2 (summary line, always visible — NEW):** one-line `description` rendered as a dimmer sub-label. Font size ~85% of the name line. Truncated with ellipsis if it exceeds row width; full text still available via hover tooltip.
+- **Row height:** grows from 32 px to **64 px** (name ~22 px + summary ~18 px + padding). Well inside the 60–80 px envelope S17.1-002 §7.1 approved.
+
+The existing `btn.tooltip_text = description` (and `"[Equipped] " + description`) stays — the hover path continues to work as a screen-reader / full-text fallback.
+
+### 4.2 Shop item cards — inline one-line summary
+
+Shop cards already have more vertical room than Loadout rows, but the description is still hover-gated. Add the same one-line description directly under the item name on the card, using the same existing `description` string. Hover tooltip (if any) remains the full-text fallback. No card width or grid change.
+
+### 4.3 Energy bar legend (HUD)
+
+Add a **persistent one-line legend label** in the HUD, rendered in `godot/main.gd` as part of `_setup_ui()` / `_update_ui()`. Copy is presentation-only and reads from an existing concept (energy → weapon energy_cost, which is already in `godot/data/` catalogs).
+
+**Exact proposed copy:**
+
+> **⚡ Energy** *(blue bar)* — powers weapons; regenerates over time.
+
+Rendering:
+
+- Added as a child of the existing HUD Control (sibling of `player_info` / `enemy_info`), anchored in the top-left HUD band.
+- Uses the same `COLOR_ENERGY` tone as the arena bar for the "⚡ Energy" glyph/text so the visual link is unambiguous — the glyph/color is referenced from `main.gd`'s own constant, not imported from `arena_renderer.gd` (no cross-sacred-boundary coupling).
+- Single line. Always visible during combat. No new state, no animation, no hover behavior.
+
+This is the minimum viable #107 fix. The richer first-encounter explainer is S17.1-004's job — this just ensures the blue bar has a visible-by-default label from tick 0.
+
+### 4.4 What we explicitly do NOT do
+
+- **No item icons.** Not enough asset budget in S17.1; adds visual surface the playtest didn't ask for.
+- **No tooltip popover rework.** Godot's default hover tooltip is fine as the full-text fallback.
+- **No changes to `description` content.** If a description is truncated in the inline sub-label, the hover tooltip still shows the full string.
+- **No arena overlay.** Labeling on the arena itself would require touching `arena_renderer.gd` — sacred path.
+
+---
+
+## 5. Files / symbols for Nutts
+
+Concrete list, no ambiguity:
+
+| File | Symbol / region | Change |
+|---|---|---|
+| `godot/ui/loadout_screen.gd` | `_create_loadout_item_panel()` (L~250–290) | Replace the single-button layout with a VBox containing a name Label + summary Label + an overlay/wrapping Button as the click target. Preserve `tooltip_text` on the click target. Row size → `Vector2(500, 64)`. |
+| `godot/ui/loadout_screen.gd` | `_create_empty_slot_indicator()` (L~295+) | Match new row height (64 px) so empty slots align visually with populated rows. Text unchanged. |
+| `godot/ui/loadout_screen.gd` | Any hardcoded `36`/`32` row stride inside `_build_ui()` | Update stride to match new row height. |
+| `godot/ui/shop_screen.gd` | The card-render block that reads `description` (~L576–590) | Add an always-visible one-line description label to each shop card beneath the name. Existing tooltip path preserved. |
+| `godot/main.gd` | `_setup_ui()` (or wherever `player_info` is wired) + `_update_ui()` | Add a new static `Label` (e.g. `energy_legend`) with the exact copy from §4.3. No dynamic content — set once, never updated. |
+| `godot/ui/` (new, optional) | — | No new files required. |
+
+**Do not** touch: `godot/arena/arena_renderer.gd`, anything in `godot/combat/**`, `godot/data/**`.
+
+---
+
+## 6. Edge cases
+
+### 6.1 Items with empty or missing `description`
+
+Some item catalog entries may have an empty `description` string. The inline summary line must render an empty row or a fallback. **Decision:** if `description == ""`, render a single em-dash `"—"` in the summary slot, same color as the sub-label. Keeps row height consistent so the scroll container math stays predictable.
+
+### 6.2 Very long descriptions
+
+Truncate with ellipsis at the label's horizontal extent (Godot `Label.autowrap_mode = TextServer.AUTOWRAP_OFF` + `text_overrun_behavior = TextServer.OVERRUN_TRIM_ELLIPSIS`). Full text remains available via the existing hover tooltip.
+
+### 6.3 Font / line-height impact on S17.1-001 scroll
+
+S17.1-001 landed scroll-position preservation for Shop (save-before / `call_deferred("_restore_scroll")`). Growing Shop card height changes the total content height, which could make a saved scroll position exceed the new content max. S17.1-001 §5.1 already specifies clamping to max on restore — our growth doesn't change that contract, just exercises it. No new work required on the scroll side as long as Nutts verifies the clamp still fires.
+
+### 6.4 Max-inventory Loadout stress
+
+At `inventory_size = 50` with 64 px rows, total content height is ~3200 px. S17.1-002's scroll region absorbs this (§7.1 explicitly underwrites per-row growth to 60–80 px). No footer impact. Verified indirectly by S17.1-002's AC-4 (scroll range grows with inventory).
+
+### 6.5 Mobile / touch
+
+Larger rows are easier to tap — no regression. Summary text may truncate earlier on narrow viewports; hover/long-press tooltip remains as fallback. No mobile-specific code change here.
+
+### 6.6 i18n
+
+Not handled this sprint. Copy is English-only and hardcoded. When an i18n pass lands, the energy legend copy and the `"—"` fallback need to be keyed into whatever translation system the project adopts. **Noted only** — out of scope for S17.1.
+
+### 6.7 Focus / keyboard navigation
+
+The inline Labels are non-focusable; the wrapping Button remains the focus target. Keyboard nav order is unchanged from current behavior. No regression.
+
+### 6.8 Empty-state Loadout layout
+
+If the player has no items in a slot, the empty-slot indicator still occupies the 64 px stride — so an empty Loadout has slightly more vertical air than before. This is acceptable (and arguably better framed) but if it reads "too tall" in Optic review, drop empty-slot stride back to 32 px as a follow-up.
+
+---
+
+## 7. Acceptance tests
+
+### 7.1 [AC-1] Loadout summary line is rendered without hover
+
+For each of at least 3 distinct equipped item types (weapon, armor, module), open the Loadout screen and capture the rendered row's text content. Assert the row contains **both** the item name **and** a non-empty sub-label (the description, or `"—"` fallback) in the initial render — **without** any hover event fired.
+
+### 7.2 [AC-2] Row height is 64 px (±2 px for padding)
+
+Inspect the `PanelContainer` row for a populated Loadout item. Assert `size.y` ∈ [62, 66]. Assert the full row is rendered inside `ScrollArea/Content` (no child escapes the scroll region).
+
+### 7.3 [AC-3] Shop card shows inline description
+
+In the Shop screen, for any card rendered, the inline description label is visible in the card layout without hover. Assert the label node exists, is visible, and has non-empty text for items with a non-empty `description`.
+
+### 7.4 [AC-4] Energy legend label exists and shows correct copy
+
+On entering a match, the HUD contains a label whose text contains both `"Energy"` and one of `"blue bar"` / `"weapons"` / `"regenerates"` (anchor-text assertion, resilient to minor copy tweaks). Verify it is visible at match start — not hidden behind a first-encounter flag.
+
+### 7.5 [AC-5] Hover tooltip still works
+
+After inline labels are added, hover on a Loadout item still produces the existing `tooltip_text` after Godot's default hover delay. Assert `btn.tooltip_text == description` (or `"[Equipped] " + description` when equipped). This is a regression guard — we're **adding** inline visibility, not **replacing** hover.
+
+### 7.6 [AC-6] No change to sacred paths
+
+CI-side: diff assertion that this PR touches zero files under `godot/combat/**`, `godot/data/**`, `godot/arena/**`, or `docs/gdd.md`. (Manual gate — Specc to confirm.)
+
+---
+
+## 8. Coordination notes
+
+### 8.1 S17.1-001 (Shop scroll preservation)
+
+The Shop card height grows slightly because of the added inline description. S17.1-001's restore path clamps to max content height (§5.1), so a saved scroll position that now exceeds the new max will gracefully snap to bottom rather than error. No changes needed in S17.1-001; this task exercises that clamp path. Nutts should verify the clamp fires when running AC-1/AC-3 from S17.1-001 against updated Shop rows.
+
+### 8.2 S17.1-002 (Loadout overlap)
+
+This task lives inside the envelope S17.1-002 §7.1 authorized: per-item row grows to 64 px (inside the 60–80 px ceiling), rows remain children of `ScrollArea/Content: VBoxContainer`, no footer impact, no scroll region resize. We stay in-card; no new panels, no sibling popovers this sprint. S17.1-002's max-inventory AC (AC-4) stays valid — scroll range naturally grows as row stride increases.
+
+### 8.3 S17.1-004 (First-run HUD explainer)
+
+S17.1-004 is the first-encounter overlay that walks the player through each HUD element, including the energy bar. Our design deliberately **does not** build an overlay — only the always-visible legend. The two are additive: S17.1-004's overlay can point an arrow at our legend label, reference the same copy, and dismiss cleanly without touching anything we built. Recommend S17.1-004 reuse the "⚡ Energy" glyph and color token from `main.gd` for visual continuity.
+
+---
+
+## 9. Complexity estimate
+
+**Complexity: S (small).**
+
+- 3 files edited (`loadout_screen.gd`, `shop_screen.gd`, `main.gd`).
+- Adds 2 new Labels, restructures 1 row builder into a VBox layout.
+- No new data, no new signals, no new scenes.
+- Test surface: 5–6 new assertions (§7), all short.
+
+Estimated wall-clock for Nutts: **~1.5–3 hours** including Godot headless test wiring. Largest risk is getting the Loadout row VBox right on first build (Godot layout quirks with mixed Button + Label children); mitigation: use the existing `_create_empty_slot_indicator()` VBox pattern as the template.
+
+---
+
+## 10. Depersonalization
+
+This doc uses "HCD" / "Human Creative Director" in prospective references. Existing verbatim playtest quotes are preserved as-is.


### PR DESCRIPTION
Design doc for [S17.1-003] — visible-by-default tooltips for Loadout/Shop items and a labeled energy bar legend.

**Chosen approach:** (a) Inline descriptors — small always-rendered description text under each item name, plus a persistent HUD legend for the energy bar. Simplest option that addresses both #103 (undiscoverable hover) and #107 (unlabeled blue bar) without introducing new UI surfaces.

**Scope-gate compliance:** UI presentation only. Zero changes to `godot/combat/**`, `godot/data/**`, `godot/arena/**`, `docs/gdd.md`. Energy bar label lives in `main.gd` HUD (not sacred), not in the arena renderer (sacred).

**Coordination:** Fits inside S17.1-002 §7.1's authorized envelope (64 px row stride, inside the 60–80 px ceiling; in-card, not sibling-popover). Additive to S17.1-001's scroll clamp. Non-overlapping with S17.1-004's first-run overlay (legend is always-visible; overlay is the richer explainer).

**Complexity:** S — 3 files edited (`loadout_screen.gd`, `shop_screen.gd`, `main.gd`), ~1.5–3h for Nutts.

**For Specc App review:** doc length 233 lines (under the 250–400 target range but all required sections present; kept tight deliberately after prior spawn timed out). If Specc wants more depth on any section, flag and I'll expand.

— Gizmo
