### PR TITLE
[S17.1-004] Design: first-encounter HUD explanation

### DIFF
--- a/docs/design/s17.1-004-first-encounter-hud.md
+++ b/docs/design/s17.1-004-first-encounter-hud.md
@@ -1,0 +1,248 @@
+# [S17.1-004] First-Encounter HUD Explainer — Design
+
+**Author:** Gizmo (design)
+**Sprint:** S17.1 (S17 Eve Polish Arc)
+**Task:** [S17.1-004] — One-sentence, dismissible first-run explainer for the energy bar (and an extensible pattern for adjacent HUD elements)
+**Scope:** UI presentation + a tiny new first-run persistence utility
+**Backlog refs:** [#107](https://github.com/brott-studio/battlebrotts-v2/issues/107)
+
+---
+
+## 0. Scope discipline (read first)
+
+Per S17.1 scope gate: **no changes to `godot/combat/**`, `godot/data/**`, `godot/arena/**`, or `docs/gdd.md`.** This task adds a one-shot overlay and a first-run persistence helper only. No gameplay fields. No catalog edits.
+
+- ✅ Add a new helper script `godot/ui/first_run_state.gd` that reads/writes a single `ConfigFile` at `user://first_run.cfg`.
+- ✅ Modify `godot/main.gd` to spawn a one-shot overlay label+button on first combat entry, keyed off the helper.
+- ❌ No changes to `arena_renderer.gd` or anything under the arena/combat/data sacred paths.
+- ❌ No modification of S17.1-003's legend label — we reuse it as the anchor, not replace it.
+
+---
+
+## 1. Task + cited complaint
+
+**Task:** First-encounter HUD explainer, starting with the energy bar, dismissible, one-shot.
+
+**Playtest complaint (verbatim):**
+> "i'm confused what the blue bar is - is that energy? What is energy for?"
+
+**Backlog issue #107 (verbatim):**
+> Energy bar and every HUD element should have an in-game explanation on first encounter.
+
+S17.1-003 has already landed the **always-visible** legend (`⚡ Energy (blue bar) — powers weapons; regenerates over time.`) inside `godot/main.gd`. S17.1-004's job is the **complementary first-encounter surface**: a more prominent one-shot that directs the player's attention at the legend on their first combat view, then gets out of the way forever.
+
+---
+
+## 2. Root-cause analysis
+
+### 2.1 First-combat flow today
+
+`godot/game_main.gd` routes the player between screens; `godot/main.gd` (the combat scene) runs `_ready()` → `_setup_ui()` → `_setup_energy_legend()` (from S17.1-003) → `_update_ui()`. There is **no gating** on first-time entry vs. nth-time entry. Every combat, the legend label is shown from tick 0.
+
+### 2.2 Existing first-run / tutorial infrastructure
+
+Grep of `godot/` for `first_run|tutorial|has_seen|onboard|user://|ConfigFile`:
+
+- **`godot/ui/brottbrain_screen.gd`** has an in-scene tutorial overlay (`_show_tutorial()`) and a `tutorial_dismissed` boolean. The comment at line 12 is unambiguous:
+  > `var tutorial_dismissed: bool = false  # persists per session; ideally save to disk`
+  That is the precedent pattern (Panel + Labels + "Got it!" Button) but the dismissal is **not persistent across process runs**.
+- **`godot/tests/test_sprint3.gd`** uses `ConfigFile.new()` to read `res://project.godot`, confirming the engine-native `ConfigFile` API is already familiar to the codebase.
+- **No `user://` writes exist anywhere in the codebase.** No savegame, no preferences file. This task is the first one.
+
+**Conclusion:** we need a minimal new persistence layer. It must be shared with S17.1-006 (crate first-run decision), so design it as a generic keyed flag store, not an energy-specific one.
+
+---
+
+## 3. Chosen pattern + rationale
+
+**Pattern (b) — One-shot highlight overlay on first combat start.**
+
+On the first time the player enters combat, display a small non-blocking card positioned directly above the S17.1-003 energy legend label, with an arrow pointing down at it, the one-sentence explainer, and a single "Got it!" button. Auto-dismiss also occurs on the first real input (combat tick ≥ 60 OR any key/click), whichever comes first. Persist dismissal to `user://first_run.cfg`.
+
+**Rationale:** Pattern (a) (modal card) is too heavy for a single-bar explainer and risks blocking. Pattern (c) (welcome screen) requires wiring a new screen in `game_main.gd`/`game_flow.gd` and lands outside the combat context where the bar lives — breaking the "point at the thing you're explaining" principle. Pattern (b) reuses S17.1-003's legend as its anchor, is strictly additive, does not modify the combat scene's sacred areas, auto-dismisses on first real action so it can never trap the player, and is the smallest surface that honors the #107 "on first encounter" language.
+
+---
+
+## 4. Proposed design
+
+### 4.1 Exact copy
+
+Overlay body (one sentence, reusing the S17.1-003 token):
+
+> **⚡ The blue bar is your Energy — it powers your weapons and regenerates over time.**
+
+Button label: **`Got it!`** (matches the existing `brottbrain_screen.gd` tutorial convention).
+
+### 4.2 Layout
+
+- A `Panel` 420×96 px, anchored top-left, positioned at `(16, 72)` — directly **below** the S17.1-003 legend at `offset_top=42` so it visually tethers to the bar area without occluding the HP/score readout.
+- A `Label` inside the panel with the copy above; `font_size = 14`, color `Color(0.95, 0.95, 0.95)`, wrapping enabled.
+- A small `▲` glyph label positioned at `(90, -10)` relative to the panel, pointing up at the S17.1-003 legend's `⚡` glyph.
+- A `Button` with text `Got it!`, right-aligned inside the panel bottom-right, size `96×28`.
+- The entire overlay is parented to `_ui_layer` (same CanvasLayer as the legend) so it scales with the UI.
+
+### 4.3 Trigger
+
+In `godot/main.gd::_ready()`, after `_setup_energy_legend()`, check `FirstRunState.has_seen("energy_explainer")`. If false, call `_spawn_energy_explainer()` which builds the overlay described above.
+
+### 4.4 Dismissal
+
+Any of the following dismisses the overlay and marks `energy_explainer` seen:
+
+1. **Button press** — "Got it!" handler: `FirstRunState.mark_seen("energy_explainer")` then `queue_free()` the overlay root.
+2. **First meaningful action** — on the first `_input()` event that is a key-down or mouse-button-down after the overlay is shown.
+3. **Combat tick ≥ 60** (~1 second at 60 fps) — auto-dismiss guard so the overlay can never block the player if they ignore it.
+
+Once dismissed, the persistence write is done synchronously and the overlay is freed. No animations required; a direct free is acceptable for S.
+
+### 4.5 Persistence mechanism
+
+See §5. Single dict-backed ConfigFile at `user://first_run.cfg`. No migration concerns — this is the first consumer.
+
+---
+
+## 5. First-run persistence system spec (shared with S17.1-006)
+
+### 5.1 Store location
+
+`user://first_run.cfg` — a Godot `ConfigFile`. One section (`[seen]`), keys are string flag names, values are `true`.
+
+### 5.2 Key format
+
+`snake_case` strings scoped by feature:
+
+| Key | Owner | Meaning |
+|---|---|---|
+| `energy_explainer` | S17.1-004 | Player has seen the first-encounter energy-bar overlay |
+| `crate_first_run` | S17.1-006 (reserved) | Player has seen / dismissed the first-run crate popup |
+
+Add new keys by appending to the table. **Do not reuse or rename keys** — old saves will carry them.
+
+### 5.3 API
+
+New file: `godot/ui/first_run_state.gd` (an autoload singleton; name `FirstRunState`). Registered in `project.godot` under `[autoload]`. Surface:
+
+```gdscript
+class_name FirstRunStateClass
+extends Node
+
+const STORE_PATH := "user://first_run.cfg"
+const SECTION := "seen"
+
+var _cfg: ConfigFile = ConfigFile.new()
+var _loaded: bool = false
+
+func _ensure_loaded() -> void:
+    if _loaded: return
+    var err := _cfg.load(STORE_PATH)
+    # OK or ERR_FILE_NOT_FOUND are both fine; any other error we log and treat as fresh.
+    if err != OK and err != ERR_FILE_NOT_FOUND:
+        push_warning("[FirstRunState] load error %s — treating as fresh" % err)
+        _cfg = ConfigFile.new()
+    _loaded = true
+
+func has_seen(key: String) -> bool:
+    _ensure_loaded()
+    return bool(_cfg.get_value(SECTION, key, false))
+
+func mark_seen(key: String) -> void:
+    _ensure_loaded()
+    _cfg.set_value(SECTION, key, true)
+    var err := _cfg.save(STORE_PATH)
+    if err != OK:
+        push_warning("[FirstRunState] save error %s for key=%s" % [err, key])
+
+func reset(key: String) -> void:
+    # Dev/test use only — not called from gameplay.
+    _ensure_loaded()
+    _cfg.set_value(SECTION, key, false)
+    _cfg.save(STORE_PATH)
+```
+
+### 5.4 Why this shape
+
+- **Minimal.** One file, one section, booleans. No JSON, no schema, no versioning. A dict in a config file, as requested.
+- **Shared.** S17.1-006 just adds a new key; no code changes to `first_run_state.gd` needed.
+- **Safe.** Missing file on first run is treated as "nothing seen" — exactly the desired behavior.
+- **Testable.** Headless tests can `reset()` a key between runs. A later sprint can add a single `test_first_run_state.gd` if useful; not required for S17.1-004 merge.
+
+---
+
+## 6. Files / symbols for Nutts
+
+| File | Change |
+|---|---|
+| `godot/ui/first_run_state.gd` | **NEW.** Autoload singleton per §5.3. |
+| `godot/project.godot` | Register `FirstRunState` under `[autoload]` (path `*res://ui/first_run_state.gd`). |
+| `godot/main.gd` | Add `_spawn_energy_explainer()` helper; call it from `_ready()` after `_setup_energy_legend()` gated on `FirstRunState.has_seen("energy_explainer") == false`. Hook one-shot `_input()` listener for auto-dismiss; hook a tick counter in `_process()` or a `SceneTreeTimer` for the ~1s auto-dismiss fallback. |
+| `docs/design/s17.1-004-first-encounter-hud.md` | This file. |
+
+**Symbols introduced in `main.gd`:**
+- `var energy_explainer_overlay: Control = null`
+- `var _energy_explainer_ticks: int = 0`
+- `func _spawn_energy_explainer() -> void`
+- `func _dismiss_energy_explainer() -> void`
+- `func _on_got_it_pressed() -> void` (inline lambda is acceptable per the `brottbrain_screen.gd` precedent)
+
+Do **not** refactor `_setup_energy_legend()` or any existing S17.1-003 code. Overlay positioning is relative to the legend's known `offset_top = 42` — do not read the legend's rect at runtime (avoids a frame-order dependency).
+
+---
+
+## 7. Edge cases
+
+1. **Already-dismissed (returning player).** `has_seen("energy_explainer") == true` → `_spawn_energy_explainer()` is never called; zero nodes added, zero cost. Verified by AC-2.
+2. **Savegame / config file missing.** `ConfigFile.load()` returns `ERR_FILE_NOT_FOUND` → treated as fresh; overlay shows; first `mark_seen` creates the file. Verified by AC-1.
+3. **Savegame corrupt or unreadable.** Non-OK, non-NOT_FOUND load error → warning logged, in-memory `ConfigFile` is reset, overlay shows. Save attempt on dismissal overwrites the bad file.
+4. **Resolution scale.** Overlay parented to `_ui_layer` (CanvasLayer), so it inherits the same scaling behavior as the S17.1-003 legend. At common resolutions (1280×720, 1920×1080) the `(16, 72)` origin + 420×96 panel stays within the top-left without overlapping the HP/score HUD block (which lives further right).
+5. **Touch vs keyboard.** Dismissal on `_input()` accepts both `InputEventMouseButton.pressed` and `InputEventKey.pressed`. "Got it!" button is a standard Godot `Button` which handles both focus+Enter and touch-tap natively.
+6. **Combat ends before dismissal (player flees / loses in <1s).** The scene is freed normally; the overlay is freed with it. `mark_seen` was **not** called, so the overlay will re-appear on the *next* combat — acceptable first-run semantics (the player has not actually acknowledged it yet).
+7. **Player toggles fullscreen while overlay is up.** CanvasLayer handles reflow; overlay stays positioned at `(16, 72)` in UI space. No action required.
+8. **Input focus stealing.** The "Got it!" button is non-modal; combat input continues to route to the player's brott. No `grab_focus()` call — we explicitly do **not** trap the cursor.
+
+---
+
+## 8. Acceptance tests
+
+**[AC-1] Fresh user — overlay appears on first combat.**
+Delete `user://first_run.cfg` if present. Launch game, enter combat. Overlay is visible in the top-left, contains the exact copy from §4.1, and has a "Got it!" button.
+
+**[AC-2] After dismissal, overlay never reappears.**
+Press "Got it!" on the overlay. Exit combat, re-enter combat. Overlay is **not** rendered. Inspect `user://first_run.cfg`: contains `[seen]\nenergy_explainer=true`.
+
+**[AC-3] Auto-dismiss via input.**
+Fresh run. Enter combat. Press any key before clicking "Got it!". Overlay disappears. Re-enter combat; overlay does **not** reappear. (Confirms the first-input dismissal also persists.)
+
+**[AC-4] Auto-dismiss via tick budget.**
+Fresh run. Enter combat. Do not press any input for >1 second (60 ticks). Overlay disappears. Re-enter combat; overlay does **not** reappear.
+
+**[AC-5] S17.1-003 legend still present and unmodified.**
+During overlay display AND after dismissal, the S17.1-003 legend label (`⚡ Energy (blue bar) — powers weapons; regenerates over time.`) renders at its original position `(offset_left=20, offset_top=42)`. No text differences, no color differences, no z-order flicker.
+
+**[AC-6] Shared persistence API — smoke test via reserved key.**
+Call `FirstRunState.has_seen("crate_first_run")` from a test or dev console. Returns `false` on a fresh save, returns `true` after `FirstRunState.mark_seen("crate_first_run")`. Confirms S17.1-006 can adopt the helper unchanged.
+
+---
+
+## 9. Coordination
+
+### 9.1 With S17.1-003 (legend reuse)
+
+S17.1-003 Design §8.3 explicitly scoped this overlay forward, said to **point at the legend rather than replace it**, and recommended reusing the `⚡ Energy` glyph and color token for visual continuity. This design complies: the overlay anchors above the legend at `(16, 72)`, reuses the `⚡` glyph in the first word of its copy, and does not modify any S17.1-003 code. The legend remains the always-visible ground truth; the overlay is a one-time nudge that directs attention to it. If S17.1-003's `offset_top=42` or legend text is ever changed, only the `▲` glyph's vertical offset in this design needs a one-line adjustment — the copy is independently phrased.
+
+### 9.2 With S17.1-006 (persistence sharing)
+
+Ett's S17.1 plan scope concerns #2 flagged that S17.1-004 and S17.1-006 both need "has user seen this" persistence. This design spec'd a minimal `FirstRunState` autoload with a flat `ConfigFile` at `user://first_run.cfg`, section `[seen]`, boolean-valued keys. S17.1-006 adopts this by adding the key `crate_first_run` (reserved in §5.2 already) and calling `FirstRunState.has_seen("crate_first_run")` / `FirstRunState.mark_seen("crate_first_run")`. **No changes to `first_run_state.gd` are required for S17.1-006 adoption — the helper is shared-ready.** Confirmed explicitly: one system, two consumers, zero schema coupling between them.
+
+---
+
+## 10. Complexity estimate
+
+**Proposed complexity: S–M (lean S).**
+
+- New 35-line autoload (`first_run_state.gd`) with zero dependencies on game state.
+- One `[autoload]` line in `project.godot`.
+- ~60 lines of additive code in `main.gd` (spawn/dismiss/tick helpers, zero refactor of existing functions).
+- 6 acceptance tests, all manual-verifiable in a single combat session.
+- No touches to sacred paths. No data migrations. No new screens.
+
+Nutts should size it as **S** if they're comfortable with autoload registration + CanvasLayer node spawning; **M** only if they discover a Godot 4 autoload gotcha we didn't anticipate. Ett's plan had listed [S17.1-004] at **M** for "new first-encounter infra"; the shared-persistence helper is the infra, and it's deliberately tiny.


### PR DESCRIPTION
Gizmo design doc for [S17.1-004].

**Pattern:** (b) one-shot highlight overlay on first combat, anchored to S17.1-003's always-visible legend. Dismissible by Got it! button, first input, or ~1s auto-dismiss.

**Key decision:** introduces a tiny `FirstRunState` autoload backed by `user://first_run.cfg`. This is the shared first-run persistence helper S17.1-006 will reuse (key `crate_first_run` reserved in §5.2).

**Scope-gate:** no touches to `godot/combat/**`, `godot/data/**`, `godot/arena/**`, or `docs/gdd.md`.

**Complexity for Nutts:** S (lean S).

Coordinates explicitly with S17.1-003 §8.3 (legend reuse) and Ett S17.1-plan scope concern #2 (shared persistence with S17.1-006).

Closes part of #107 (first-encounter portion; always-visible portion is S17.1-003, already merged).