### PR TITLE
[S17.1-005] Design: random-event popup

### DIFF
--- a/docs/design/s17.1-005-random-event-popup.md
+++ b/docs/design/s17.1-005-random-event-popup.md
@@ -1,0 +1,172 @@
+# [S17.1-005] Random-Event Popup Polish — Design
+
+**Author:** Gizmo (design)
+**Sprint:** S17.1 (S17 Eve Polish Arc)
+**Task:** [S17.1-005] — Make the trick-choice (random-event) popup skippable, less interruptive, and honest about item removal before the player commits.
+**Scope:** UI presentation (modal layout + button wiring) + one small addition to `apply_trick_choice` dispatch in `shop_screen.gd` for a "skip" result. No data edits, no outcome-table changes, no combat/arena touch.
+**Backlog refs:** [#106](https://github.com/brott-studio/battlebrotts-v2/issues/106)
+
+---
+
+## 0. Scope discipline (read first)
+
+Per S17.1 scope gate: **no changes to `godot/combat/**`, `godot/data/**`, `godot/arena/**`, or `docs/gdd.md`.**
+
+- ✅ Modify `godot/ui/trick_choice_modal.gd` + `.tscn` — add a third "Skip" affordance and a pre-commit item-loss preview row.
+- ✅ Modify `godot/ui/shop_screen.gd` — accept a `"skip"` resolution (distinct from `choice_a`/`choice_b`) and bypass `apply_trick_choice` cleanly.
+- ❌ No edit to `godot/data/trick_choices.gd` (sacred — outcome tables).
+- ❌ No change to trick frequency or spawn rate (playtest complaint is framing/chaos, not raw frequency — see §2.3; holding frequency constant per acceptance criterion option (b), with rationale in §3).
+- ❌ No change to `ItemTokens` resolution or `GameState.apply_trick_choice`.
+
+---
+
+## 1. Task + cited complaints
+
+**Task:** Random-event popup redesign toward "skippable or rarer," with a pre-commit preview for item-removal outcomes.
+
+**Playtest complaints (verbatim, 2026-04-18):**
+> "the popup asking for trading or opening crates is kind of annoying"
+> "the random events with decision are pretty chaotic, taking my items"
+
+**Backlog #106 (verbatim):**
+> Spec: `docs/kb/ux-vision.md` anti-patterns. Options: skippable, rarer, or redesigned to feel rewarding rather than interruptive.
+
+`ux-vision.md` explicitly flags: *"Popup spam (random events, crate/trade prompts) that interrupt flow."*
+
+---
+
+## 2. Root-cause analysis
+
+### 2.1 Current popup surface
+
+`godot/ui/trick_choice_modal.gd` + `trick_choice_modal.tscn` is the sole random-event popup. It's spawned from `godot/ui/shop_screen.gd::_maybe_show_trick_then_build()` on entering the shop. The modal has:
+
+- A dimmed `Overlay` ColorRect (alpha 0.6 black) — blocks all other input.
+- A centered `Panel` 600×300 with `Dialogue`, `Prompt`, and **exactly two buttons** (`ChoiceA`, `ChoiceB`). No third option. No escape.
+- `resolved(trick_id, choice_key)` signal fires on click; modal self-queues-free.
+
+**Observation 1 — no skip path.** The player must pick A or B. ESC does nothing (no `_input` handler). "Walk away / Walk past / No risk" copy exists on many tricks' `choice_b`, but it's **inconsistent** — not every trick has a neutral-decline option, and several tricks' `choice_b` is still a committed action (e.g. `scrap_trader` haggle still spends 5 bolts). The player has no universal "not this time" affordance.
+
+### 2.2 Item-removal surprise
+
+From `godot/data/trick_choices.gd`, several tricks silently remove items via `ITEM_LOSE` / `{item_name}` tokens. Example — `toll_goblin`:
+
+- Button label: **"Hand something over"** (no preview of which item).
+- Flavor (post-commit): **"Goblin grunts, takes your {item_name}. Drops 5 bolts on the way out."**
+
+The player clicks not knowing which item they lose. S13.8 item 5 already pre-resolves the `{item_name}` token before the modal shows — so the data is known *before* the click — but the modal never surfaces it. This is the "chaotic, taking my items" complaint in a single shot: the information exists and is deliberately withheld until after commitment.
+
+Same class applies to `scavenger_kid` `choice_a` (`random_weak` grant is obscured) and any future `ITEM_LOSE` trick.
+
+### 2.3 Frequency
+
+Shop entry triggers the modal once per shop visit (gated by `_trick_shown` on the ShopScreen instance). Shop visits are per-round, which is already a constrained cadence. **Frequency is not the root cause** — the ux-vision "popup spam" label refers to the fact that *every* shop entry has a popup with no opt-out, which makes it feel spammy even though absolute count is modest. Fixing (1) add skip and (2) pre-commit preview addresses the felt-chaos without a data change. Per acceptance-criterion option (b), frequency held constant; rationale landed in this doc per the gate.
+
+---
+
+## 3. Chosen pattern + rationale
+
+**Pattern:** Redesigned modal with a **third always-present "Skip" button** + a **pre-commit preview row** under any choice whose effect includes `ITEM_LOSE` or `ITEM_GRANT`.
+
+**Rationale:** The existing modal is already the right surface (centered, readable, Eve-aesthetic compatible). It fails on two axes: no universal decline path, and deliberate concealment of item-level consequences until after commit. Both are fixable inside the existing scene without touching data. A skip button is one node + one signal branch; the preview row is one `Label` per choice button, populated from `patched` (which is already pre-resolved by `shop_screen.gd::_prepare_trick_for_modal`). This is the minimum change that hits both #106 acceptance bullets (skip affordance + pre-commit preview) and the ux-vision anti-pattern without risking the sacred data path. ESC is also wired to the skip path as the secondary affordance (button is primary, ESC is parity).
+
+---
+
+## 4. Proposed design
+
+### 4.1 Layout (revised `trick_choice_modal.tscn`)
+
+- `Overlay` ColorRect (alpha lowered from 0.6 → **0.45**) — still dims the backdrop but reads calmer, per ux-vision "restrained" pillar.
+- `Panel` unchanged in position. Height grows from 300 → **340** to fit the preview row. Corners unchanged (PanelContainer inherits theme).
+- New `VBox/Buttons` becomes a 3-button row: `ChoiceA` | `ChoiceB` | `Skip`.
+  - `Skip` button size_flags_horizontal = 3 (equal width), label **"Not now"** (neutral, non-judgmental).
+  - `Skip` uses a desaturated variant — `modulate = Color(0.78, 0.82, 0.88)` — so the eye still lands on A/B first but decline is unambiguously present.
+- New `VBox/PreviewRow` (above `Buttons`): an `HBoxContainer` with two `Label`s (`PreviewA`, `PreviewB`), each aligned under its button. `font_size = 12`, color `Color(0.85, 0.85, 0.85)`, autowrap on. Visible only when the choice's resolved effect touches inventory (grant or lose); hidden for pure bolts/HP deltas.
+
+### 4.2 Exact copy — preview row template
+
+For each choice, evaluate its `effect_type` (and `effect_type_2`) after `_prepare_trick_for_modal` resolves tokens. Populate the preview label from these templates:
+
+| Effect class on the choice | Preview copy |
+|---|---|
+| `ITEM_LOSE` | `− You lose your {item_name}.` |
+| `ITEM_GRANT` | `+ You receive a {item_name}.` |
+| `ITEM_LOSE` + `ITEM_GRANT` (trade) | `You trade your {item_a} for a {item_b}.` |
+| `ITEM_LOSE` + `BOLTS_DELTA` positive | `− {item_name}   + {n} bolts` |
+| `ITEM_GRANT` + `BOLTS_DELTA` negative | `+ {item_name}   − {n} bolts` |
+| No `ITEM_*` effect | *(row hidden for this choice)* |
+
+Bolts-only and HP-only effects are *not* surprising (button label + existing prompt already cover them), so the preview row stays hidden for them. This keeps the modal dense only when density is earned.
+
+### 4.3 Skip button behavior
+
+- Click or ESC → emit `resolved(trick_id, "skip")`.
+- `shop_screen.gd` receives `"skip"`, calls **neither** `apply_trick_choice` nor any other effect; goes straight to `_build_ui()`. No bolts change, no HP change, no item change.
+- Modal tween-out matches the existing A/B fadeout (0.15s). No flavor toast on skip — silence is the reward.
+
+### 4.4 Animation + timing
+
+- Fade-in unchanged (0.2s alpha tween).
+- Button-press cyan flash (0.1s) unchanged for A/B. Skip gets a shorter, dimmer flash: `Color(0.8, 0.9, 1.0)`, 0.08s, no flavor toast, no 1.0s hold.
+- Skip path total dismiss latency: **≤ 0.23s** (flash + fadeout). Non-skip paths unchanged.
+
+---
+
+## 5. Files / symbols for Nutts
+
+### 5.1 Files to edit
+
+- `godot/ui/trick_choice_modal.tscn` — add `Skip` Button to `Buttons` HBox; add `PreviewRow` HBox with `PreviewA`/`PreviewB` labels above `Buttons`; grow Panel offset_bottom by ~40; lower overlay alpha to 0.45.
+- `godot/ui/trick_choice_modal.gd` — add `@onready var _btn_skip`, `_preview_a`, `_preview_b`; wire `_btn_skip.pressed` → `_on_skip()`; add `_unhandled_input(event)` for ESC → `_on_skip()`; add `_populate_previews(trick)` helper; emit `resolved(trick_id, "skip")` on skip path.
+- `godot/ui/shop_screen.gd::_maybe_show_trick_then_build()` — at the `if choice_key == "skip":` branch, skip the `apply_trick_choice` call and still `_build_ui()`. Keep `modal.queue_free()` ordering (S13.8 invariant).
+
+### 5.2 Files NOT to edit
+
+- `godot/data/trick_choices.gd` — sacred.
+- `godot/game/game_state.gd::apply_trick_choice` — no signature change.
+- `godot/combat/**`, `godot/arena/**` — untouched.
+- `godot/ui/first_run_state.gd` — unrelated (S17.1-004).
+
+### 5.3 Preview-row token source
+
+`_prepare_trick_for_modal()` in `shop_screen.gd` already pre-resolves `{item_name}` via `ItemTokens`. Pass the patched dict through to the modal (already done) and read the resolved strings from `trick[choice_key]["flavor_line"]` *and* from a new pair of fields Nutts should add to the patched dict: `trick[choice_key]["preview_name"]` (for `ITEM_LOSE`/`ITEM_GRANT`) and `trick[choice_key]["preview_name_2"]` (for the second effect). These are populated inside `_prepare_trick_for_modal` from the same pool-token resolution already happening — no new RNG call, no divergence from what `apply_trick_choice` will apply.
+
+---
+
+## 6. Edge cases
+
+1. **Skip as default when data is malformed.** If `trick` is empty or missing required keys, the modal must still dismiss cleanly — wire `_on_skip` to be the fallback path. No-op on `apply_trick_choice`.
+2. **ESC during fade-in.** ESC is ignored until `_overlay.modulate.a >= 0.95` to prevent a double-fire before buttons have rendered. One-shot guard (`_resolving = true`) on first click/ESC to prevent double-resolution.
+3. **Trick with no `ITEM_*` effect on either choice.** Both preview labels hidden. Panel height does not shrink back (prevents layout jitter across tricks); the hidden row occupies its minimum (≈18 px) — acceptable, keeps modal size stable.
+4. **Trade trick (`scrap_trader`).** `choice_a` has `BOLTS_DELTA: -15` + `ITEM_GRANT: random_module`. Preview reads: `+ {item_name}   − 15 bolts`. `choice_b` has only `BOLTS_DELTA: -5` — no preview row.
+5. **Screen-reader / focus order.** Tab order: ChoiceA → ChoiceB → Skip. Default focus on ChoiceA (unchanged from today). Skip is last so it never steals focus from the intended primary decision.
+6. **Resolution scale.** Panel is anchored center with fixed offsets; the added row and skip button stay inside the panel at all supported resolutions (1280×720 → 1920×1080 → 2560×1440). No viewport-scale branch needed.
+7. **Audio cue.** None added. Modal audio is out of scope for S17.1 (ux-vision audio arc is separate). Keeping the modal silent preserves the calm Eve-aesthetic; a "whoosh" on skip would undercut "silence is the reward."
+8. **Multiple events in one session.** Cadence is one-per-shop-visit; `_trick_shown` guard on ShopScreen instance is unchanged. Skip doesn't alter cadence (doesn't re-queue the trick for later).
+9. **Tests touching the modal.** `test_sprint13_8_modal_hardening.gd` asserts `queue_free()` precedes `apply_trick_choice()` for A/B paths. The skip path needs its own parallel assertion: `queue_free()` runs AND `apply_trick_choice` is NOT called. Nutts should add a new assertion in a new test file, not mutate existing S13.8 tests.
+
+---
+
+## 7. Acceptance tests
+
+1. **Skip button present + wired.** Instantiate `trick_choice_modal.tscn`, call `show_trick(any_trick)`, assert `_btn_skip` is visible, enabled, and clicking it emits `resolved(trick_id, "skip")`. (Unit.)
+2. **ESC = skip.** Same setup; send `ui_cancel` / ESC event; assert `resolved(trick_id, "skip")` fires. (Unit.)
+3. **Skip path does not mutate game state.** Set up a `GameState` with known bolts / HP / inventory, trigger the trick modal through `ShopScreen`, resolve with skip, assert bolts/HP/inventory all unchanged byte-for-byte. (Functional.)
+4. **Pre-commit preview for `ITEM_LOSE`.** Force `toll_goblin` trick with a known item in inventory (fixture), assert `PreviewA.text` contains the resolved item name (same name that would be removed on commit). (Unit.)
+5. **Pre-commit preview for `ITEM_GRANT`.** Force `crate_find` trick with known RNG seed, assert `PreviewA.text` contains the item name that `apply_trick_choice` grants. Byte-equality between preview name and post-commit granted name. (Functional — covers the "no divergence" invariant.)
+6. **No preview for pure bolts/HP tricks.** Force `rusty_launcher` (pellet-mod + bolts only, no items); assert both `PreviewA` and `PreviewB` are hidden. (Unit.)
+
+---
+
+## 8. Coordination with S17.1-003 / S17.1-004
+
+- **S17.1-003 (Loadout visible tooltips):** different surface (loadout screen vs. shop-entry modal). No shared nodes, no z-order interaction. No conflict.
+- **S17.1-004 (First-encounter HUD explainer):** lives in the combat scene on `main.gd`, anchored top-left at `(16, 72)`. The trick-choice modal is on `CanvasLayer layer=100` in the shop scene — a different scene tree, never co-rendered. No z-order, no layout, no persistence conflict. S17.1-005 does **not** use `first_run_state.gd` (the skip button is always present, not one-shot).
+
+One-paragraph summary: S17.1-005's surface is isolated to the shop-entry modal and does not render alongside either S17.1-003's loadout labels or S17.1-004's combat overlay. No shared state, no shared nodes, no z-order overlap.
+
+---
+
+## 9. Complexity estimate
+
+**M (medium).** Two scene nodes added, one new handler method, one new helper (`_populate_previews`), one new branch in `shop_screen.gd`, and minor additions to `_prepare_trick_for_modal` to expose already-resolved names as top-level patched fields. Three new tests. No new infra, no new data, no sacred-path touch. Nutts should land this in a single PR under a few hundred lines diff.


### PR DESCRIPTION
Design doc for S17.1-005 — random-event popup polish.

**Backlog:** #106
**Chosen pattern:** Skip button ("Not now") + ESC as parity + pre-commit item-loss/grant preview row on the existing trick-choice modal.
**Scope:** UI presentation only. No changes to `godot/data/trick_choices.gd`, `godot/game/game_state.gd::apply_trick_choice`, or any combat/arena/data path.
**Complexity for Nutts:** M.
**Hook point:** `godot/ui/trick_choice_modal.{gd,tscn}` + a single skip-branch addition in `godot/ui/shop_screen.gd::_maybe_show_trick_then_build()`.

Frequency held constant (option b per acceptance criteria) — rationale in §2.3: popup cadence is already one-per-shop-visit, and the felt-chaos is framing, not count.