### PR TITLE
[S17.1-005] Random-event popup: skip button + item preview

### DIFF
--- a/godot/tests/test_runner.gd
+++ b/godot/tests/test_runner.gd
@@ -49,6 +49,7 @@ const SPRINT_TEST_FILES := [
 	"res://tests/test_sprint17_1_loadout_overlap.gd",
 	"res://tests/test_sprint17_1_visible_tooltips.gd",
 	"res://tests/test_sprint17_1_first_encounter_hud.gd",
+	"res://tests/test_sprint17_1_random_event_popup.gd",
 ]
 
 var file_pass_count := 0

--- a/godot/tests/test_sprint17_1_random_event_popup.gd
+++ b/godot/tests/test_sprint17_1_random_event_popup.gd
@@ -1,0 +1,229 @@
+## S17.1-005 — Random-event popup redesign (skip + preview)
+## Usage: godot --headless --script tests/test_sprint17_1_random_event_popup.gd
+##
+## Covers design §7 acceptance tests:
+##   1. Skip button present + wired (source + scene).
+##   2. ESC = skip (source grep on _unhandled_input + ui_cancel).
+##   3. Skip path does NOT call apply_trick_choice (source grep on the
+##      "skip" branch + return ordering in shop_screen.gd).
+##   4. Pre-commit preview renders resolved item name for ITEM_LOSE.
+##   5. Pre-commit preview renders resolved item name for ITEM_GRANT.
+##   6. No preview for pure bolts/HP tricks.
+##
+## Plus S13.8 regression: _trick_shown guard and queue_free() precedence
+## preserved.
+extends SceneTree
+
+var pass_count := 0
+var fail_count := 0
+var test_count := 0
+
+func _initialize() -> void:
+	print("=== S17.1-005 Random-event popup tests ===\n")
+	_run_all()
+	print("\n=== Results: %d passed, %d failed, %d total ===" % [pass_count, fail_count, test_count])
+	if fail_count > 0:
+		quit(1)
+	else:
+		quit(0)
+
+func assert_eq(a, b, msg: String) -> void:
+	test_count += 1
+	if a == b:
+		pass_count += 1
+	else:
+		fail_count += 1
+		print("  FAIL: %s (got %s, expected %s)" % [msg, str(a), str(b)])
+
+func assert_true(cond: bool, msg: String) -> void:
+	test_count += 1
+	if cond:
+		pass_count += 1
+	else:
+		fail_count += 1
+		print("  FAIL: %s" % msg)
+
+func _read_source(path: String) -> String:
+	var f := FileAccess.open(path, FileAccess.READ)
+	if f == null:
+		return ""
+	var txt: String = f.get_as_text()
+	f.close()
+	return txt
+
+func _run_all() -> void:
+	_test_scene_declares_skip_button()
+	_test_scene_declares_preview_row()
+	_test_modal_script_wires_skip()
+	_test_modal_script_wires_esc()
+	_test_shop_skip_branch_bypasses_apply()
+	_test_preview_item_lose()
+	_test_preview_item_grant()
+	_test_preview_hidden_for_bolts_only()
+	_test_preview_trade()
+	_test_s13_8_regressions_preserved()
+
+## AC1 — Skip button present in scene.
+func _test_scene_declares_skip_button() -> void:
+	print("Scene: trick_choice_modal.tscn declares Skip button")
+	var src: String = _read_source("res://ui/trick_choice_modal.tscn")
+	assert_true(src.find("[node name=\"Skip\" type=\"Button\"") != -1, "Skip Button node present")
+	assert_true(src.find("Not now") != -1, "Skip label = 'Not now'")
+	assert_true(src.find("color = Color(0, 0, 0, 0.45)") != -1, "Overlay alpha lowered to 0.45")
+
+## Preview row wiring in scene.
+func _test_scene_declares_preview_row() -> void:
+	print("Scene: PreviewRow with PreviewA/PreviewB present")
+	var src: String = _read_source("res://ui/trick_choice_modal.tscn")
+	assert_true(src.find("[node name=\"PreviewRow\"") != -1, "PreviewRow node present")
+	assert_true(src.find("[node name=\"PreviewA\"") != -1, "PreviewA label present")
+	assert_true(src.find("[node name=\"PreviewB\"") != -1, "PreviewB label present")
+
+## AC1 — Skip wired in modal script.
+func _test_modal_script_wires_skip() -> void:
+	print("Source: modal script wires _btn_skip -> _on_skip and emits 'skip'")
+	var src: String = _read_source("res://ui/trick_choice_modal.gd")
+	assert_true(src.find("_btn_skip") != -1, "_btn_skip declared")
+	assert_true(src.find("_btn_skip.pressed.connect") != -1, "_btn_skip.pressed connected")
+	assert_true(src.find("func _on_skip()") != -1, "_on_skip handler exists")
+	assert_true(src.find("resolved.emit(tid, \"skip\")") != -1, "skip emits resolved(id, \"skip\")")
+
+## AC2 — ESC == skip.
+func _test_modal_script_wires_esc() -> void:
+	print("Source: modal script handles ui_cancel (ESC) via _unhandled_input")
+	var src: String = _read_source("res://ui/trick_choice_modal.gd")
+	assert_true(src.find("_unhandled_input") != -1, "_unhandled_input handler declared")
+	assert_true(src.find("ui_cancel") != -1, "ui_cancel action checked")
+	# ESC calls _on_skip (not a second emit path).
+	var esc_block_ok: bool = false
+	var idx: int = src.find("ui_cancel")
+	if idx != -1:
+		var tail: String = src.substr(idx, 200)
+		esc_block_ok = tail.find("_on_skip()") != -1
+	assert_true(esc_block_ok, "ui_cancel branch calls _on_skip()")
+	assert_true(src.find("_resolving") != -1, "one-shot _resolving guard declared")
+
+## AC3 — Skip branch in shop_screen.gd bypasses apply_trick_choice.
+func _test_shop_skip_branch_bypasses_apply() -> void:
+	print("Source: shop_screen.gd skip branch bypasses apply_trick_choice")
+	var src: String = _read_source("res://ui/shop_screen.gd")
+	var skip_idx: int = src.find("if choice_key == \"skip\":")
+	var apply_idx: int = src.find("apply_trick_choice(patched, choice_key)")
+	var qfree_idx: int = src.find("modal.queue_free()")
+	assert_true(skip_idx != -1, "skip branch present")
+	assert_true(apply_idx != -1, "apply_trick_choice call still present for non-skip paths")
+	assert_true(qfree_idx != -1, "queue_free still present")
+	# Ordering: queue_free < skip-branch < apply_trick_choice (skip returns
+	# before apply can run; S13.8 invariant preserved for A/B paths).
+	assert_true(qfree_idx < skip_idx, "queue_free() precedes skip branch (S13.8 kept)")
+	assert_true(skip_idx < apply_idx, "skip branch precedes apply_trick_choice call")
+	# The skip branch must contain a `return` before apply_trick_choice.
+	var between: String = src.substr(skip_idx, apply_idx - skip_idx)
+	assert_true(between.find("return") != -1, "skip branch returns before apply_trick_choice")
+
+## AC4 — Preview for ITEM_LOSE renders the resolved item name.
+func _test_preview_item_lose() -> void:
+	print("Preview: ITEM_LOSE with a direct token renders '- You lose your <name>.'")
+	var script := load("res://ui/trick_choice_modal.gd")
+	# Pick a direct item token from the scrap_tinker pool so resolve_token
+	# returns a stable display name without RNG.
+	var tok := "minigun"
+	var resolved: Dictionary = ItemTokens.resolve_token(tok)
+	var expected_name: String = ItemTokens.display_name(resolved) if not resolved.is_empty() else ""
+	var choice: Dictionary = {
+		"label": "Hand something over",
+		"effect_type": TrickChoices.EffectType.ITEM_LOSE,
+		"effect_value": tok,
+	}
+	var line: String = script._preview_for_choice(choice)
+	if expected_name != "":
+		assert_true(line.find(expected_name) != -1, "preview contains resolved name '%s' (got '%s')" % [expected_name, line])
+		assert_true(line.begins_with("−") or line.begins_with("- "), "lose line starts with a minus glyph (got '%s')" % line)
+	else:
+		# Token unresolvable in this build — preview must be empty per design.
+		assert_eq(line, "", "unresolvable token yields empty preview")
+
+## AC5 — Preview for ITEM_GRANT renders the resolved item name; equals
+## what apply_trick_choice would produce for this patched choice.
+func _test_preview_item_grant() -> void:
+	print("Preview: ITEM_GRANT with a direct token renders '+ You receive a <name>.'")
+	var script := load("res://ui/trick_choice_modal.gd")
+	var tok := "overclock"
+	var resolved: Dictionary = ItemTokens.resolve_token(tok)
+	var expected_name: String = ItemTokens.display_name(resolved) if not resolved.is_empty() else ""
+	var choice: Dictionary = {
+		"label": "Crack it",
+		"effect_type": TrickChoices.EffectType.ITEM_GRANT,
+		"effect_value": tok,
+		"flavor_line": "Nice. Found a {item_name}.",
+	}
+	var line: String = script._preview_for_choice(choice)
+	if expected_name != "":
+		assert_true(line.find(expected_name) != -1, "preview contains granted name '%s' (got '%s')" % [expected_name, line])
+		assert_true(line.begins_with("+"), "grant line starts with a plus glyph (got '%s')" % line)
+	else:
+		assert_eq(line, "", "unresolvable token yields empty preview")
+
+## AC6 — No preview for pure bolts/HP tricks.
+func _test_preview_hidden_for_bolts_only() -> void:
+	print("Preview: pure BOLTS_DELTA / HP_DELTA choices yield empty preview")
+	var script := load("res://ui/trick_choice_modal.gd")
+	var bolts_choice: Dictionary = {
+		"label": "Walk past",
+		"effect_type": TrickChoices.EffectType.BOLTS_DELTA,
+		"effect_value": 0,
+	}
+	assert_eq(script._preview_for_choice(bolts_choice), "", "bolts-only preview is empty")
+	var hp_choice: Dictionary = {
+		"label": "Snap it up",
+		"effect_type": TrickChoices.EffectType.HP_DELTA,
+		"effect_value": -5,
+	}
+	assert_eq(script._preview_for_choice(hp_choice), "", "hp-only preview is empty")
+	var combo: Dictionary = {
+		"label": "Grab pellets",
+		"effect_type": TrickChoices.EffectType.NEXT_FIGHT_PELLET_MOD,
+		"effect_value": 3,
+		"effect_type_2": TrickChoices.EffectType.HP_DELTA,
+		"effect_value_2": -5,
+	}
+	assert_eq(script._preview_for_choice(combo), "", "pellet+hp preview is empty")
+	assert_eq(script._preview_for_choice({}), "", "empty choice preview is empty")
+
+## Trade preview: ITEM_LOSE + ITEM_GRANT renders both names in one line.
+func _test_preview_trade() -> void:
+	print("Preview: ITEM_LOSE + ITEM_GRANT renders trade template")
+	var script := load("res://ui/trick_choice_modal.gd")
+	var tok_lose := "minigun"
+	var tok_grant := "overclock"
+	var lose_name := ItemTokens.display_name(ItemTokens.resolve_token(tok_lose))
+	var grant_name := ItemTokens.display_name(ItemTokens.resolve_token(tok_grant))
+	if lose_name == "" or grant_name == "":
+		print("  SKIP: token names unresolvable in this build")
+		return
+	var trade_choice: Dictionary = {
+		"label": "Trade",
+		"effect_type": TrickChoices.EffectType.ITEM_LOSE,
+		"effect_value": tok_lose,
+		"effect_type_2": TrickChoices.EffectType.ITEM_GRANT,
+		"effect_value_2": tok_grant,
+	}
+	var line: String = script._preview_for_choice(trade_choice)
+	assert_true(line.begins_with("You trade your"), "trade line starts with 'You trade your' (got '%s')" % line)
+
+## Regression: S13.8 guards preserved after S17.1-005 changes.
+func _test_s13_8_regressions_preserved() -> void:
+	print("Regression: _trick_shown guard still works + queue_free ordering kept")
+	var script := load("res://ui/trick_choice_modal.gd")
+	var modal = script.new()
+	assert_true(modal != null, "modal instantiates via script.new()")
+	assert_eq(modal._trick_shown, false, "_trick_shown defaults to false")
+	modal._trick_shown = true
+	modal.show_trick({"id": "dummy"})
+	assert_eq(modal._trick_shown, true, "_trick_shown remains true after re-entry")
+	assert_true(modal._trick.is_empty(), "_trick not overwritten on re-entry (no-op)")
+	modal.free()
+	# _resolving defaults false on a fresh modal.
+	var m2 = script.new()
+	assert_eq(m2._resolving, false, "_resolving defaults to false")
+	m2.free()

--- a/godot/tests/test_sprint17_1_random_event_popup.gd.uid
+++ b/godot/tests/test_sprint17_1_random_event_popup.gd.uid
@@ -1,0 +1,1 @@
+uid://c0uwerxv3e7vr

--- a/godot/ui/shop_screen.gd
+++ b/godot/ui/shop_screen.gd
@@ -132,6 +132,11 @@ func _maybe_show_trick_then_build() -> void:
 	# S13.8: queue_free BEFORE apply so modal is always reclaimed,
 	# even if apply_trick_choice raises on malformed trick data.
 	modal.queue_free()
+	# S17.1-005 — Skip path: bypass apply_trick_choice entirely. No bolts/HP
+	# /inventory change, no flavor toast. Silence is the reward.
+	if choice_key == "skip":
+		_build_ui()
+		return
 	# S13.8 item 5: pass patched dict so apply operates on the pre-resolved
 	# pool tokens (RNG-consistent with the toast the modal showed).
 	game_state.apply_trick_choice(patched, choice_key)

--- a/godot/ui/trick_choice_modal.gd
+++ b/godot/ui/trick_choice_modal.gd
@@ -7,30 +7,123 @@ signal resolved(trick_id: String, choice_key: String)
 @onready var _prompt: Label = $Overlay/Panel/VBox/Prompt
 @onready var _btn_a: Button = $Overlay/Panel/VBox/Buttons/ChoiceA
 @onready var _btn_b: Button = $Overlay/Panel/VBox/Buttons/ChoiceB
+@onready var _btn_skip: Button = $Overlay/Panel/VBox/Buttons/Skip
+@onready var _preview_a: Label = $Overlay/Panel/VBox/PreviewRow/PreviewA
+@onready var _preview_b: Label = $Overlay/Panel/VBox/PreviewRow/PreviewB
 @onready var _toast: Label = $Overlay/Toast
 var _trick: Dictionary = {}
 # S13.8: one-shot guard. Modal instances are single-use; shop_screen creates
 # a fresh instance per visit, so we don't reset this. Re-entry is a no-op.
 var _trick_shown: bool = false
+# S17.1-005: one-shot resolution guard. First click/ESC locks all further
+# input paths so A/B/skip cannot double-fire.
+var _resolving: bool = false
 
 func show_trick(trick: Dictionary) -> void:
 	if _trick_shown:
 		return
 	_trick_shown = true
 	_trick = trick
-	_dialogue.text = trick["brottbrain_text"]
-	_prompt.text = trick["prompt"]
-	_btn_a.text = trick["choice_a"]["label"]
-	_btn_b.text = trick["choice_b"]["label"]
+	_dialogue.text = trick.get("brottbrain_text", "")
+	_prompt.text = trick.get("prompt", "")
+	_btn_a.text = trick.get("choice_a", {}).get("label", "")
+	_btn_b.text = trick.get("choice_b", {}).get("label", "")
+	_btn_skip.text = "Not now"
 	_toast.visible = false
 	_overlay.modulate.a = 0.0
 	_btn_a.pressed.connect(func(): _on_choice("choice_a"))
 	_btn_b.pressed.connect(func(): _on_choice("choice_b"))
+	_btn_skip.pressed.connect(func(): _on_skip())
+	_populate_previews(trick)
 	create_tween().tween_property(_overlay, "modulate:a", 1.0, 0.2)
 
+## S17.1-005 — ESC parity for the Skip button. Ignored until fade-in
+## completes (guards against double-fire while buttons render).
+func _unhandled_input(event: InputEvent) -> void:
+	if _resolving or not _trick_shown:
+		return
+	if _overlay == null or _overlay.modulate.a < 0.95:
+		return
+	if event.is_action_pressed("ui_cancel"):
+		get_viewport().set_input_as_handled()
+		_on_skip()
+
+## S17.1-005 — Populate PreviewA/PreviewB from the already-resolved trick
+## dict (patched by shop_screen._prepare_trick_for_modal). No new RNG call.
+## Row labels stay hidden for pure bolts/HP effects; visible only when a
+## choice touches inventory (ITEM_GRANT / ITEM_LOSE).
+func _populate_previews(trick: Dictionary) -> void:
+	_preview_a.text = _preview_for_choice(trick.get("choice_a", {}))
+	_preview_b.text = _preview_for_choice(trick.get("choice_b", {}))
+	_preview_a.visible = _preview_a.text != ""
+	_preview_b.visible = _preview_b.text != ""
+	var gray := Color(0.85, 0.85, 0.85)
+	_preview_a.add_theme_color_override("font_color", gray)
+	_preview_b.add_theme_color_override("font_color", gray)
+	_preview_a.add_theme_font_size_override("font_size", 12)
+	_preview_b.add_theme_font_size_override("font_size", 12)
+
+static func _name_from_token(tok: String) -> String:
+	if tok == "":
+		return ""
+	var resolved: Dictionary = ItemTokens.resolve_token(tok)
+	if resolved.is_empty():
+		return ""
+	return ItemTokens.display_name(resolved)
+
+## Build a preview line for one choice. Covers the six effect-class rows
+## from design §4.2; returns "" when no preview is earned.
+static func _preview_for_choice(choice: Dictionary) -> String:
+	if choice.is_empty():
+		return ""
+	var et = choice.get("effect_type")
+	var et2 = choice.get("effect_type_2")
+	var ev: String = str(choice.get("effect_value", ""))
+	var ev2: String = str(choice.get("effect_value_2", ""))
+	var EG = TrickChoices.EffectType.ITEM_GRANT
+	var EL = TrickChoices.EffectType.ITEM_LOSE
+	var BD = TrickChoices.EffectType.BOLTS_DELTA
+	var item_et_name := ""
+	var item_et2_name := ""
+	if et == EG or et == EL:
+		item_et_name = _name_from_token(ev)
+	if et2 == EG or et2 == EL:
+		item_et2_name = _name_from_token(ev2)
+	# Trade: lose + grant
+	if (et == EL and et2 == EG) or (et == EG and et2 == EL):
+		var lose_name := item_et_name if et == EL else item_et2_name
+		var grant_name := item_et_name if et == EG else item_et2_name
+		if lose_name != "" and grant_name != "":
+			return "You trade your %s for a %s." % [lose_name, grant_name]
+	# Lose + bolts positive
+	if et == EL and et2 == BD and int(choice.get("effect_value_2", 0)) > 0 and item_et_name != "":
+		return "− %s   + %d bolts" % [item_et_name, int(choice["effect_value_2"])]
+	if et2 == EL and et == BD and int(choice.get("effect_value", 0)) > 0 and item_et2_name != "":
+		return "− %s   + %d bolts" % [item_et2_name, int(choice["effect_value"])]
+	# Grant + bolts negative
+	if et == EG and et2 == BD and int(choice.get("effect_value_2", 0)) < 0 and item_et_name != "":
+		return "+ %s   − %d bolts" % [item_et_name, -int(choice["effect_value_2"])]
+	if et2 == EG and et == BD and int(choice.get("effect_value", 0)) < 0 and item_et2_name != "":
+		return "+ %s   − %d bolts" % [item_et2_name, -int(choice["effect_value"])]
+	# Pure ITEM_LOSE
+	if et == EL and item_et_name != "":
+		return "− You lose your %s." % item_et_name
+	if et2 == EL and item_et2_name != "":
+		return "− You lose your %s." % item_et2_name
+	# Pure ITEM_GRANT
+	if et == EG and item_et_name != "":
+		return "+ You receive a %s." % item_et_name
+	if et2 == EG and item_et2_name != "":
+		return "+ You receive a %s." % item_et2_name
+	return ""
+
 func _on_choice(key: String) -> void:
+	if _resolving:
+		return
+	_resolving = true
 	_btn_a.disabled = true
 	_btn_b.disabled = true
+	_btn_skip.disabled = true
 	var btn: Button = _btn_a if key == "choice_a" else _btn_b
 	var orig := btn.modulate
 	btn.modulate = Color(0.0, 1.0, 1.0)
@@ -43,3 +136,22 @@ func _on_choice(key: String) -> void:
 	tw.tween_property(_overlay, "modulate:a", 0.0, 0.15)
 	await tw.finished
 	resolved.emit(_trick["id"], key)
+
+## S17.1-005 — Skip path: short dim flash, no flavor toast, fade out.
+## Emits resolved(trick_id, "skip"). shop_screen bypasses apply_trick_choice.
+func _on_skip() -> void:
+	if _resolving:
+		return
+	_resolving = true
+	_btn_a.disabled = true
+	_btn_b.disabled = true
+	_btn_skip.disabled = true
+	var orig := _btn_skip.modulate
+	_btn_skip.modulate = Color(0.8, 0.9, 1.0)
+	await get_tree().create_timer(0.08).timeout
+	_btn_skip.modulate = orig
+	var tw := create_tween()
+	tw.tween_property(_overlay, "modulate:a", 0.0, 0.15)
+	await tw.finished
+	var tid: String = String(_trick.get("id", ""))
+	resolved.emit(tid, "skip")

--- a/godot/ui/trick_choice_modal.tscn
+++ b/godot/ui/trick_choice_modal.tscn
@@ -6,16 +6,16 @@ script = ExtResource("1")
 [node name="Overlay" type="ColorRect" parent="."]
 anchor_right = 1.0
 anchor_bottom = 1.0
-color = Color(0, 0, 0, 0.6)
+color = Color(0, 0, 0, 0.45)
 [node name="Panel" type="PanelContainer" parent="Overlay"]
 anchor_left = 0.5
 anchor_top = 0.5
 anchor_right = 0.5
 anchor_bottom = 0.5
 offset_left = -300.0
-offset_top = -150.0
+offset_top = -170.0
 offset_right = 300.0
-offset_bottom = 150.0
+offset_bottom = 170.0
 [node name="VBox" type="VBoxContainer" parent="Overlay/Panel"]
 [node name="TopRow" type="HBoxContainer" parent="Overlay/Panel/VBox"]
 [node name="Portrait" type="ColorRect" parent="Overlay/Panel/VBox/TopRow"]
@@ -27,12 +27,28 @@ autowrap_mode = 3
 [node name="Prompt" type="Label" parent="Overlay/Panel/VBox"]
 autowrap_mode = 3
 horizontal_alignment = 1
+[node name="PreviewRow" type="HBoxContainer" parent="Overlay/Panel/VBox"]
+alignment = 1
+[node name="PreviewA" type="Label" parent="Overlay/Panel/VBox/PreviewRow"]
+size_flags_horizontal = 3
+horizontal_alignment = 1
+autowrap_mode = 3
+custom_minimum_size = Vector2(0, 18)
+[node name="PreviewB" type="Label" parent="Overlay/Panel/VBox/PreviewRow"]
+size_flags_horizontal = 3
+horizontal_alignment = 1
+autowrap_mode = 3
+custom_minimum_size = Vector2(0, 18)
 [node name="Buttons" type="HBoxContainer" parent="Overlay/Panel/VBox"]
 alignment = 1
 [node name="ChoiceA" type="Button" parent="Overlay/Panel/VBox/Buttons"]
 size_flags_horizontal = 3
 [node name="ChoiceB" type="Button" parent="Overlay/Panel/VBox/Buttons"]
 size_flags_horizontal = 3
+[node name="Skip" type="Button" parent="Overlay/Panel/VBox/Buttons"]
+size_flags_horizontal = 3
+text = "Not now"
+modulate = Color(0.78, 0.82, 0.88, 1)
 [node name="Toast" type="Label" parent="Overlay"]
 anchor_left = 0.5
 anchor_top = 0.85


### PR DESCRIPTION
## [S17.1-005] Random-event popup: skip button + item preview

Implements **docs/design/s17.1-005-random-event-popup.md** (PR #170 / Gizmo design).

**Scope:** presentation-only change inside `trick_choice_modal` + a single `skip` branch in `shop_screen.gd`. Zero touch to `godot/combat/**`, `godot/data/**`, `godot/arena/**`, or `docs/gdd.md`.

**Backlog ref:** #106 — popups "annoying / chaotic, taking my items."

### What changed

- **Third "Not now" skip button** with ESC parity (`ui_cancel`). One-shot `_resolving` guard prevents A/B/Skip double-fire; ESC ignored until fade-in completes.
- **Pre-commit PreviewRow** (`PreviewA`, `PreviewB`) populated from the already-resolved tokens produced by `_prepare_trick_for_modal` — no new RNG, no divergence from what `apply_trick_choice` will apply.
- **Six preview templates** (design §4.2): pure `ITEM_LOSE` / `ITEM_GRANT`, trade, lose+bolts, grant+bolts. Row hidden for pure bolts/HP choices.
- **Overlay alpha** lowered 0.6 → 0.45 (ux-vision "restrained" pillar).
- **Skip path** in `shop_screen._maybe_show_trick_then_build()` bypasses `apply_trick_choice` entirely and still calls `_build_ui()`. S13.8 `queue_free()`-before-`apply_trick_choice` invariant preserved for A/B paths.

### Tests (`godot/tests/test_sprint17_1_random_event_popup.gd`, 34 assertions)

- AC1 — Skip button present + wired (scene + script).
- AC2 — ESC → skip via `_unhandled_input` / `ui_cancel`.
- AC3 — Skip path does NOT call `apply_trick_choice` (ordering grep + `return` in skip branch).
- AC4 — Pre-commit preview renders resolved item name for `ITEM_LOSE`.
- AC5 — Pre-commit preview renders resolved item name for `ITEM_GRANT`.
- AC6 — No preview for pure bolts/HP tricks.
- Trade template (`ITEM_LOSE` + `ITEM_GRANT`).
- S13.8 `_trick_shown` regression + `_resolving` default.

All 34 assertions pass locally. S13.8 modal-hardening / toast tests still green (15/15 + 12/12). S17.1-001..004 regressions still green.

### LoC (non-.uid)

| File | +/− |
|---|---|
| `godot/ui/trick_choice_modal.gd` | +116 / −4 |
| `godot/ui/trick_choice_modal.tscn` | +19 / −3 |
| `godot/ui/shop_screen.gd` | +5 / −0 |
| `godot/tests/test_sprint17_1_random_event_popup.gd` | +229 / −0 (new) |
| `godot/tests/test_runner.gd` | +1 / −0 |

### Review path

Boltz review → Optic verify → Specc approve+merge.

### Notes for review

- Preview row uses a minimum-height (~18 px) placeholder when hidden to prevent layout jitter across tricks (edge case §6.3).
- Preview helpers are `static` + pure on `choice` dicts — easy to unit-test without a scene.
- `TrickChoices`/`ItemTokens` referenced as class_names (consistent with existing S13.8 tests).

Design: docs/design/s17.1-005-random-event-popup.md
Sprint: sprints/sprint-17.1.md (S17 Eve Polish Arc)
Coord: HCD / Human Creative Director (per depersonalization rule).
