### PR TITLE
[S17.1-006] Design: first-run crate

### DIFF
--- a/docs/design/s17.1-006-first-run-crate.md
+++ b/docs/design/s17.1-006-first-run-crate.md
@@ -1,0 +1,130 @@
+# S17.1-006 — First-Run Crate Decision: Contextualize
+
+**Task:** [S17.1-006] First-run crate decision — contextualize or defer
+**Backlog issue:** [#107](https://github.com/brott-studio/battlebrotts-v2/issues/107) (first-encounter HUD / decision-surface explanation)
+**Sub-sprint:** S17.1 (S17 Eve Polish Arc)
+**Author:** Gizmo
+**Precedent:** `docs/design/s17.1-004-first-encounter-hud.md` (sibling first-run feature)
+
+---
+
+## 1. Task & cited complaint
+
+Playtest quote (verbatim):
+
+> "the screen asking whether i want to open a crate was jarring to be the first thing i see"
+
+The screen in question is the **trick-choice modal** shown on the player's first scrapyard visit, which — when the RNG-picked trick happens to be `crate_find` — opens with no framing:
+
+- **BrottBrain:** *"...looks like a crate. Could be good, could be rats."*
+- **Prompt:** *"Pry it open?"*
+- Choices: Crack it / Walk past / Not now.
+
+On a first run this is the player's first real decision surface, and it lands cold. The player has no mental model yet for what a crate "is" in this game's loop.
+
+## 2. Root-cause analysis
+
+The `crate_find` entry (in `godot/data/trick_choices.gd`) is one of several tricks in the Scrapyard pool. Current flow:
+
+1. Player enters Scrapyard shop → `ShopScreen._maybe_show_trick_then_build()` fires (shop_screen.gd:104).
+2. `game_state.pick_unseen_trick()` randomly selects an unseen trick from `TrickChoices.TRICKS`.
+3. `trick_choice_modal.tscn` instantiates with `brottbrain_text` + `prompt` + two choices + Skip.
+
+There is **no existing tutorial, hint, or framing layer** above the trick modal. The modal itself carries the full narrative load. For the `crate_find` trick on first run, the "what is a crate / what does opening do" context is missing — the copy jumps straight into dry-humor flavor without grounding.
+
+Note: `TrickChoices` data (`godot/data/trick_choices.gd`) lives under `godot/data/**` — **in scope-gate territory**. We must not edit it. Framing must be added at the **presentation layer** (modal or an adjacent overlay), not in data.
+
+## 3. Chosen pattern: (a) Contextualize — one-line framing above the existing prompt
+
+**Rationale.** `ux-vision.md` calls out popup spam as an anti-pattern and calls for "in-game explanation on first encounter" for every decision surface. Path (a) adds a single calm line above the existing choice — no new gate, no reorder of scrapyard flow, no borrowing from `godot/combat` or `godot/arena`. Path (b) (defer until after first shop/loadout interaction) would require wiring a new ordering gate into league/scrapyard flow, which risks drifting toward combat/arena scope and was explicitly flagged M-complexity in the task brief. Path (a) matches the sibling S17.1-004 overlay style (small, dismissible, one-shot, `FirstRunState`-gated), keeps the existing modal behavior identical on subsequent runs, and resolves the "jarring" complaint by adding grounding rather than hiding the decision.
+
+## 4. Proposed design
+
+### 4.1 Trigger
+
+In `trick_choice_modal.gd::show_trick()`, immediately after populating `_dialogue` / `_prompt`, check:
+
+```gdscript
+if trick.get("id", "") == "crate_find" and not FirstRunState.has_seen("crate_first_run"):
+    _show_first_run_framing()
+    FirstRunState.mark_seen("crate_first_run")
+```
+
+Guarded by trick id (`crate_find`) AND the `FirstRunState` flag. Any other trick id, or any subsequent `crate_find` encounter, skips the framing and renders the modal exactly as today.
+
+### 4.2 Framing line
+
+A new `Label` node (`FirstRunFraming`) added to the modal scene, positioned **above** `Dialogue` inside the existing `$Overlay/Panel/VBox`. Visible only when `_show_first_run_framing()` is called; hidden by default.
+
+Copy (BrottBrain-adjacent, calm, one line; keeps Eve-style restraint):
+
+> *"Crates are optional loot. Opening might give you an item — or nothing."*
+
+Exactly one line. No emoji. No exclamation. Font size 13 (one step smaller than `Prompt`), color `Color(0.75, 0.75, 0.75)` (dimmer than main prompt to read as context-chrome, not choice text).
+
+### 4.3 Dismissal
+
+The framing line dismisses **with the modal itself** — there is no separate dismiss affordance. When the player clicks Crack it / Walk past / Not now (or hits ESC), the modal closes and the framing goes with it. The `mark_seen("crate_first_run")` call fires on *show*, not on *resolution*, so even if the player Skips, the framing won't re-appear next time.
+
+### 4.4 Persistence reuse
+
+- **Store:** `user://first_run.cfg` (shared, owned by S17.1-004).
+- **Key:** `crate_first_run` (reserved in S17.1-004 §5.2, AC-6-tested).
+- **API:** `FirstRunState.has_seen("crate_first_run")` / `FirstRunState.mark_seen("crate_first_run")`.
+- **Zero changes to `godot/ui/first_run_state.gd`** — API already fits.
+- **Zero changes to `godot/project.godot`** — autoload already registered.
+
+### 4.5 Out of scope
+
+- No changes to `godot/data/trick_choices.gd` (scope gate: `godot/data/**`).
+- No changes to `game_state.pick_unseen_trick()` (scope gate: no combat/arena drift; selection stays RNG-driven).
+- No reorder of scrapyard-first-visit flow (that would be path b — rejected).
+- No change to `_overlay`, button layout, or preview rows from S17.1-005.
+
+## 5. Files / symbols for Nutts
+
+| File | Change |
+|---|---|
+| `godot/ui/trick_choice_modal.tscn` | **EDIT.** Add one `Label` node named `FirstRunFraming` inside `$Overlay/Panel/VBox`, positioned as the first child (above `TopRow`). Hidden by default. |
+| `godot/ui/trick_choice_modal.gd` | **EDIT.** Add `@onready var _first_run_framing: Label = $Overlay/Panel/VBox/FirstRunFraming`. In `show_trick()`, after dialogue/prompt assignment, call `_maybe_show_first_run_framing(trick)`. Implement the helper per §4.1 and the copy per §4.2. |
+| `godot/tests/test_sprint17_1_first_run_crate.gd` | **NEW.** Unit test per §7. |
+| `docs/design/s17.1-006-first-run-crate.md` | This file. |
+
+**Symbols introduced in `trick_choice_modal.gd`:**
+- `@onready var _first_run_framing: Label`
+- `func _maybe_show_first_run_framing(trick: Dictionary) -> void`
+
+**Persistence key confirmation:** `FirstRunState.has_seen("crate_first_run")` and `FirstRunState.mark_seen("crate_first_run")` — verbatim per S17.1-004 §5.2. No new keys. No autoload edits.
+
+## 6. Edge cases
+
+1. **Multiple crate encounters same session, `has_seen` flips mid-session.** `mark_seen` fires on first `show_trick` with id `crate_find`; any re-entry (same session or later) reads `has_seen = true` and skips framing. No re-show.
+2. **Player skips the first crate modal (ESC / "Not now") without reading framing.** Still marked seen — design intent: first-run explanation is a one-shot, not enforced reading. Second encounter shows the modal plain. Matches S17.1-004 auto-dismiss philosophy (§ S17.1-004 AC-3).
+3. **Player's first scrapyard trick happens to NOT be `crate_find`.** Framing does not fire; `crate_first_run` stays `false`. On a later scrapyard visit where `crate_find` is selected, framing fires once there — still "first-run" in the feature sense, even if not first-ever trick.
+4. **Save-file missing / corrupted.** `FirstRunState._ensure_loaded()` treats missing/corrupt as fresh (per S17.1-004 §5.3). Framing fires on first `crate_find`. No crash.
+5. **Resolution scaling.** `FirstRunFraming` uses the existing `VBox` layout — it inherits the same anchor/resize rules as `Dialogue` and `Prompt`. No new Control_set_anchors calls needed. One-line label wraps if the panel is narrow (set `autowrap_mode = TextServer.AUTOWRAP_WORD_SMART`).
+6. **Z-order / scene stacking.** Modal is a `CanvasLayer`; framing is inside the same `Panel`. No interaction with S17.1-004's overlay (which lives on `main.gd`, dismissed before scrapyard entry) or S17.1-005's skip button (adjacent in the same modal — sibling node, no overlap).
+
+## 7. Acceptance tests
+
+File: `godot/tests/test_sprint17_1_first_run_crate.gd` (headless, pattern per `test_sprint17_1_first_encounter_hud.gd`).
+
+- **AC-1 — First-run framing appears.** With `FirstRunState.reset("crate_first_run")` called, instantiate the modal and call `show_trick(crate_find_trick)`. Assert `_first_run_framing.visible == true` and `_first_run_framing.text != ""`.
+- **AC-2 — Second-run framing suppressed.** Call `FirstRunState.mark_seen("crate_first_run")`, then `show_trick(crate_find_trick)`. Assert `_first_run_framing.visible == false`.
+- **AC-3 — Non-crate trick never shows framing.** With `crate_first_run` unseen, call `show_trick(risk_for_reward_trick)`. Assert `_first_run_framing.visible == false` and `FirstRunState.has_seen("crate_first_run") == false` (no stray mark).
+- **AC-4 — Framing marks seen on show (not on resolve).** Unseen → `show_trick(crate_find_trick)` → assert `FirstRunState.has_seen("crate_first_run") == true` **before** any button press.
+- **AC-5 — Choice resolution unchanged.** After `show_trick`, emit a Choice A press; assert `resolved` fires with `("crate_find", "choice_a")` regardless of framing visibility. (Parity with existing modal behavior.)
+- **AC-6 — Framing copy matches spec.** Assert `_first_run_framing.text` equals the §4.2 string verbatim (guards against copy drift).
+
+Cleanup in each test: `FirstRunState.reset("crate_first_run")` before and after.
+
+## 8. Coordination (S17.1-003 / -004 / -005)
+
+- **S17.1-004 (first-encounter HUD explainer):** This design fully reuses S17.1-004's `FirstRunState` autoload (§5.2 reserved key `crate_first_run`, AC-6 tested). **Zero edits** to `first_run_state.gd` or `project.godot`. Two consumers of one persistence system — the "one system, two consumers" outcome Risk §first-run-persistence-infra-sprawl was mitigated for.
+- **S17.1-005 (random-event popup redesign):** This task edits the same modal (`trick_choice_modal.gd` / `.tscn`). The new `FirstRunFraming` label is a sibling of `TopRow` inside `VBox`, does not touch the `PreviewRow`, Skip button, or ESC-handler S17.1-005 added. Z-order stays in the existing `CanvasLayer` stack. Expect a small merge where S17.1-005 already landed; Nutts should rebase this branch on top of the merged S17.1-005.
+- **S17.1-003 (loadout tooltips):** No overlap — different scene.
+- **Coord risk:** None identified. Scope-gate verification passes by inspection: zero diffs to `godot/combat/**`, `godot/data/**`, `godot/arena/**`, `docs/gdd.md`.
+
+## 9. Complexity estimate
+
+**S** (small). Summary: one new `Label` node in one scene, ~15 LOC in one script, one new test file, reuses fully-shipped persistence. No new infra, no scope-gate risk, no scene restructuring.


### PR DESCRIPTION
Design doc for S17.1-006. Path **(a) contextualize** — one-line framing above the existing `crate_find` trick modal, gated by `FirstRunState.has_seen("crate_first_run")`.

- Reuses S17.1-004 `FirstRunState` autoload (zero edits to persistence infra)
- Presentation layer only — zero touches to `godot/data/**`, `godot/combat/**`, `godot/arena/**`, `docs/gdd.md`
- Complexity: **S** (one Label node + ~15 LOC + one test file)
- Cited issue: #107

See doc §3 for path-selection rationale vs `docs/kb/ux-vision.md`.