### PR TITLE
[S17.1-006] First-run crate contextual framing

### DIFF
--- a/godot/tests/test_runner.gd
+++ b/godot/tests/test_runner.gd
@@ -50,6 +50,7 @@ const SPRINT_TEST_FILES := [
 	"res://tests/test_sprint17_1_visible_tooltips.gd",
 	"res://tests/test_sprint17_1_first_encounter_hud.gd",
 	"res://tests/test_sprint17_1_random_event_popup.gd",
+	"res://tests/test_sprint17_1_first_run_crate.gd",
 ]
 
 var file_pass_count := 0

--- a/godot/tests/test_sprint17_1_first_run_crate.gd
+++ b/godot/tests/test_sprint17_1_first_run_crate.gd
@@ -1,0 +1,218 @@
+## Sprint 17.1-006 — First-run crate contextual framing
+## Usage: godot --headless --script tests/test_sprint17_1_first_run_crate.gd
+## Design: docs/design/s17.1-006-first-run-crate.md
+##
+## Covers design §7 acceptance tests:
+##   AC-1 — First-run framing appears for `crate_find`.
+##   AC-2 — Second-run framing suppressed (mark_seen already set).
+##   AC-3 — Non-crate trick never shows framing, never marks key.
+##   AC-4 — Framing marks seen on show (not on resolve).
+##   AC-5 — Choice resolution unchanged (resolved signal parity).
+##   AC-6 — Framing copy matches spec verbatim.
+##
+## Tests instantiate the packed scene (not script.new()) so @onready refs
+## resolve. Each test resets `crate_first_run` before + after.
+extends SceneTree
+
+var pass_count := 0
+var fail_count := 0
+var test_count := 0
+
+const MODAL_SCENE_PATH := "res://ui/trick_choice_modal.tscn"
+const CRATE_KEY := "crate_first_run"
+const EXPECTED_COPY := "Crates are optional loot. Opening might give you an item \u2014 or nothing."
+
+func _initialize() -> void:
+	print("=== S17.1-006 First-run crate framing tests ===\n")
+	_run_all_async()
+
+func _run_all_async() -> void:
+	await _run_all()
+	_reset_key()
+	print("\n=== Results: %d passed, %d failed, %d total ===" % [pass_count, fail_count, test_count])
+	if fail_count > 0:
+		quit(1)
+	else:
+		quit(0)
+
+func assert_eq(a, b, msg: String) -> void:
+	test_count += 1
+	if a == b:
+		pass_count += 1
+	else:
+		fail_count += 1
+		print("  FAIL: %s (got %s, expected %s)" % [msg, str(a), str(b)])
+
+func assert_true(cond: bool, msg: String) -> void:
+	test_count += 1
+	if cond:
+		pass_count += 1
+	else:
+		fail_count += 1
+		print("  FAIL: %s" % msg)
+
+func assert_false(cond: bool, msg: String) -> void:
+	assert_true(not cond, msg)
+
+func _frs() -> Node:
+	return get_root().get_node_or_null("FirstRunState")
+
+func _reset_key() -> void:
+	var frs := _frs()
+	if frs != null:
+		frs.call("reset", CRATE_KEY)
+
+func _crate_trick() -> Dictionary:
+	return {
+		"id": "crate_find",
+		"brottbrain_text": "...looks like a crate.",
+		"prompt": "Pry it open?",
+		"choice_a": {"label": "Crack it", "flavor_line": "Nice."},
+		"choice_b": {"label": "Walk past", "flavor_line": "Ok."},
+	}
+
+func _non_crate_trick() -> Dictionary:
+	return {
+		"id": "risk_for_reward",
+		"brottbrain_text": "Hmm.",
+		"prompt": "Take the risk?",
+		"choice_a": {"label": "Yes", "flavor_line": "bold."},
+		"choice_b": {"label": "No", "flavor_line": "safe."},
+	}
+
+func _spawn_modal() -> Node:
+	var scene: PackedScene = load(MODAL_SCENE_PATH)
+	if scene == null:
+		return null
+	var modal: Node = scene.instantiate()
+	get_root().add_child(modal)
+	return modal
+
+func _run_all() -> void:
+	await _test_ac1_first_run_framing_appears()
+	await _test_ac2_second_run_framing_suppressed()
+	await _test_ac3_non_crate_trick_never_shows_framing()
+	await _test_ac4_framing_marks_seen_on_show()
+	await _test_ac5_choice_resolution_unchanged()
+	await _test_ac6_framing_copy_matches_spec()
+
+# --- AC-1 ---
+func _test_ac1_first_run_framing_appears() -> void:
+	print("AC-1: first-run framing appears for crate_find")
+	_reset_key()
+	var modal := _spawn_modal()
+	assert_true(modal != null, "modal scene instantiates")
+	if modal == null:
+		return
+	await process_frame
+	modal.call("show_trick", _crate_trick())
+	await process_frame
+	var framing: Label = modal.get_node_or_null("Overlay/Panel/VBox/FirstRunFraming")
+	assert_true(framing != null, "FirstRunFraming label exists in scene")
+	if framing != null:
+		assert_true(framing.visible, "framing is visible on first run")
+		assert_true(framing.text != "", "framing text is non-empty")
+	modal.queue_free()
+	await process_frame
+	_reset_key()
+
+# --- AC-2 ---
+func _test_ac2_second_run_framing_suppressed() -> void:
+	print("AC-2: framing suppressed when key already seen")
+	_reset_key()
+	var frs := _frs()
+	assert_true(frs != null, "FirstRunState autoload present")
+	if frs == null:
+		return
+	frs.call("mark_seen", CRATE_KEY)
+	var modal := _spawn_modal()
+	if modal == null:
+		return
+	await process_frame
+	modal.call("show_trick", _crate_trick())
+	await process_frame
+	var framing: Label = modal.get_node_or_null("Overlay/Panel/VBox/FirstRunFraming")
+	if framing != null:
+		assert_false(framing.visible, "framing is hidden on second run")
+	modal.queue_free()
+	await process_frame
+	_reset_key()
+
+# --- AC-3 ---
+func _test_ac3_non_crate_trick_never_shows_framing() -> void:
+	print("AC-3: non-crate trick never shows framing, never marks key")
+	_reset_key()
+	var modal := _spawn_modal()
+	if modal == null:
+		return
+	await process_frame
+	modal.call("show_trick", _non_crate_trick())
+	await process_frame
+	var framing: Label = modal.get_node_or_null("Overlay/Panel/VBox/FirstRunFraming")
+	if framing != null:
+		assert_false(framing.visible, "framing is hidden for non-crate trick")
+	var frs := _frs()
+	if frs != null:
+		assert_false(bool(frs.call("has_seen", CRATE_KEY)), "crate_first_run remains unseen after non-crate trick")
+	modal.queue_free()
+	await process_frame
+	_reset_key()
+
+# --- AC-4 ---
+func _test_ac4_framing_marks_seen_on_show() -> void:
+	print("AC-4: framing marks key seen on show (before any button press)")
+	_reset_key()
+	var frs := _frs()
+	if frs == null:
+		return
+	assert_false(bool(frs.call("has_seen", CRATE_KEY)), "baseline: key unseen")
+	var modal := _spawn_modal()
+	if modal == null:
+		return
+	await process_frame
+	modal.call("show_trick", _crate_trick())
+	await process_frame
+	# No button press has occurred; key must already be flipped.
+	assert_true(bool(frs.call("has_seen", CRATE_KEY)), "key marked seen on show, not on resolve")
+	modal.queue_free()
+	await process_frame
+	_reset_key()
+
+# --- AC-5 ---
+func _test_ac5_choice_resolution_unchanged() -> void:
+	print("AC-5: resolved signal still fires with (trick_id, choice_key) for crate_find")
+	_reset_key()
+	var modal := _spawn_modal()
+	if modal == null:
+		return
+	await process_frame
+	modal.call("show_trick", _crate_trick())
+	await process_frame
+	# Press Choice A directly. `_on_choice` is async (awaits tween timers)
+	# totaling ~1.25s. Await the `resolved` signal instead of polling.
+	modal.call("_on_choice", "choice_a")
+	var result: Array = await modal.resolved
+	var tid: String = String(result[0]) if result.size() > 0 else ""
+	var key: String = String(result[1]) if result.size() > 1 else ""
+	assert_eq(tid, "crate_find", "resolved tid == crate_find")
+	assert_eq(key, "choice_a", "resolved key == choice_a")
+	modal.queue_free()
+	await process_frame
+	_reset_key()
+
+# --- AC-6 ---
+func _test_ac6_framing_copy_matches_spec() -> void:
+	print("AC-6: framing copy matches §4.2 verbatim")
+	_reset_key()
+	var modal := _spawn_modal()
+	if modal == null:
+		return
+	await process_frame
+	modal.call("show_trick", _crate_trick())
+	await process_frame
+	var framing: Label = modal.get_node_or_null("Overlay/Panel/VBox/FirstRunFraming")
+	if framing != null:
+		assert_eq(framing.text, EXPECTED_COPY, "framing text matches spec")
+	modal.queue_free()
+	await process_frame
+	_reset_key()

--- a/godot/tests/test_sprint17_1_first_run_crate.gd.uid
+++ b/godot/tests/test_sprint17_1_first_run_crate.gd.uid
@@ -1,0 +1,1 @@
+uid://bnbopl17glw8d

--- a/godot/ui/trick_choice_modal.gd
+++ b/godot/ui/trick_choice_modal.gd
@@ -10,7 +10,13 @@ signal resolved(trick_id: String, choice_key: String)
 @onready var _btn_skip: Button = $Overlay/Panel/VBox/Buttons/Skip
 @onready var _preview_a: Label = $Overlay/Panel/VBox/PreviewRow/PreviewA
 @onready var _preview_b: Label = $Overlay/Panel/VBox/PreviewRow/PreviewB
+@onready var _first_run_framing: Label = $Overlay/Panel/VBox/FirstRunFraming
 @onready var _toast: Label = $Overlay/Toast
+
+## S17.1-006 — First-run contextual framing for the `crate_find` trick.
+## Key reserved by S17.1-004 (see first_run_state.gd §Consumers).
+const CRATE_FIRST_RUN_KEY := "crate_first_run"
+const CRATE_FRAMING_TEXT := "Crates are optional loot. Opening might give you an item \u2014 or nothing."
 var _trick: Dictionary = {}
 # S13.8: one-shot guard. Modal instances are single-use; shop_screen creates
 # a fresh instance per visit, so we don't reset this. Re-entry is a no-op.
@@ -30,6 +36,7 @@ func show_trick(trick: Dictionary) -> void:
 	_btn_b.text = trick.get("choice_b", {}).get("label", "")
 	_btn_skip.text = "Not now"
 	_toast.visible = false
+	_maybe_show_first_run_framing(trick)
 	_overlay.modulate.a = 0.0
 	_btn_a.pressed.connect(func(): _on_choice("choice_a"))
 	_btn_b.pressed.connect(func(): _on_choice("choice_b"))
@@ -155,3 +162,33 @@ func _on_skip() -> void:
 	await tw.finished
 	var tid: String = String(_trick.get("id", ""))
 	resolved.emit(tid, "skip")
+
+## S17.1-006 — First-run framing: show a one-line context label above the
+## existing dialogue the first time the player encounters a `crate_find`
+## trick. `mark_seen` fires on show (not on resolve), so Skip / ESC / any
+## dismissal still counts as having seen the framing. See design §4.
+func _maybe_show_first_run_framing(trick: Dictionary) -> void:
+	if _first_run_framing == null:
+		return
+	_first_run_framing.visible = false
+	if String(trick.get("id", "")) != "crate_find":
+		return
+	var frs: Node = _get_first_run_state()
+	if frs == null:
+		return
+	if bool(frs.call("has_seen", CRATE_FIRST_RUN_KEY)):
+		return
+	_first_run_framing.text = CRATE_FRAMING_TEXT
+	_first_run_framing.visible = true
+	frs.call("mark_seen", CRATE_FIRST_RUN_KEY)
+
+func _get_first_run_state() -> Node:
+	if not is_inside_tree():
+		return null
+	var tree := get_tree()
+	if tree == null:
+		return null
+	var root := tree.get_root()
+	if root == null:
+		return null
+	return root.get_node_or_null("FirstRunState")

--- a/godot/ui/trick_choice_modal.tscn
+++ b/godot/ui/trick_choice_modal.tscn
@@ -17,6 +17,12 @@ offset_top = -170.0
 offset_right = 300.0
 offset_bottom = 170.0
 [node name="VBox" type="VBoxContainer" parent="Overlay/Panel"]
+[node name="FirstRunFraming" type="Label" parent="Overlay/Panel/VBox"]
+visible = false
+modulate = Color(0.75, 0.75, 0.75, 1)
+autowrap_mode = 3
+horizontal_alignment = 1
+theme_override_font_sizes/font_size = 13
 [node name="TopRow" type="HBoxContainer" parent="Overlay/Panel/VBox"]
 [node name="Portrait" type="ColorRect" parent="Overlay/Panel/VBox/TopRow"]
 custom_minimum_size = Vector2(80, 80)


### PR DESCRIPTION
## Summary

Implements **[S17.1-006]** — first-run crate contextual framing. Sixth and final task of sub-sprint S17.1.

Adds a one-line context Label ("Crates are optional loot. Opening might give you an item — or nothing.") above the `crate_find` trick modal on the player's first encounter. Resolves the playtest complaint: *"the screen asking whether i want to open a crate was jarring to be the first thing i see."*

## References

- Design doc: [`docs/design/s17.1-006-first-run-crate.md`](https://github.com/brott-studio/battlebrotts-v2/pull/174) (Gizmo, PR #174)
- Sub-sprint plan: `sprints/sprint-17.1.md`
- Arc brief: `sprints/sprint-17.md`
- Cited issue: #107
- Prior-art persistence: S17.1-004 (PR #168) — `FirstRunState` autoload; reserved key `crate_first_run` was AC-6 verified there

## Design pattern

Pattern **(a) Contextualize** per design §3. One-line framing Label added above the existing dialogue, gated on `trick.id == "crate_find"` AND `FirstRunState.has_seen("crate_first_run") == false`. `mark_seen` fires on **show** (not on resolve) so ESC / Skip / Not-now all count as having seen the framing — one-shot, matches S17.1-004 philosophy.

## Changes (4 files; scope-clean)

| File | Change | LoC |
|---|---|---|
| `godot/ui/trick_choice_modal.tscn` | New `FirstRunFraming` Label as first child of `VBox` (above `TopRow`). Hidden by default; autowrap; centered; `modulate = Color(0.75, …)`; `font_size = 13`. | +6 |
| `godot/ui/trick_choice_modal.gd` | `_maybe_show_first_run_framing()` helper + `@onready` ref + `_get_first_run_state()` lookup. Called from `show_trick()` after dialogue/prompt population. | +37 |
| `godot/tests/test_sprint17_1_first_run_crate.gd` | **NEW.** Headless test suite covering design §7 AC-1..AC-6 via scene instantiation. | +218 |
| `godot/tests/test_runner.gd` | Register new test file. | +1 |
| `godot/tests/test_sprint17_1_first_run_crate.gd.uid` | Godot-generated sidecar for the new script (matches the pattern for every other `.gd` test file on main). | +1 |

**Zero edits to** `godot/ui/first_run_state.gd`, `godot/project.godot`, `godot/data/**`, `godot/combat/**`, `godot/arena/**`, `docs/gdd.md` — scope-gate clean by inspection.

## Acceptance tests

All six ACs from design §7 pass locally:

- **AC-1** — First-run framing appears for `crate_find` with fresh `FirstRunState`.
- **AC-2** — Framing suppressed when `crate_first_run` already marked seen.
- **AC-3** — Non-crate trick never shows framing and never marks the key.
- **AC-4** — Framing marks key seen on show (not on button-press resolve).
- **AC-5** — `resolved(trick_id, choice_key)` signal still fires correctly after framing path — parity with existing modal behavior preserved.
- **AC-6** — Framing copy matches §4.2 verbatim.

## Local verification

```
=== Sprint-file results: 30 files passed, 0 files failed ===
=== OVERALL: inline PASS | sprint files PASS ===
```

S17.1-001..005 + S13.8 regression suites all green locally. New file `test_sprint17_1_first_run_crate.gd`: 13/13 pass.

## Review path

Boltz reviews → Optic verifies → Specc approves+merges (strict order).

## Author

Nutts (build agent, battlebrotts-v2). Reviewed-by-plan: HCD.
