### PR TITLE
[S17.2] Spec: scout feel — nimble, not magical

### DIFF
--- a/docs/design/s17.2-scout-feel.md
+++ b/docs/design/s17.2-scout-feel.md
@@ -1,0 +1,384 @@
+# [S17.2] Scout Feel — Nimble, Not Magical
+
+**Author:** Gizmo (design)
+**Sprint:** S17.2 (S17 Eve Polish Arc)
+**Task:** Phase-1 spec for scout-feel pass. Ett will slot this into the S17.2 plan as the blueprint for the implementation task (tentatively `[S17.2-003]`).
+**Scope:** Movement feel of the Scout chassis. Velocity-direction smoothing + angular-velocity cap + optional reversal damping. No base-speed change. No combat-balance change. No GDD touch.
+**Sprint gate:** S17 scope gate still in force. See §0.
+
+---
+
+## 0. Scope discipline (read first)
+
+Per `sprints/sprint-17.md` scope gate:
+
+- ✅ Modify `godot/combat/combat_sim.gd` — add a velocity-smoothing layer (new helpers) and re-route combat-movement position writes through it.
+- ✅ Modify `godot/combat/brott_state.gd` — add a real `velocity` vector as a first-class movement field and expose `max_angular_velocity` / `accel_cap` derived stats.
+- ✅ Add a tunable-constants block (values live in `combat_sim.gd`, NOT `chassis_data.gd`, to preserve the scope-gate on `godot/data/**`).
+- ❌ No change to `godot/data/chassis_data.gd` Scout row (speed/accel/decel/turn_speed stay).
+- ❌ No change to any `godot/data/**` file (weapon, armor, module).
+- ❌ No change to `docs/gdd.md`.
+- ❌ No change to Scout's agility archetype identity. "Fastest chassis" stays true.
+- ❌ No scope-creep into the wall-stuck bug. That's a sibling task (`[S17.2-001]/[S17.2-002]`). §7 notes the intersection only.
+
+**Scope-gate touches of `godot/combat/**`:** these are explicitly permitted by `sprint-17.md` §"Sub-sprint breakdown / S17.2" ("Scout movement feel pass") and by the arc-level "Gizmo invariant" clause requiring Gizmo to name concrete angular-velocity caps / commit-window values. No balance-number edits — the numbers we touch are *movement smoothing parameters*, not weapon/HP/damage.
+
+---
+
+## 1. Problem statement
+
+### 1.1 HCD framing (verbatim, 2026-04-18 playtest)
+
+> It's obviously very easy for computer objects to move in any way possible. Things in computer world can change direction instantaneously. This breaks immersion for bot-like characters because real-life objects don't work like this. Real life object (including very nimble ones!) have to shift weight and shift direction over time. And if we imagine that brotts are on wheels (I'm assuming?) then the wheels must take time to turn and things like that. Or even if it's a multi-directional wheel, it still has to slow down before switching direction (even if nimbly). This subtle difference is very noticeable for humans and makes the difference between random flashes of light on a screen and a life-like moving object. I'm not against scouts being nimble and fast - that's the point of the character, however, I didn't like how they didn't feel life-like.
+
+### 1.2 Playback (HCD-approved design invariants)
+
+- The problem is **NOT** speed. Scouts stay fast.
+- The problem is **instantaneous direction change**. Real objects have rotational + translational inertia: `decelerate → rotate → re-accelerate` in an arc.
+- Target feel: **nimble but physical.** Fast direction changes, but with a visible arc.
+- Invariant: **"Scouts are nimble, not magical."**
+  - Nimble = high max angular velocity + high translational acceleration + low mass feel.
+  - Magic = instantaneous reversal.
+  - Scouts get the first. **NOT** the second.
+
+### 1.3 Supporting playtest quotes (from S17 arc brief, citations 1)
+
+> "scout still feels a little bit too fast to follow. or maybe it's the changing directions is so fast, it makes it feel like I'm watching mice run around rather than weighty brotts"
+> "the way scout moves is so crazy fast, ruins the robot feel"
+> "its movements are very jerky too"
+
+Note the "jerky" complaint is a second-order signal: **jerk** (derivative of acceleration) is literally infinite on a sign-flip-velocity step. HCD's instinct is correct at the physics-math level, not just the aesthetic level.
+
+---
+
+## 2. Current implementation audit
+
+### 2.1 Movement loop shape
+
+`combat_sim.gd` is a tick-based sim at **10 Hz** (`TICKS_PER_SEC = 10`, `TICK_DELTA = 0.1`). This is the first critical fact: at 10 Hz, a 1-frame direction-flip is a **100 ms** discontinuity. That's above the ~50 ms threshold where humans start perceiving motion as "teleport-like," which matches HCD's "flashes of light on a screen" language exactly.
+
+### 2.2 How Brotts actually move — position writes, not physics
+
+Brotts do **not** use Godot physics (`CharacterBody2D.move_and_slide` / `RigidBody2D._integrate_forces`). The entire sim is custom tick math over `Vector2` positions. Search results from `godot/combat/combat_sim.gd`:
+
+- Direct `b.position += <direction> * <scalar>` writes: ~15 sites (lines 449, 463, 505, 510, 516, 518, 520, 570, 572, 574, 576, 662, 664, 666, 775, 784, 788, 794, 806, 812, 832).
+- No `b.velocity` vector field exists — `brott_state.gd:28` declares `var velocity: Vector2 = Vector2.ZERO` but **grep confirms it is never read or written in `combat_sim.gd`**. It is vestigial.
+- `var current_speed: float` (`brott_state.gd:29`) is the only speed state. It is a **scalar**.
+
+### 2.3 What IS smoothed today (speed magnitude)
+
+`brott_state.gd:116-121` exposes:
+
+```gdscript
+func accelerate_toward_speed(target_speed: float, dt: float) -> void:
+    if current_speed < target_speed:
+        current_speed = minf(current_speed + get_effective_accel() * dt, target_speed)
+    elif current_speed > target_speed:
+        current_speed = maxf(current_speed - get_effective_decel() * dt, target_speed)
+```
+
+Every movement site calls `b.accelerate_toward_speed(target, TICK_DELTA)` before computing `spd = b.current_speed * TICK_DELTA` and then `b.position += direction * spd`. So **speed magnitude is smoothed** via the chassis `accel` / `decel` values (`chassis_data.gd:14-15`: Scout `accel=660`, `decel=880` px/s²).
+
+### 2.4 What is NOT smoothed today (direction)
+
+The `direction` vector passed into every `b.position += direction * spd` write is **recomputed from scratch every tick** from `to_target = b.target.position - b.position` (or perpendicular-to-target, or unstick-nudge direction). There is **zero smoothing** between last tick's direction and this tick's direction.
+
+Specifically: during the TCR state machine (see `combat_sim.gd:758-835`), the three phases TENSION / COMMIT / RECOVERY each compute a fresh direction vector every tick. A phase transition — e.g., the end of a 0.8s COMMIT dash flipping into a RECOVERY retreat — writes a position delta along a vector that is **the algebraic negative** of the previous tick's vector, within one tick, with no velocity-vector continuity.
+
+At Scout's `current_speed ≈ 200 px/s` (commit-speed cap, `combat_sim.gd:46`), a 180° flip in one tick is:
+
+- Velocity-vector magnitude change: from `+200` to `-200` in `0.1s` → effective acceleration of `4000 px/s²`.
+- Scout's chassis `accel` (660) and `decel` (880) are already being used, but **only to control the scalar `current_speed`**, not the vector. The vector can still snap instantly.
+
+### 2.5 Visual rotation (`facing_angle`) — already smoothed, but visual-only
+
+`combat_sim.gd:527-536` smooths `b.facing_angle` toward `desired_angle` at `b.turn_speed * TICK_DELTA` (Scout `turn_speed=360°/s`). This is the sprite-rotation display. Per `brott_state.gd:20` comment: **"visual only (°/s)"** — it does not gate movement. The bot's body arrow on screen points wherever `facing_angle` is, but the bot's *motion* direction is completely independent.
+
+This is the core visual mismatch producing the "mice running" read: the sprite appears to face one way, but the position can snap in a totally different direction the same tick. The eye reads two contradictory signals. See §3.
+
+### 2.6 Chassis data for reference (no change proposed here)
+
+```
+SCOUT:    speed=220, accel=660,  decel=880,  turn_speed=360°/s   (visual only)
+BRAWLER:  speed=120, accel=240,  decel=360,  turn_speed=240°/s
+FORTRESS: speed= ~,  accel=...,  decel=...,  turn_speed=...°/s
+```
+
+Scout is already the highest-accel, highest-turn-speed chassis. Those numbers do NOT need to change. The problem is that `turn_speed` is visual-only and the vector-direction pipeline ignores the physical arc implied by those numbers.
+
+---
+
+## 3. Root cause
+
+Restated precisely:
+
+1. **Velocity is scalar-only.** The sim has no `velocity: Vector2` it updates and respects tick-to-tick. It computes a fresh direction every tick and multiplies by a smoothed scalar speed.
+2. **Direction is derived, not stateful.** "Where am I going?" is re-derived every tick from the current geometric relationship to the target (or TCR phase, or separation push). Last tick's direction is thrown away.
+3. **Angular velocity is unmodeled in the motion layer.** The physical concept "it takes time to rotate the velocity vector" is not represented anywhere in the movement code. The `turn_speed` field models it for the *sprite*, but nothing physical.
+4. **Phase transitions are the worst offenders.** TENSION orbit (tangential) → COMMIT dash (radial in) → RECOVERY retreat (radial out) all happen in consecutive ticks with sign-flipped direction vectors. For Scout, this creates the "mice scurrying / jerky" read on every engagement cycle.
+5. **Unstick nudge adds a fourth discontinuity.** When a bot is flagged stuck (`_check_and_handle_stuck`, `combat_sim.gd:630`), the nudge direction can be near-orthogonal or opposite to the current travel direction, with no smoothing.
+
+**Quantified:** Scout peak `current_speed` in commit is `min(220*1.4, 200) = 200 px/s`. A phase-end direction reversal is a vector change of `400 px/s` in `0.1s` = **`4000 px/s²` effective vector acceleration**, which is **6× Scout's chassis `accel` of 660 px/s²**. The physics the chassis data implies is being violated by the motion layer, every phase transition.
+
+---
+
+## 4. Proposed design
+
+### 4.1 Two new concepts in `brott_state.gd`
+
+Add real vector state, replacing the scalar-only model:
+
+```gdscript
+# S17.2: True velocity vector. Source of truth for position updates.
+var velocity: Vector2 = Vector2.ZERO  # (already declared, vestigial — now used)
+
+# S17.2: Per-chassis angular-velocity cap (rad/s). Derived at setup() from
+# chassis data; NOT a data-file field (no data/ edit).
+var max_angular_velocity: float = 0.0  # rad/s
+```
+
+Chassis-specific derivation (inside `brott_state.gd::setup()`), gated by `chassis_type` without touching `chassis_data.gd`:
+
+```gdscript
+# S17.2: angular-velocity cap. Hand-tuned, not data-driven, to keep data/** sacred.
+match chassis_type:
+    ChassisData.ChassisType.SCOUT:   max_angular_velocity = deg_to_rad(540.0)  # 1.5 turns/s
+    ChassisData.ChassisType.BRAWLER: max_angular_velocity = deg_to_rad(270.0)
+    ChassisData.ChassisType.FORTRESS:max_angular_velocity = deg_to_rad(150.0)
+```
+
+### 4.2 Velocity-smoothing helper (new, `combat_sim.gd`)
+
+All combat-movement position writes route through one helper. Replace the scalar-only path with:
+
+```gdscript
+# S17.2: Smooth velocity vector toward a desired (direction × scalar-speed) vector,
+# respecting the chassis angular-velocity cap and translational accel/decel.
+# `desired` is the vector the caller WANTS this tick (e.g., `to_target.normalized() * commit_spd`).
+# Returns the actual displacement to apply to b.position this tick.
+func _smooth_velocity(b: BrottState, desired: Vector2, dt: float) -> Vector2:
+    var cur := b.velocity
+    var des := desired  # magnitude is already the per-tick target speed scaled by dt? No — see §4.3.
+    # Step 1: rotate current velocity toward desired direction, capped by max_angular_velocity.
+    if cur.length_squared() > 0.0001 and des.length_squared() > 0.0001:
+        var cur_angle := cur.angle()
+        var des_angle := des.angle()
+        var angle_diff := wrapf(des_angle - cur_angle, -PI, PI)
+        var max_rot := b.max_angular_velocity * dt
+        var rot := clampf(angle_diff, -max_rot, max_rot)
+        cur = cur.rotated(rot)
+    # Step 2: blend magnitude toward desired magnitude at chassis accel/decel rates.
+    var cur_mag := cur.length()
+    var des_mag := des.length()
+    var mag_delta: float
+    if des_mag > cur_mag:
+        mag_delta = minf(b.get_effective_accel() * dt, des_mag - cur_mag)
+    else:
+        mag_delta = -minf(b.get_effective_decel() * dt, cur_mag - des_mag)
+    var new_mag := cur_mag + mag_delta
+    var new_dir := cur.normalized() if cur.length_squared() > 0.0001 else des.normalized()
+    b.velocity = new_dir * new_mag
+    # Step 3: apply reversal damping if angle diff was ≥ REVERSAL_ANGLE_THRESHOLD.
+    # (See §4.4 — optional "plant foot" dip.)
+    return b.velocity * dt
+```
+
+### 4.3 Integration with existing sites
+
+Every current write of the shape `b.position += direction * spd` becomes:
+
+```gdscript
+# Before
+b.position += to_target.normalized() * commit_spd
+
+# After
+var desired_vel := to_target.normalized() * b.current_speed  # per-second vector
+b.position += _smooth_velocity(b, desired_vel, TICK_DELTA)
+```
+
+Key: the existing `accelerate_toward_speed` / `current_speed` scalar system stays intact (it's already correctly driven by brain / TCR phase / afterburner). We just use `current_speed` as the **target magnitude** of the velocity vector instead of as the direct displacement. The smoothing layer bridges desired-vector → actual-vector → displacement.
+
+### 4.4 Reversal damping (optional "plant foot" dip)
+
+When a phase transition produces an angle diff `|Δθ| > REVERSAL_ANGLE_THRESHOLD` (proposed `120°`), scale the target magnitude down by `REVERSAL_DAMPING_FACTOR` (proposed `0.35`) for `REVERSAL_DAMPING_TICKS` (proposed `2` = 200 ms). This creates a brief "decelerate-plant-rotate-accelerate" visible beat on hard reversals, matching HCD's wheels-turning intuition. Implementation: a short timer `b.reversal_damping_timer: float` on `BrottState`, armed when `_smooth_velocity` detects a large angle diff, consumed by the magnitude step.
+
+### 4.5 Proposed constants (all in `combat_sim.gd` — NOT `chassis_data.gd`)
+
+```gdscript
+# S17.2: Scout-feel constants. Kept in combat_sim.gd to preserve the data/** scope gate.
+const REVERSAL_ANGLE_THRESHOLD_DEG: float = 120.0   # angle diff that triggers "plant foot"
+const REVERSAL_DAMPING_FACTOR: float = 0.35         # target-mag scale during damping
+const REVERSAL_DAMPING_TICKS: int = 2               # ticks of damping (200 ms)
+```
+
+Per-chassis max-angular-velocity values (set in `brott_state.gd::setup()`):
+
+| Chassis  | max_angular_velocity | Reasoning                                                 |
+|----------|----------------------|------------------------------------------------------------|
+| SCOUT    | 540°/s (9.4 rad/s)   | Fast arc; at 200 px/s this is ~3.5 px of chord per 1° of turn — highly nimble, but NOT instantaneous. A full 180° pivot takes ~333 ms; a 90° turn takes ~167 ms (≈1.7 ticks). Fast, but visible. |
+| BRAWLER  | 270°/s               | Half of Scout. Deliberate. Reads as "tracked vehicle."     |
+| FORTRESS | 150°/s               | Siege-walker. Turns like a tank. Intentional.             |
+
+---
+
+## 5. Nimble-vs-weighty calibration
+
+### 5.1 Why these numbers are on the "nimble" end
+
+The reference benchmark is HCD's verbatim invariant: **"Scouts are nimble, not magical."**
+
+For Scout, the proposed values give:
+
+- **180° reversal time:** 333 ms (from 540°/s cap). That's about **3 ticks**. HCD can *see* the arc happen across 3 frames, but it resolves well under human reaction time.
+- **Translational accel unchanged:** 660 px/s². From a dead stop, Scout hits peak 200 px/s commit speed in `200 / 660 ≈ 303 ms`. Already fast.
+- **Reversal damping tuned low:** 0.35× target mag for 200 ms. This is a *dip*, not a *stop*. Scout never fully plants its wheels; it just visibly loses ~65% of its target speed for two ticks. This produces the pivot-silhouette without killing pursuit urgency.
+
+Qualitatively: a Scout mid-commit that flips into recovery will show ~100 ms of decel, ~200 ms of rotation overlapping the end of decel, then ~150 ms of re-accel. Total visible-arc window: ~300–400 ms, which is exactly the "nimble but physical" regime HCD described.
+
+### 5.2 Contrast — what a "weighty tank" Scout would look like (REJECTED)
+
+For the same spec structure, a tank-feel Scout would be:
+
+| Param                        | Nimble (proposed) | Weighty tank (contrast — REJECTED) |
+|------------------------------|-------------------|-------------------------------------|
+| `max_angular_velocity`       | 540°/s            | 120°/s                              |
+| `REVERSAL_DAMPING_FACTOR`    | 0.35              | 0.05 (near-full stop)               |
+| `REVERSAL_DAMPING_TICKS`     | 2 (200 ms)        | 6 (600 ms)                          |
+| `base_accel` (would require data edit) | 660      | 200                                 |
+
+Weighty-tank 180° reversal time would be ~1500 ms (15 ticks). That's a *second and a half* of visible planting — way too slow. Scout would feel like Brawler. HCD explicitly rejects this: "I'm not against scouts being nimble and fast - that's the point of the character."
+
+The proposed numbers are **deliberately closer to "magical" than to "weighty"** on the spectrum, because magical was only off by a few hundred milliseconds of visible arc. We do NOT want to overshoot.
+
+### 5.3 Agility-archetype preservation
+
+Scout remains:
+
+- Highest base speed (220 px/s, unchanged).
+- Highest accel (660 px/s², unchanged).
+- Highest angular velocity (540°/s, new but consistent with highest `turn_speed` today).
+- Lowest reversal damping threshold effective time (200 ms — Brawler/Fortress unchanged; if we later extend this to them, they get longer dips).
+
+No delta to Scout's agility archetype identity in the GDD sense. It still out-classes Brawler/Fortress on every agility metric by ≥2× ratio. The change is that instantaneous warps are replaced by very-fast-but-finite warps.
+
+---
+
+## 6. Alternative approaches considered
+
+### 6.1 Alt A — Lower Scout base_speed (REJECTED)
+
+Reduce `speed` from 220 to ~150. Would nominally reduce the perception of "mice running."
+
+**Rejected because:**
+- HCD explicitly said "I'm not against scouts being nimble and fast." Speed reduction is the wrong axis.
+- Violates scope gate (`godot/data/**` is sacred for S17).
+- Doesn't fix the jerk / direction-flip problem — a 150 px/s scalar that still flips sign in one tick is still jerky.
+
+### 6.2 Alt B — Smooth only the visual sprite (sync `facing_angle` to movement direction) (REJECTED)
+
+Make the sprite lag behind the motion, so even if the body still snaps, the visible rotation smooths.
+
+**Rejected because:**
+- Visual-only fix for a motion-layer problem. HCD's complaint isn't that the sprite is spinning weirdly; it's that the *object* is teleport-turning. Smoothing the sprite without smoothing the body would create a worse decoherence: sprite saying "still going east" while body is already west.
+- The underlying "physics feels unreal" critique doesn't resolve — the bot still covers impossible ground on a phase transition.
+
+### 6.3 Alt C — Convert sim to Godot `RigidBody2D._integrate_forces` physics (REJECTED)
+
+Let the engine apply force → mass → acceleration natively.
+
+**Rejected because:**
+- Massive rewrite; the deterministic-tick model (required for JSON log replay, test harness, and combat_sim batch tooling) would break.
+- The sim depends on tick-exact positional reproducibility for the test suite. RigidBody2D would diverge per-frame.
+- 10-Hz tick granularity is a hard constraint from the pacing decisions. Physics would fight it.
+- Out of scope for a polish arc; would be a whole combat-rearch sprint.
+
+### 6.4 Alt D — Chosen approach — vector-velocity smoothing with per-chassis angular cap
+
+**Accepted** because it's surgical (one helper, a dozen call-site swaps), preserves determinism (pure math on existing tick state), and directly addresses the named root cause (velocity direction has no inertia model). See §4.
+
+---
+
+## 7. Wall-stuck intersection note
+
+**Short answer:** the scout-feel code and the wall-stuck code share a **file** (`combat_sim.gd`) but NOT a **root cause**. Addressing scout-feel will NOT incidentally fix wall-stuck.
+
+Evidence:
+
+- Wall-stuck triggers in `_check_and_handle_stuck` at `combat_sim.gd:630` via the `_stuck_history` window: if displacement over 15 ticks < 10 px, arm an 8-tick unstick maneuver.
+- The unstick maneuver writes `b.position += nudge * UNSTICK_NUDGE_PX_PER_TICK` at `combat_sim.gd:665`. This is one of the 15+ position-write sites that the new `_smooth_velocity` helper would route through.
+- Smoothing the unstick nudge through the new velocity pipeline could actually make wall-stuck **slightly worse** in edge cases: if the bot's current velocity is facing INTO the wall (which is why it got stuck), the angular-velocity cap would add ~100–300 ms of "rotate out of wall direction" lag before the nudge becomes effective.
+
+**Implication for sprint plan:** the scout-feel task (`[S17.2-003]` or renumbered) must be implemented AFTER the wall-stuck root-cause investigation (`[S17.2-001]`), so the wall-stuck patch can account for the new velocity-smoothing layer. If scout-feel lands first, the unstick path should probably BYPASS `_smooth_velocity` (write directly to `b.position`, same as today) until wall-stuck is resolved. See §11 open questions for Ett.
+
+**No scope creep in this spec.** The wall-stuck root cause is a separate investigation and its own patch. This spec only notes that the two tasks must be ordered and that the unstick write-site needs an opt-out flag.
+
+---
+
+## 8. Acceptance criteria
+
+Behavioral / qualitative (HCD / Optic will judge):
+
+- **AC-1 Visible-arc test.** In a canned scenario where Scout commits toward an enemy and the enemy moves behind Scout, Scout must take **≥ 3 ticks (300 ms)** to complete the 180° turn. Verifiable by sampling `b.velocity.angle()` per tick across the phase transition.
+- **AC-2 No straight-line slowdown.** On straight-line approach (no phase transition) from stop, Scout must still reach peak `current_speed` within the same number of ticks as today (±1 tick). Translational accel untouched.
+- **AC-3 Pursuit still closes.** Given a fleeing Brawler, Scout still closes the gap in a comparable number of ticks to today — acceptable regression: up to **+15%** tick-count in chase scenarios.
+- **AC-4 Phase-transition damping visible.** On a COMMIT → RECOVERY transition, `b.current_speed` magnitude must dip by ≥ 35% for 2 ticks (the reversal damping window). Log-verifiable.
+- **AC-5 No teleport.** Over any 3-tick window, the position delta must satisfy `|Δp| ≤ base_speed * 1.5 * 3 * TICK_DELTA + small_epsilon`. If this fails, a smoothing bug has leaked.
+- **AC-6 HCD subjective read.** In Optic visual-diff (old-Scout vs new-Scout), the scout movement reads as "brott" not "mouse" per S17 arc acceptance criterion.
+
+Testable / automated:
+
+- **AC-T1** Unit test: `_smooth_velocity(cur=Vector2(200,0), desired=Vector2(-200,0), dt=0.1)` returns a vector whose angle is rotated by at most `max_angular_velocity * 0.1` from the current vector's angle.
+- **AC-T2** Replay-determinism: with a fixed RNG seed, two runs of the same match must produce byte-identical JSON logs. No new float-order nondeterminism introduced.
+- **AC-T3** Regression: the full existing test suite must pass unchanged. No test quarantining. (Hard requirement per S17 arc framework gates.)
+
+---
+
+## 9. Tuning plan
+
+**Assume one tuning pass is needed post-implementation.** The concrete numbers in §4.5 are first-draft educated values; getting feel exactly right requires HCD's eye on a live build.
+
+Nutts should expose (all in `combat_sim.gd`, NOT data files):
+
+- `MAX_ANGULAR_VELOCITY_SCOUT_DEG: float` — default 540, tunable.
+- `REVERSAL_ANGLE_THRESHOLD_DEG: float` — default 120, tunable.
+- `REVERSAL_DAMPING_FACTOR: float` — default 0.35, tunable.
+- `REVERSAL_DAMPING_TICKS: int` — default 2, tunable.
+
+**Debug overlay (recommended, non-blocking):** a dev-only toggle that draws, for each bot, a short vector representing `b.velocity` and a second vector representing `desired` this tick. Makes the rotation-lag visible in the arena viewer. Nutts can implement via `arena_renderer.gd` with a dev flag. If too much scope, defer to a carry-forward.
+
+**Playtest-ready drop:** after the tuning pass lands, the build should go to HCD for a 5-minute feel check before the S17.2 audit closes. "Does this read as brott vs mouse?" is a one-question check that doesn't need a full playtest session.
+
+---
+
+## 10. Files/symbols for Nutts
+
+| File                          | Edit                                                              | LoC est. | Complexity |
+|-------------------------------|-------------------------------------------------------------------|----------|------------|
+| `godot/combat/brott_state.gd` | Activate `velocity` field, add `max_angular_velocity`, add `reversal_damping_timer`, set in `setup()`. | ~15 | S |
+| `godot/combat/combat_sim.gd`  | Add `_smooth_velocity` helper (~40 LoC). Add 4 new constants. Replace ~15 call sites of `b.position += dir * spd` with two-line `desired_vel + _smooth_velocity` form. Add opt-out path for unstick nudge (pass `bypass_smoothing=true` until wall-stuck resolved). | ~90 | M |
+| `godot/tests/` (new file)     | `test_s17_2_scout_feel.gd`: unit tests for `_smooth_velocity`, AC-T1 above. | ~60 | S |
+
+**Total estimated complexity: M (medium).** Larger than a typical S17.1 task because it touches the hot movement loop, but smaller than a data-refactor because the change is additive: one helper, callsite-by-callsite migration.
+
+**Landmines Nutts should watch for:**
+
+- Tick ordering: `_smooth_velocity` reads `b.velocity` from last tick. If any path updates `b.velocity` mid-tick and another path reads it later in the same tick, ordering matters. Recommendation: `b.velocity` is written exactly once per tick, at the end of the combined movement resolution — collapse the existing multiple `b.position +=` calls into one `desired_vel` accumulator per tick per bot, then apply `_smooth_velocity` once. This also fixes the moonwalk-era concern about multiple push sources interleaving.
+- Afterburner / overtime multipliers: those already stack on `current_speed`. Since `_smooth_velocity` uses `current_speed` as magnitude target, multipliers compose correctly.
+- Bot-bot separation push (`combat_sim.gd:560-580`): this is a **non-goal-directed** position write. Decision for Nutts: route separation through `_smooth_velocity` too (cleaner, more consistent, but may make overlap resolution laggy), OR bypass (simpler, may reintroduce some instant-direction-change signals but only on overlaps, which are rare). **Default recommendation: bypass** — separation is a geometry correction, not a movement intent.
+
+---
+
+## 11. Open questions for Ett
+
+1. **Task numbering.** Spec assumes `[S17.2-003]` is "Scout movement feel pass" per arc brief. Confirm once Ett emits the `sprint-17.2.md` plan file.
+2. **Ordering with wall-stuck.** §7 argues scout-feel should land AFTER wall-stuck investigation (`[S17.2-001]`) so the unstick write-site bypass flag can be scoped correctly. Confirm ordering in the sub-sprint plan.
+3. **Post-implementation playtest.** §9 recommends a playtest-ready drop between Nutts-implement and Specc-audit, for HCD's 5-minute feel check. Is this Ett-plannable within S17.2, or does it push S17.3 back?
+4. **Brawler/Fortress scope.** Proposed angular caps (270°/s, 150°/s) for Brawler/Fortress are included for consistency, but the HCD complaint was Scout-specific. Ett should decide: apply smoothing to all three chassis this sprint, or Scout-only and carry-forward the others? Recommendation: apply to all three — the helper works generically, and the caps are high enough for Brawler/Fortress to not feel different in typical gameplay.
+5. **Debug overlay.** §9 proposes a dev-only velocity overlay. If Ett wants it in S17.2, file as a separate micro-task (~S complexity). Otherwise carry-forward.
+6. **Specc audit flow.** Per framework note in the task prompt, design-doc PR needs Specc App approval; Riv handles Specc post-hoc. Spec itself has nothing blocking.
+
+---
+
+## 12. One-line summary for Riv
+
+Scout feels unreal because `combat_sim.gd` writes `position += direction * speed` with a fresh direction every tick and zero angular inertia. Proposal: add a `_smooth_velocity` helper that rotates a real `b.velocity` toward the desired direction at a chassis-specific `max_angular_velocity` (Scout 540°/s) with a brief reversal-damping dip on > 120° flips. Scope-safe: no `data/**`, no GDD, no combat-balance numbers. Complexity M. Tuning pass expected.


### PR DESCRIPTION
Phase-1 design spec for S17.2 scout-feel pass. Ett will integrate into the S17.2 plan file.

## TL;DR
Scout feels unreal because `combat_sim.gd` writes `position += direction * speed` with a fresh direction every tick and zero angular inertia. Spec proposes a `_smooth_velocity` helper that rotates a real `b.velocity` toward desired direction at a chassis-specific `max_angular_velocity` (Scout 540°/s) with brief reversal-damping on >120° flips.

## Key findings
- **Current implementation:** custom tick-based sim (10 Hz), not Godot physics. Writes `b.position += dir * spd` at ~15 sites. Scalar `current_speed` smoothing exists via chassis accel/decel — vector direction smoothing does NOT.
- **Root cause:** direction is recomputed every tick from geometry; last tick's vector is thrown away. Phase transitions (TENSION→COMMIT→RECOVERY) produce sign-flipped vectors in 100 ms = effective 4000 px/s² vector accel (6× chassis cap).
- **Scope-safe:** no `godot/data/**` edits (new constants live in `combat_sim.gd`). No GDD touch. No balance numbers.

## Proposed numbers (tunable)
- Scout `max_angular_velocity`: 540°/s → 180° reversal in ~300 ms (~3 ticks)
- `REVERSAL_ANGLE_THRESHOLD`: 120°
- `REVERSAL_DAMPING_FACTOR`: 0.35× for 200 ms on hard flips

## Wall-stuck intersection
Shares file, NOT root cause. §7 notes scout-feel impl must land AFTER wall-stuck investigation so the unstick nudge can get a `bypass_smoothing` opt-out. No scope creep.

## Complexity for Nutts: M
~90 LoC in `combat_sim.gd`, ~15 LoC in `brott_state.gd`, plus a unit test file. See §10 for symbol-level map.

Doc: `docs/design/s17.2-scout-feel.md` (384 lines).