### PR TITLE
[S17.2-001] Investigation: wall-stuck root cause

### DIFF
--- a/docs/design/s17.2-001-wall-stuck.md
+++ b/docs/design/s17.2-001-wall-stuck.md
@@ -1,0 +1,185 @@
+# [S17.2-001] Investigation: Wall-Stuck Root Cause
+
+**Author:** Gizmo (investigation)
+**Sprint:** S17.2 (S17 Eve Polish Arc)
+**Task:** [S17.2-001] — diagnose the wall-stuck bug HCD has been hitting since S13.10. Investigation only. The fix lands in [S17.2-002] (Nutts).
+**Tracked issue:** #180 (filed as part of this task per Ett's S17.2 sub-sprint plan).
+**Scope gate:** Investigation writes no source code. The downstream fix is pre-approved for `godot/combat/**` (Ett's S17.2 plan); `godot/arena/**` remains sacred unless this doc escalates.
+
+---
+
+## 1. Problem statement
+
+From HCD playtest notes (paraphrased; see issue #180 for verbatim and citations):
+
+- Bots occasionally stop moving mid-fight, always next to a wall or pillar.
+- Sometimes only one of the two bots is affected; sometimes both.
+- In the extreme case both bots freeze and just exchange shots until one dies — HCD cited "last 5 shots of scout fight, both stopped and just shot."
+- Repeatable, present since S13.10; S14.1-B added the current displacement-window unstick system, which mitigated but did not fully solve the issue.
+
+The current anti-stuck system lives entirely in `godot/combat/combat_sim.gd` (`_check_and_handle_stuck`, `_is_near_geometry`, `_wall_escape_direction`). No navmesh / A* pathing exists in the codebase — the project uses direct steering against wall clamps + circular pillar repel + TCR state-machine movement.
+
+## 2. Reproduction
+
+### 2.1 High-level repro recipe
+
+Conditions that most reliably reproduce freezing in the current build:
+
+1. Arena: default `arena_renderer` with 4 pillars (centered at ±2.5 tiles from arena center).
+2. Chassis: Scout vs Scout (highest base speed + tightest orbit band magnifies the edge case) or any mixed matchup.
+3. Weapon: medium-range (3–5 tile) — ensures `in_combat_movement` stays on and TCR runs.
+4. Geometry trigger: one bot ends up in a corner-adjacent zone that is ALSO within pillar-proximity range — i.e., near-corner + near-inner-pillar simultaneously. The four inner pillars sit at offsets of 2.5 tiles from arena center; the arena is 16×16 tiles. The band where corner-proximity (within 1 tile of wall on two axes) overlaps pillar-proximity (within 60 px of an inner pillar) is narrow but reachable when a bot gets chased into a corner while a pillar is nearby.
+
+### 2.2 Observable sequence (code-level)
+
+Tick-by-tick, the freeze unfolds as follows:
+
+1. Bot enters TCR COMMIT phase (`combat_sim.gd:805`), dashes toward target.
+2. Target is on the far side of an inner pillar. COMMIT write: `b.position += to_target.normalized() * commit_spd` (line 812).
+3. Pillar-repel pushes the bot back out: `b.position = pillar_pos + to_target.normalized() * (BOT_HITBOX_RADIUS + 16.0)` (line 591).
+4. Wall-clamp trims the bot against the adjacent wall (line 580).
+5. Net per-tick displacement is tiny (<1 px). `_stuck_history` accumulates, and after 15 ticks (1.5 s) at <10 px total, `_unstick_timer` arms (line 687).
+6. `_wall_escape_direction` is called. For a bot simultaneously near a wall AND near a pillar that lies roughly between the bot and open space, the wall contribution (pushing away from wall into arena) and the pillar contribution (pushing away from pillar, which, for this geometry, points roughly back toward the wall) partially cancel. See §4 for the specific mechanism.
+7. The resulting escape vector has small magnitude. The 7 px/tick nudge (`UNSTICK_NUDGE_PX_PER_TICK`, line 634) applied to a near-zero normalized-ish vector still writes 7 px, but in a direction that does not clear the wedge.
+8. After 8 ticks of unstick, `_stuck_history` clears and the cycle repeats.
+9. Because COMMIT keeps pushing the bot back into the pillar each tick, the bot oscillates within a ~20–30 px bubble indefinitely. To the viewer this reads as "frozen against the wall."
+
+### 2.3 Minimal repro for Nutts
+
+Arena-sim a deterministic Scout vs Scout match with seed chosen to drive one bot into the upper-left-quadrant inner pillar while also within 1 tile of the top wall. Log `nav_unstick` tick events. Repro-positive if a bot fires ≥3 `nav_unstick` events within an 8-second window AND net displacement between the first and last event is <2 tiles.
+
+## 3. Implementation audit
+
+### 3.1 Tick order inside `_physics_step` for one bot
+
+Per-tick ordering for a bot in `in_combat_movement`:
+
+1. `_do_combat_movement(b, spd)` — TCR state machine writes `b.position` (line 493).
+2. Wall-clamp: `b.position.x = clampf(...)`, `b.position.y = clampf(...)` (line 580).
+3. Wall-collision orbit flip: if `b.position != old_pos`, `b.orbit_direction *= -1` (line 584).
+4. Pillar repulsion: for each pillar within `BOT_HITBOX_RADIUS + 16`, push bot out (line 589).
+5. `_check_and_handle_stuck(b)` (line 600):
+   - If `_unstick_timer > 0`: compute `_wall_escape_direction`, apply moonwalk-clamped nudge (lines 637–670).
+   - Else if `_is_near_geometry(b)`: append to `_stuck_history`, trim to 15 ticks, trigger unstick if window displacement < 10 px (lines 681–695).
+   - Else: clear history and early-out.
+
+### 3.2 Displacement-window trigger (`combat_sim.gd:681-695`)
+
+Trigger condition:
+
+    b.position.distance_to(b._stuck_history[0]) < STUCK_MIN_PX  # 10 px
+
+This is Euclidean distance between first and last sample, NOT path length. For a bot oscillating in a 20–30 px bubble around a fixed point, the first and last samples are usually within 10 px of each other even though the bot covered ~100+ px of arc. Trigger fires reliably in the wedge case — this side of the system works correctly.
+
+On trigger, the handler:
+
+- Sets `_unstick_timer = 8` ticks.
+- Flips `orbit_direction`.
+- Resets TCR to TENSION phase with fresh timer.
+- Sets `backup_distance = TILE_SIZE` (forces lateral-orbit branch in TENSION).
+- Clears `_stuck_history`.
+- Emits a `nav_unstick` tick event.
+
+All of this is sound in isolation.
+
+### 3.3 Escape direction (`combat_sim.gd:698-714`)
+
+    const WALL_PROX_PX: float = TILE_SIZE          # 32 px
+    const PILLAR_PROX_PX: float = BOT_HITBOX_RADIUS + 48.0  # 60 px
+    var e := Vector2.ZERO
+    if b.position.x < WALL_PROX_PX: e.x += 1.0
+    if b.position.x > arena_px - WALL_PROX_PX: e.x -= 1.0
+    if b.position.y < WALL_PROX_PX: e.y += 1.0
+    if b.position.y > arena_px - WALL_PROX_PX: e.y -= 1.0
+    for p in _get_pillar_positions():
+        var away: Vector2 = b.position - p
+        if away.length() < PILLAR_PROX_PX and away.length() > 0.01:
+            e += away.normalized()
+
+Wall contributions: unit-axis (`1.0`) per wall the bot is near.
+Pillar contribution: normalized (length 1.0) away-from-pillar per pillar within 60 px.
+
+The function does NOT normalize the final `e` — so magnitude depends on how many sources contributed and how well they align. When wall and pillar terms are ~antiparallel, `e` can have magnitude as low as near-zero while not being exactly `Vector2.ZERO` (the fallback that biases toward target).
+
+### 3.4 Fallback bias (`combat_sim.gd:712-714`, continued)
+
+The scout-feel spec §7 notes the "bias toward target" fallback. Reading the actual function body: the fallback is only engaged when `e == Vector2.ZERO` EXACTLY. A cancellation that produces e.g. `Vector2(0.05, -0.02)` passes through the cancellation as a weak vector — the code then normalizes this in the calling site (line 643: `var nudge = _wall_escape_direction(b)` — but `nudge` is used directly, not normalized; see line 652 `push = nudge * 7.0`). So a tiny vector yields a tiny push, NOT a fallback-to-target redirect.
+
+## 4. Root cause
+
+**One-sentence statement:** When a bot is simultaneously within wall-proximity (1 tile) and pillar-proximity (60 px) of an inner pillar positioned roughly between the bot and the open arena, `_wall_escape_direction` (`godot/combat/combat_sim.gd:698`) returns a small, non-zero vector whose magnitude is degraded by cancellation between the wall and pillar contributions, and the calling code at `combat_sim.gd:652` applies `nudge * 7.0` directly without normalizing — producing an escape push that is too weak to clear the wedge before the next COMMIT tick re-pins the bot.
+
+**Precise citation:** `godot/combat/combat_sim.gd:652` uses the raw (possibly-degenerate) escape vector for the nudge. The zero-vector fallback at line 712 only catches the exact-zero case, not the near-zero case.
+
+**Why the current system mitigates but does not fix:** The geometry-prox gate (S14.1-B2) correctly fires `_stuck_history` detection only near geometry, the displacement-window correctly identifies the wedge, and the escape direction is correct in SIGN. The failure mode is purely magnitude: the escape push is not guaranteed to exceed the per-tick COMMIT pull that re-pins the bot. Open-field false-positives are solved; corner-plus-pillar true-positives where the nudge is under-powered are not.
+
+## 5. Minimal-patch proposal for S17.2-002
+
+### 5.1 Shape of fix (Nutts)
+
+In `godot/combat/combat_sim.gd`:
+
+1. **Normalize the escape vector and guarantee minimum useful magnitude.** Replace the raw `nudge` usage at line 643/652 with:
+   - Compute `e` the same way.
+   - If `e.length() < 0.25` (near-zero threshold), redirect to target-bias (same fallback currently gated at `e == Vector2.ZERO`).
+   - Else normalize: `nudge = e.normalized()`.
+   - Apply `push = nudge * UNSTICK_NUDGE_PX_PER_TICK` with existing moonwalk clamp (unchanged).
+2. **Extract the unstick nudge write into a single dedicated helper** so S17.2-003 (scout-feel) has one call-site to mark with `bypass_smoothing`. Proposed signature:
+
+        func _apply_unstick_nudge(b: BrottState, push: Vector2) -> void:
+            # S17.2-003 will route this write around the velocity-smoothing
+            # helper via a `bypass_smoothing=true` opt-out. This is the ONLY
+            # unstick write site.
+            b.position += push
+
+    Inline the existing wall-clamp immediately after the write, as it already is today.
+
+### 5.2 Files touched
+
+- `godot/combat/combat_sim.gd` — only this file.
+- No `godot/arena/**` touch required.
+- No `godot/data/**` touch.
+- No test data or chassis tuning.
+
+### 5.3 Expected LoC
+
+- ~20 lines added (magnitude gate, helper extraction, 1–2 comments).
+- ~8 lines moved/refactored (current inline nudge push → helper).
+- Net: ~25–30 LoC changed, single file, mechanical.
+
+### 5.4 S17.2-003 hook point (scout-feel dependency)
+
+The new helper `_apply_unstick_nudge` IS the `bypass_smoothing` opt-out site for the scout-feel velocity-smoothing layer. When S17.2-003 introduces `_smooth_velocity(...)` and wraps the other ~15 position-write sites, `_apply_unstick_nudge` is explicitly documented as the ONE site that does NOT route through smoothing — the 200–300 ms angular-velocity lag would defeat the unstick maneuver. See scout-feel spec §7.
+
+## 6. Scope verdict
+
+- Fix stays in `godot/combat/**` (specifically `combat_sim.gd`). Pre-approved under Ett's S17.2 plan.
+- No `godot/arena/**` touch needed. Arena geometry (wall clamps, pillar positions, pillar-repel) is CORRECT; only the combat-sim's response to that geometry needs adjustment.
+- No escalation to Riv required.
+
+## 7. Acceptance tests for Nutts
+
+1. **Wall-only wedge clears in ≤16 ticks.** Place a bot at (BOT_HITBOX_RADIUS, arena_center_y), target at (arena_center_x, arena_center_y). COMMIT pushes into wall. Expect: first `nav_unstick` fires within 20 ticks of match start; net displacement 16 ticks after first unstick is ≥ 40 px away from the wall.
+2. **Pillar-only wedge clears in ≤16 ticks.** Place bot at 60 px from inner pillar, target directly beyond the pillar. Expect: `nav_unstick` fires; bot escapes the 60 px pillar-prox band within 16 ticks of first trigger.
+3. **Corner + pillar wedge clears in ≤32 ticks.** Place bot near upper-left corner with upper-left inner pillar positioned between bot and arena center. This is the S17 repro case. Expect: at most 2 `nav_unstick` events fired total before the bot exits the combined prox zone.
+4. **No open-field false-positive regression.** Scout vs Scout open-arena match (pillars disabled): zero `nav_unstick` events across 100 ticks. (Confirms S14.1-B2 geometry gate still holds.)
+5. **Determinism preserved.** Seed X run before and after fix produce identical match outcomes when no `nav_unstick` event fires. (The patch only changes behavior inside the unstick code path.)
+6. **Scout-feel hook present.** `_apply_unstick_nudge` exists as a single function; grep confirms it is the ONLY `b.position +=` write inside `_check_and_handle_stuck`.
+
+## 8. Risks
+
+- **Determinism:** Low. The normalized nudge is still deterministic — only magnitude changes for already-triggered unstick events. Existing `test_sprint14_1_nav` expectations may need a golden-value refresh for T1/T2/T4 (pre-existing tests) if they assert exact post-unstick positions. Mitigation: Nutts should re-run the nav suite and update goldens if they shift, with a note in the PR body.
+- **Replay fidelity:** The patch is a pure per-tick change within the combat sim. Existing replays that never fired unstick are unaffected. Existing replays that DID fire unstick may desync — this is expected and matches the bug-fix intent.
+- **Perf:** Negligible. One extra `length()` check and a conditional normalize per unstick service tick (at most 8 ticks per unstick event, at most once per ~1.5 s per bot).
+- **Over-escape:** A normalized nudge is always 7 px/tick, which is larger than the current typical wall-only nudge (~7 px) and the current pillar-only nudge (~7 px) but LARGER than the degenerate-cancellation case (<2 px). Net: unstick becomes more reliable. Bots will not "over-escape" because the 8-tick cap is unchanged.
+- **Interaction with scout-feel (S17.2-003):** By design, scout-feel will bypass `_smooth_velocity` at `_apply_unstick_nudge`. This means unstick nudges break the velocity-smoothing invariant during the 8-tick escape window. Acceptable per scout-feel spec §7. Document the opt-out in a code comment on both sides.
+
+## 9. Open questions for Ett / Riv
+
+- **Q1 (Ett):** The 0.25 magnitude threshold for near-zero redirect is a guess. Should Nutts tune this empirically against the repro case, or lock it at 0.25 for the minimal patch? Recommendation: lock at 0.25; if Q2 tests fail, revisit in S17.2-002 verify.
+- **Q2 (Ett):** Should S17.2-002 ship with a new `test_sprint17_2_wall_stuck.gd` test file covering AT #1–#3 above, or extend `test_sprint14_1_nav.gd`? Recommendation: new file — keeps S17 test coverage greppable.
+- **Q3 (Riv):** Any concern about the S17.2-003 scout-feel task racing ahead before this patch lands? If scout-feel lands first, the `bypass_smoothing` hook won't exist yet and the unstick path will be smoothed — re-introducing the stuck bug with a different mechanism. Recommendation: enforce task order 001 → 002 → 003 on the S17.2 sub-sprint plan.
+
+## 10. Confidence
+
+Medium-high. The displacement-window and geometry-gate sides of the system are well-reasoned (S14.1-B2 review on PR #74 cited in code comments). The remaining failure mode is concentrated in one function (`_wall_escape_direction`) and one call site (`combat_sim.gd:652`), which keeps the patch scope small. The primary uncertainty is whether the 0.25 magnitude threshold is the right tuning point — hence Q1 above. If in-game behavior after the patch still shows occasional stuck events, the next investigation should instrument the ACTUAL magnitude distribution of `_wall_escape_direction` return vectors over a playtest session to set the threshold empirically.


### PR DESCRIPTION
Investigation doc for S17.2-001. Files issue #180. Identifies degenerate-magnitude case in `_wall_escape_direction` (`combat_sim.gd:698`) as the remaining wall-stuck failure mode after S14.1-B mitigation.

**Scope:** investigation only — no source edits. Design doc only.

**Root cause (one-liner):** unstick nudge at `combat_sim.gd:652` uses the raw (unnormalized) escape vector; when wall and pillar prox terms cancel, the push becomes too weak to clear the wedge before COMMIT re-pins the bot.

**Minimal-patch scope for S17.2-002:** single file (`godot/combat/combat_sim.gd`), ~25 LoC, normalize escape vector + near-zero-to-target fallback + extract `_apply_unstick_nudge` as the single write-site hook for S17.2-003 `bypass_smoothing`.

**Scope verdict:** `combat/**` only, no `arena/**` escalation.

Open questions listed in doc §9. Auto-merge squash armed.