### PR TITLE
README: point readers to public BattleBrotts + studio sites

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 Build autonomous combat Brotts, teach them how to fight with drag-and-drop Behavior Cards, and watch them battle in top-down arenas.
 
+🌐 **Public landing:** https://brott-studio.github.io/battlebrotts/ · **Studio site:** https://brott-studio.github.io/
+
 **Engine:** Godot 4 | **Platform:** Web (HTML5) | **Genre:** Auto-battler / Strategy
 
 <!-- STATUS-START -->


### PR DESCRIPTION
Adds 'Public landing' (https://brott-studio.github.io/battlebrotts/) and 'Studio site' (https://brott-studio.github.io/) links near the top of the README.

The `/battlebrotts/` landing is the new public face for this project; the old `/battlebrotts-v2/` dashboard has been retired.