### PR TITLE
[S17.2-003] Spec revision #2: resolve AC-T3 tension (scope: A)

### DIFF
--- a/docs/design/s17.2-003-scout-feel-revision-2.md
+++ b/docs/design/s17.2-003-scout-feel-revision-2.md
@@ -1,0 +1,184 @@
+# [S17.2-003] Spec revision #2: resolve AC-T3 tension
+
+**Author:** Gizmo (design)
+**Sprint:** S17.2 (S17 Eve Polish Arc)
+**Status:** Supersedes revision #1 (`docs/design/s17.2-003-scout-feel-revision.md`) ONLY on AC-T3 and on the regression-interpretation framing. All write-site categorization, two-lane write model, retreat-bypass, and §4–§5 implementation pattern from revision #1 stand. All §4 smoothing math from the original spec (`docs/design/s17.2-scout-feel.md`) stands.
+**Trigger:** Nutts's second implementation attempt (2026-04-21 08:25–08:34 UTC, no commit pushed) — used revision #1's retreat-bypass + two-lane pattern and hit a new class of regression: match-end tick shift (442 vs pre-change >450) and moonwalk-count sensitivity in `test_sprint11_2`. Nutts's session timed out mid-debug. Pattern of two failed attempts indicates the failure mode is **structural**, not implementation.
+
+---
+
+## 1. Diagnosis
+
+### 1.1 What broke in attempt #2
+
+With revision #1 applied — retreat writes bypass smoothing, forward-chase and lateral-orbit writes feed `desired_vel` and route through `_smooth_velocity` — Nutts observed:
+
+- `test_sprint13_3` mirror WR: no longer broken at 85.7% the way attempt #1 was. The two-lane pattern resolved the mirror-symmetry break (attempt #1 smoothed the retreat writes, which broke the `backup_distance` budget asymmetrically under RNG orbit-direction choice).
+- `test_sprint11_2` (and related stateful tests): match-end tick shifted from >450 to 442. Other stateful engagement-distance timings also drifted by ±1–3 ticks across the 100-seed sweep, in ways that probabilistically cross moonwalk-threshold or mirror-WR-band boundaries.
+
+Nutts's own last note before timeout: *"The smoothing slightly changes combat dynamics — the engagement distance is reached later because velocity smoothing doesn't accelerate instantly, so close-quarters combat timing shifted."*
+
+That note is correct and diagnostic. It is also the structural problem.
+
+### 1.2 Why revision #1's bypass pattern doesn't fix this
+
+Revision #1 correctly identified that retreat writes must not be smoothed — the `backup_distance` budget breaks otherwise. It fixed the attempt-#1 class of regression (determinism drift on retreat writes, mirror WR on retreat-budget asymmetry).
+
+But revision #1 left **all forward-chase and lateral-orbit sites smoothed**, which is the whole point of the sprint. Smoothing a forward-chase velocity vector means:
+
+- The realized velocity vector lags the commanded velocity vector by `chassis.accel * dt` on magnitude and by `max_angular_velocity * dt` on direction.
+- For Scout at `accel=660 px/s²`, reaching peak `current_speed=200 px/s` from zero now takes `200/660 ≈ 0.303 s` (about 3 ticks) of realized-trailing-commanded. Pre-smoothing, displacement was directly `current_speed * dt` the tick `current_speed` was updated — the scalar accel path was already smoothing magnitude, but the **vector** arrived at the position one-tick faster because there was no vector state being blended.
+
+Concretely: under the old path, the tick `b.current_speed` first becomes positive is the tick the bot starts covering ground. Under the new path, the tick `b.velocity` magnitude first becomes positive is the tick the bot starts covering ground, and because `b.velocity` is the blended vector (starting from prior tick's value, which might be zero or pointing elsewhere), there is an extra tick of trailing for every "stand up and go" transition and every direction-reversal transition.
+
+That extra tick, multiplied across COMMIT dashes, TENSION re-entries, and orbit pivots over a 45-second match, compounds into a 3–8 tick shift at match end. Close-quarters combat timing — how many attacks land before one bot dies — is tick-sensitive. The golden logs encode exact damage ticks and exact death ticks, and those slip.
+
+### 1.3 The AC design tension (honest read)
+
+AC-T3 says: *"the full existing test suite must pass unchanged. No quarantining."*
+
+The sprint goal says: *"change the realized velocity profile of combat movement so Scout reads as 'brott' not 'mouse'."*
+
+**These are incompatible.** You cannot change the realized velocity profile of combat movement and keep tick-identical stateful goldens. Any smoothing large enough to be *perceptible* to HCD's eye (the whole point) is large enough to shift engagement-distance-reached ticks by ±1–3, which cascades to match-end ticks, which cascades to moonwalk-sample counts over 100-seed sweeps, which cascades to mirror-WR distributions.
+
+This is not a Nutts bug. It is not a revision-#1 bug. It is an AC-design error in the original spec: AC-T3 was written as "no quarantining" as a scope-discipline fence, assuming smoothing would be invisible to the goldens. That assumption was wrong — it's invisible to unit-level behavior (AC-T1 passes) but not to stateful integration tests (`test_sprint11`, `test_sprint11_2`, `test_sprint13_3`, and likely others).
+
+Two failed implementation attempts on two different bypass strategies is the signal. The third attempt cannot succeed against AC-T3 as written.
+
+### 1.4 The invariant that IS preserved
+
+The **determinism invariant** (two runs with the same seed produce byte-identical logs) is orthogonal to golden stability and IS preserved by revision #1's retreat-bypass. That's the invariant the combat sim architecture was built around, and it is what enables replay, test fixtures, and the whole batch/harness pipeline. It must not slip.
+
+Golden log stability across a codepath change is a **different** invariant — it's "no behavioral change under this refactor" — and a sprint whose explicit purpose is "change combat-movement behavior" cannot honor it.
+
+---
+
+## 2. Chosen option — **A. Narrow AC-T3**
+
+**Justification (one line):** Options B and C either ship a cosmetic fix that won't satisfy HCD's playtest read (B) or push a small, well-understood change into a bigger-risk sprint slot (C); Option A is the honest resolution — this sprint is a combat-behavior change, so goldens encoding that behavior are supposed to regenerate, and we scope the regeneration explicitly.
+
+Options considered and rejected:
+
+- **Option B — smoothing only on site #25 (COMMIT dash forward).** Viable, very small blast radius on goldens. Would still likely shift COMMIT-phase durations by 1–2 ticks and cascade, but over fewer sites means fewer seeds tip over thresholds. However: HCD's playtest complaints were broader than COMMIT-dash alone — *"the way scout moves is so crazy fast"* and *"movements are very jerky too"* were across the board, not just on the final lunge. The "mouse" read came from TENSION-orbit-to-COMMIT-dash transitions (site #23 → #25), from COMMIT-dash-to-RECOVERY-lateral transitions (site #25 → #27), and from TENSION-lateral direction flips when the target dodges (sites #22–24). Smoothing only #25 smooths the ≈0.8s of each engagement where Scout is already in the fastest phase — it's the single most visible site, yes, but it leaves the orbit/recovery jitter that the other quotes cite. Likely delivers ~40% of the feel goal, not enough to pass AC-6 (HCD subjective read).
+- **Option C — defer to S17.3.** Cheapest in engineering risk, but S17.2's arc bar explicitly includes *"Scout 'mice to brott' feel shift confirmed by Optic and (ideally) HCD spot-check before arc close."* Deferring scout-feel out of S17.2 means S17.2 ships wall-stuck only (001+002) plus the debug overlay (004), and the arc closes without its headline polish deliverable. Not a fatal outcome, but it pushes a diagnosed-and-designed problem into a future sprint without engineering justification — the design is correct, the implementation is viable, the only blocker is AC-T3 as written. Defer would be the right call if we believed the design itself was wrong; we don't.
+
+Option A keeps the design, keeps the implementation pattern (revision #1's two-lane write model), and fixes the AC.
+
+---
+
+## 3. Golden-regeneration scope (Option A contract)
+
+This section is the audit checklist. Nutts regenerates exactly the listed goldens; anything outside this list must still pass unchanged.
+
+### 3.1 Tests that MAY have stateful shifts (regeneration permitted)
+
+Shifts expected from combat-movement velocity profile change:
+
+| Test | File | Expected shift | Regeneration allowed? |
+|---|---|---|---|
+| `test_no_moonwalking` (AC6) | `godot/tests/test_sprint11.gd` §174 | Moonwalk violation count over 100 seeds. Current threshold `≤10`, baseline ≈7, attempt #1 hit 24. | **YES** — update threshold to `≤15` (rationale: §3.2). |
+| `test_sprint11_2` (period-bounded backup invariants) | `godot/tests/test_sprint11_2.gd` | Match-end tick, per-period backup summaries, stationary-during-combat counts (±1–3 tick drift). | **YES** — regenerate summaries; invariants themselves (no >1.2-tile straight backup per period; no >3s stationary) must still hold. |
+| `test_sprint13_3` mirror-match WR | `godot/tests/test_sprint13_3.gd` §70–135 | Scout-vs-Scout mirror WR, per-shot/per-pellet hit rates, avg duration. Mirror invariant `WR ∈ [35%, 65%]` must still hold. | **YES** — mirror band is the invariant, exact value is not. Regenerate if band holds. |
+| `test_sprint14_1_nav` | `godot/tests/test_sprint14_1_nav.gd` | Navigation path counts, escape-tick summaries (±1–3 tick drift). Hard invariant "no >2s freeze" must still hold. | **YES** — regenerate summaries; freeze invariant holds. |
+| Match-end tick goldens in any test that asserts `sim.tick_count == N` | grep `tick_count ==` in `godot/tests/` | Absolute tick assertions against a specific number. | **YES** — regenerate to new number IF the test is a golden regression (not an invariant). If the assertion was an invariant (e.g., "match ends before overtime"), the invariant must still hold. |
+
+### 3.2 New thresholds (precise)
+
+- **`test_sprint11` AC6 moonwalk violation count:** change `_assert(violations <= 10, ...)` to `_assert(violations <= 15, ...)`. Rationale: smoothing adds rotational lag on the escape-from-pillar path, which slightly extends the tail of continuous-backward runs through the pillar quadrant. Baseline pre-smoothing is ≈7; attempt-#1 pathological was 24 (that was with retreat writes wrongly smoothed). Attempt-#2 with retreat-bypass should produce 9–13 on a 100-seed sweep; `≤15` gives headroom. Nutts should log the actual number observed and, if it exceeds 15, escalate back to Gizmo — that would indicate the smoothing is leaking into retreat via a missed site.
+- **`test_sprint13_3` mirror WR band:** unchanged. Band `WR ∈ [35%, 65%]` stays; the exact value inside the band regenerates. Nutts logs the observed mirror WR in the PR description for reference.
+- **Match-end tick in `test_sprint11_2`:** regenerate. Not a golden-asserted specific number in the test code as grep shows — it's a derived summary. If any test asserts an exact match-end tick against a hardcoded number, Nutts adjusts to the new number and notes the delta in PR.
+
+### 3.3 Determinism invariant (NOT narrowed — this stays strict)
+
+`AC-T2 replay-determinism` is **unchanged and strict.** Two runs of the same match with the same RNG seed must produce byte-identical JSON logs. This is the architectural invariant the combat sim was built around and is orthogonal to golden stability.
+
+Nutts verifies: pick 5 random seeds, run each twice, diff the JSON logs, all diffs must be empty.
+
+If AC-T2 fails, that is a different class of bug (float-order nondeterminism introduced by `_smooth_velocity`) and must be fixed in the same PR — it is not regenerable.
+
+### 3.4 Scope fence on regeneration
+
+Goldens OUTSIDE the combat-movement codepath must still pass unchanged:
+
+- All `test_sprint17_1_*` tests (shop/loadout/HUD/overlay/crate) — UI-layer, no combat-movement dependency.
+- All `test_sprint13_8_*` tests (modal/toast) — UI-layer.
+- `test_sprint17_2_wall_stuck` — wall-stuck invariants; these test `_apply_unstick_nudge` which bypasses smoothing per revision #1.
+- `test_sprint10`, `test_sprint3`–`test_sprint6` — pre-combat/core infra tests.
+- Every unit test of a non-combat-movement helper.
+
+Nutts runs the full suite; any failure outside §3.1 is a bug to fix, not a golden to regenerate.
+
+---
+
+## 4. Revised acceptance criteria for S17.2-003
+
+Supersedes original spec §8 AC-T3 and refines AC-1, AC-4, AC-T2 (to track revision #1's narrowing).
+
+**Behavioral / qualitative:**
+
+- **AC-1 Visible-arc test.** (From revision #1) In a scenario where Scout's **forward-intent** direction reverses > 120°, Scout must take ≥ 3 ticks (300 ms) to complete the rotation. Verified by sampling `b.velocity.angle()` per tick across the transition.
+- **AC-2 No straight-line slowdown (relaxed).** On a straight-line approach from stop, Scout must reach peak `current_speed` within ≤ +1 tick of pre-change baseline. (Was `±1 tick`; now bounded only on the slow side since smoothing structurally cannot accelerate faster than the old scalar path.)
+- **AC-3 Pursuit still closes.** Unchanged. Chase-scenario regression ≤ +15% tick count.
+- **AC-4 Phase-transition damping visible (scoped).** (From revision #1) On a **forward-intent direction reversal** across a phase boundary, `b.velocity.length()` must dip by ≥ 35% for 2 ticks.
+- **AC-5 No teleport.** Unchanged.
+- **AC-6 HCD subjective read.** Unchanged. Optic visual-diff passes; feel reads as "brott" not "mouse".
+
+**Testable / automated:**
+
+- **AC-T1 Unit test for `_smooth_velocity`.** Unchanged.
+- **AC-T2 Replay-determinism (strict).** Two runs, same seed → byte-identical JSON logs. Nutts verifies on ≥5 seeds before opening PR.
+- **AC-T3 (revised) — Regression with scoped golden regeneration.**
+  - The full existing test suite must pass.
+  - Goldens listed in §3.1 of this revision are permitted to regenerate. New threshold in §3.2 for `test_sprint11` AC6. All other golden shifts must hold their **invariants** (moonwalk ≤1.2 tiles per period, mirror WR ∈ [35%, 65%], no >2s freeze, no >3s stationary) even if summary counts shift.
+  - Goldens outside §3.1 must pass unchanged.
+  - No quarantining — if a test outside §3.1 breaks, fix it; do not quarantine.
+- **AC-T4 Retreat-budget invariant (from revision #1 §6).** With a synthetic TENSION-too-close scenario, total backward displacement across one full TCR cycle must be ≤ `TILE_SIZE * 2 + epsilon`. This confirms the retreat-bypass is working.
+
+---
+
+## 5. Updated migration checklist for Nutts
+
+Revision #1's §5.4 checklist still applies (category-tag each site, forward-chase + lateral-orbit → accumulator, retreat → direct write, corrections → direct write, single `_smooth_velocity` apply). **Add the following post-impl verification steps:**
+
+1. Run `test_sprint11` alone. Record moonwalk violation count. Expected 9–13. If > 15, stop and escalate to Gizmo — retreat bypass may have missed a site.
+2. Run `test_sprint13_3` Scout-mirror only. Record WR. Expected in [35%, 65%]. If outside band, stop and escalate.
+3. Run AC-T2 determinism check on 5 seeds. Byte-diff logs. Must be empty.
+4. Run full suite. For any failure outside §3.1, fix (not regenerate).
+5. For any golden in §3.1 that requires update, update in the same PR with a comment citing `s17.2-003-scout-feel-revision-2.md §3.1` and the pre/post number.
+6. PR description must include:
+   - Moonwalk violation count (expected 9–13).
+   - Mirror WR observed (expected [35, 65]%).
+   - List of goldens regenerated and pre/post values.
+   - Determinism check result (5 seeds, all byte-identical).
+
+---
+
+## 6. If regeneration reveals something unexpected
+
+If during regeneration Nutts observes **behavioral anomalies** beyond stateful-drift — e.g., bots now consistently failing to engage, matches consistently timing out, one chassis dominating every mirror — that is **not** a regenerable golden. That is a behavioral regression and must be diagnosed.
+
+Escalation path:
+- Nutts: pause, post findings, tag Gizmo.
+- Gizmo: triage whether the observed behavior is within the "nimble but physical" invariant envelope (tuning adjustment of the four `combat_sim.gd` constants) or outside it (design revision #3 needed).
+
+Tuning-level adjustment is a constant change and stays in this sprint. Design-level anomaly triggers a pause, escalation to Ett/HCD, and probable scope reduction to Option C.
+
+---
+
+## 7. HCD visibility
+
+This revision narrows AC-T3 but does NOT reduce scope. It is a design-call within the sprint envelope — the combat-movement pipeline is now explicitly declared to be a behavior-changing sprint, and the goldens that encode the old behavior are explicitly permitted to regenerate under bounded invariants.
+
+**Not an HCD decision under normal framework rules.** Surfacing to HCD only for awareness:
+
+- The S17.2 arc bar "*Scout 'mice to brott' feel shift confirmed*" requires the sprint to change behavior. Goldens encoding old behavior must therefore shift. This revision makes that explicit.
+- The architectural invariant (determinism / same-seed-byte-identical) is preserved strictly.
+- No GDD change. No `godot/data/**` change. No balance-number change. Scope gates hold.
+
+If HCD reads this and disagrees with the narrowing, fall back to Option C (defer S17.2-003 to S17.3) — this revision doc provides the rationale for either path.
+
+---
+
+## 8. One-line summary for Riv
+
+AC-T3 "no existing test changes" was written assuming smoothing would be golden-invisible; two failed Nutts attempts prove it can't be. Revision #2 narrows AC-T3 to permit regeneration of stateful combat-movement goldens (specific list in §3.1, new moonwalk threshold `≤15`) while keeping replay-determinism strict. All revision #1 design (retreat-bypass, two-lane write model) stands. Nutts re-attempts on this revised AC; if regeneration surfaces behavioral anomalies (not just tick drift), escalate to Gizmo — fallback is Option C defer to S17.3.


### PR DESCRIPTION
## Summary

Revision #2 of the S17.2-003 scout-feel spec. Resolves the AC-T3 design tension that caused two failed Nutts implementation attempts.

**Option chosen: A — Narrow AC-T3.** Permit regeneration of stateful combat-movement goldens while keeping replay-determinism strict.

Doc lands at `docs/design/s17.2-003-scout-feel-revision-2.md` (184 LoC). Does not modify original spec or revision #1.

## Diagnosis

Two implementation attempts, two different failure modes:

- **Attempt #1** (branch `nutts/s17.2-003-scout-feel`, commit `aea977623`): naive §5 "one accumulator, one smooth call" — smoothed retreat writes. Broke `backup_distance` budget → moonwalk violations 24/100 vs ≤10 threshold, Scout-mirror WR 85.7% vs [35–65%] band. Revision #1 (PR #184) issued to fix via retreat-bypass + two-lane write model.
- **Attempt #2** (2026-04-21 08:25–08:34 UTC, no commit pushed, session timed out): used revision #1's retreat-bypass. Mirror WR no longer broken. But match-end tick shifted from >450 to 442, and other stateful engagement-distance timings drifted ±1–3 ticks across the 100-seed sweep — tipping moonwalk and related invariants probabilistically.

Nutts's own note at timeout: *"The smoothing slightly changes combat dynamics — the engagement distance is reached later because velocity smoothing doesn't accelerate instantly."*

**Why revision #1's bypass pattern doesn't fix this:** revision #1 correctly fixed retreat-write determinism drift. But forward-chase and lateral-orbit sites remain smoothed — that's the point of the sprint. Smoothing them adds ~1 extra tick of realized-trailing-commanded per "stand up and go" or direction-reversal transition. Over a 45-second match with ~dozens of such transitions, this compounds to ±3–8 tick drift at match end. Tick-sensitive stateful goldens (moonwalk sample counts, match-end ticks, mirror-WR over 100 seeds) slip.

**This is not a Nutts bug. It is not a revision #1 bug. It is an AC-design error:** AC-T3 was written assuming smoothing would be golden-invisible. That's true at the unit level (AC-T1 passes) but false for stateful integration tests. AC-T3 as written and "visible scout-feel change" cannot coexist.

## Chosen option — A. Narrow AC-T3

Permit regeneration of stateful combat-movement goldens as part of this sprint. Keep the determinism invariant (byte-identical logs for same-seed runs) strict.

**Justification:** Option B (smooth COMMIT-dash only) under-delivers on AC-6 — HCD's playtest complaints were broader than the final lunge (TENSION orbit, direction flips, recovery lateral all cited). Option C (defer to S17.3) available as fallback, but the design is correct and the implementation is viable — the only blocker is AC-T3 as written.

This is a design call, not a scope reduction. The design envelope, the scope gates (no `data/**`, no GDD), and the architectural invariant (determinism) all hold.

## Goldens permitted to regenerate (full list in doc §3.1)

| Test | Shift | Regenerate? |
|---|---|---|
| `test_sprint11` AC6 moonwalk count | Threshold `≤10` → `≤15` | YES |
| `test_sprint11_2` stateful summaries | Match-end tick, per-period backup, stationary counts (±1–3 tick drift). Invariants (≤1.2 tile per period, no >3s stationary) must hold. | YES (summaries; invariants hold) |
| `test_sprint13_3` mirror WR | Exact WR value regenerates; band `[35%, 65%]` must hold | YES (value; band holds) |
| `test_sprint14_1_nav` summaries | ±1–3 tick drift. "No >2s freeze" invariant must hold. | YES (summaries; invariant holds) |
| Any test with hardcoded `tick_count == N` against a match-end | Regenerate if it's a golden; hold if it's an invariant ("must end before overtime") | Case-by-case |

**Outside §3.1 — unchanged.** UI tests, wall-stuck test, pre-combat tests, unit tests of non-combat helpers must all pass unchanged. No quarantining.

## New threshold (precise)

- `test_sprint11:208` — `_assert(violations <= 10, ...)` → `_assert(violations <= 15, ...)`. Baseline ≈7, attempt-#1 pathological 24 (retreat wrongly smoothed), attempt-#2 expected 9–13 (retreat-bypass in place). `≤15` gives headroom. If Nutts observes >15 → escalate, retreat-bypass likely missed a site.

## Determinism invariant (NOT narrowed)

AC-T2 stays strict. Two runs, same seed → byte-identical JSON logs. Nutts verifies on ≥5 seeds before opening PR. If AC-T2 fails, that's a float-order bug, not regenerable.

## Updated AC list for Nutts's next attempt

(Full list in doc §4; key changes below)

- **AC-2 (relaxed):** peak speed reached ≤ +1 tick of baseline (was ±1; smoothing structurally can't accelerate faster than old scalar path).
- **AC-T3 (revised):** full suite passes. Goldens in §3.1 may regenerate under bounded invariants. Threshold change in §3.2. Goldens outside §3.1 unchanged. No quarantining.
- **AC-T4 (from rev #1):** retreat-budget synthetic test — total backward ≤ `TILE_SIZE * 2 + epsilon` per TCR cycle. Confirms retreat-bypass.
- **New post-impl verification checklist** (doc §5): Nutts records moonwalk count, mirror WR, determinism check, goldens regenerated in PR description.

## Scope escape hatch

If during regeneration Nutts observes **behavioral anomalies** beyond tick drift (bots failing to engage, chassis dominating mirror, matches timing out) — pause, post findings, tag Gizmo. Tuning-level adjustment stays in sprint. Design-level anomaly triggers fallback to Option C (defer to S17.3).

## HCD visibility

This is a design-call within the sprint envelope, not a scope reduction. Surfacing for awareness only — S17.2 arc bar explicitly requires Scout feel to change, so goldens encoding old behavior are expected to regenerate. If HCD disagrees with the narrowing, fallback is Option C.

## Out of scope

- No code changes in this PR.
- No `godot/data/**`, no `godot/arena/**`, no `docs/gdd.md`.
- Does not modify original spec or revision #1.

---

cc @Ett for Nutts hand-off once merged. @Riv audit handoff per framework. Label: gizmo.
