### PR TITLE
[S17.2-003] Scout feel: velocity smoothing + angular cap + budget-gated smoothed lane

### DIFF
--- a/docs/design/s17.2-003-retreat-calibration-addendum1.md
+++ b/docs/design/s17.2-003-retreat-calibration-addendum1.md
@@ -1,0 +1,146 @@
+# [S17.2-003] Addendum 1: smoothed-intent lane budget-gating
+
+**Author:** Gizmo (design)
+**Date:** 2026-04-21
+**Status:** Supplements `s17.2-003-retreat-calibration.md` (the two-phase-tick addendum) and closes the strict-zero moonwalk gap Riv flagged per §2.2 escalation.
+**Trigger:** After the halving + S15.2-migration landed (commits `c8df9b9`, `2e30547`, `e95ff83`), `test_sprint11_2.gd::test_away_juke_cap_across_seeds` still reported 4/100 violations where the contract is 0/100. Per the §2.2 pre-commit, that means a pre-cap budget-bypass outside the known separation-overlap exception. This addendum diagnoses it and rules on the fix.
+
+---
+
+## 1. Diagnosis
+
+### 1.1 Failing seeds
+
+Instrumented the test (temporary `print` on violation, restored before PR). Four failing seeds:
+
+| Seed | Tick | `pos` at violate | `bd` | Phase | Stance | Notes |
+|---|---|---|---|---|---|---|
+| 5 | 85 | (160.78, **12.0**) | 18.15 | 0 (TENSION) | 0 (Aggressive) | Top wall (y=12) |
+| 8 | 95 | (**500.0**, 334.20) | 6.05 | 0 (TENSION) | 0 (Aggressive) | Right wall (x=500) |
+| 80 | 64 | (**12.0**, 175.52) | 0.00 | 0 (TENSION) | 0 (Aggressive) | Left wall (x=12) |
+| 83 | 53 | (400.63, **500.0**) | 30.25 | 0 (TENSION) | 0 (Aggressive) | Bottom wall (y=500) |
+
+**Common pattern:** every violation occurs while bot 0 is arena-clamped against a wall, in stance=0 aggressive, phase=0 TENSION, with unstick inactive. All four hit the same mechanism.
+
+### 1.2 Tick-by-tick trace (seed 80, representative)
+
+Bot 0 pinned at x=12 (left wall), target (bot 1) directly below at (12, ~240). `to_target = (0, +y)`. Ticks 50–64 show a perfect limit cycle:
+
+```
+T50  mv=(0, -3.52)  dot=-1.000  bd=0   vel=(-23.48, -35.24)  orbit=+1
+T51  mv=(0, -0.17)  dot=-1.000  bd=0   vel=(-42.32,  -1.72)  orbit=-1
+T52  mv=(0, -3.52)  dot=-1.000  bd=0   vel=(-23.48, -35.24)  orbit=+1
+T53  mv=(0, -0.17)  dot=-1.000  bd=0   vel=(-42.32,  -1.72)  orbit=-1
+...  (15 ticks, bot drifts 3.52 px/pair upward)
+T64  mv=(0, -3.52)  dot=-1.000  bd=0   backup_run=38.73  VIOLATE
+```
+
+Every tick is 100% anti-target. `backup_distance` stays at **0.00** throughout — the moonwalk is entirely invisible to the authored-retreat budget.
+
+### 1.3 Mechanism
+
+In-band TENSION orbit at close range sets `desired_vel_t = perp_t * orbit_direction * current_speed`. Because `to_target` is pure vertical here, `perp_t` is pure horizontal. Intent is `(-220, 0)` or `(+220, 0)` — **no backward component by design.**
+
+Two compounding effects produce the backward drift anyway:
+
+1. **Arena clamp strips position, not velocity.** `combat_sim.gd` L642–644:
+   ```gdscript
+   b.position.x = clampf(b.position.x, BOT_HITBOX_RADIUS, arena_px - BOT_HITBOX_RADIUS)
+   ```
+   When the bot is pinned against the left wall, its x-position is clamped back to 12 every tick. But `b.velocity.x` retains the -220-ish value. Next tick, `_smooth_velocity` rotates that velocity toward the new intent. Because the **x-component is capped at the wall but the y-component is free**, rotation effectively leaks lateral energy into a persistent y-velocity.
+
+2. **Orbit-direction flip on wall collision.** L648 flips `orbit_direction *= -1` every tick the clamp fires. That flips `desired_vel_t` sign every tick. `_smooth_velocity` sees a 180° intent reversal, fires `REVERSAL_DAMPING_TICKS`, but the magnitude never fully decays because intent keeps re-arming. The two alternating velocity vectors `(-23.5, -35.2)` and `(-42.3, -1.7)` are the steady-state of this coupled-oscillator system — and both have **negative y**. Net y-drift per tick pair: -3.69 px.
+
+Neither the intent vector nor the authored-retreat writes charge this backward drift to `backup_distance`. The smoothed-intent lane is the last unbudgeted bypass. (Separation was gated in S15 → L630; unstick was gated in S15 → L797. Smoothed-intent was not, because its intent vector was presumed to respect target-direction semantics.)
+
+**Wall-stuck detection does not catch this case** because the bot is "moving" at ~3.7 px/tick — far above the `STUCK_MIN_PX / STUCK_WINDOW_TICKS` = 10px/15-tick stuck threshold. The bot is moving freely, just backward.
+
+### 1.4 Seed 83 variant
+
+Seed 83 shows a slightly different fingerprint: `bd` climbs 6.05 → 12.10 → 18.15 → 24.20 → 30.25 over 5 consecutive ticks at `mvLen = 6.05`. That's the authored TENSION-too-close retreat writing correctly and consuming budget as designed. Five ticks of pure authored retreat = 30.25 px, then the 6th tick's smoothed-lateral (post-cap freeze) leaks an additional ~8 px backward via the same wall-clamp-velocity mechanism, pushing `backup_run` over 38.4.
+
+Same root cause — smoothed-lane bypasses the budget — just with a longer authored-retreat prefix.
+
+## 2. Ruling
+
+**Root cause: Riv's hypothesis #1, activated by wall-clamp.**
+
+Velocity-smoothing integrates state across ticks, and the arena-clamp removes the spatial consequence of that state on one axis without removing the velocity itself. The coupled oscillator created by the wall-clamp + orbit-direction-flip produces persistent backward drift that is never charged to `backup_distance`. This is not a calibration issue; it is a structural budget-bypass.
+
+**The invariant violated:** `backup_distance` was supposed to bound total per-period backward motion across all lanes. It does not. The smoothed-intent lane leaks.
+
+## 3. Fix directive for Nutts
+
+### 3.1 Change (canonical: close the smoothed-lane leak)
+
+**File:** `godot/combat/combat_sim.gd`
+
+**Where:** at every call site that writes `b.position += _smooth_velocity(b, desired, TICK_DELTA)` — there are ten of these (L483, L504, L556, L565, L579, L583, L985, L1005, L1033; plus the partial at L575 in stance-2 kiting). Route them all through a new helper.
+
+**New helper** (add near `_smooth_velocity`, below L876):
+
+```gdscript
+# S17.2-003 Addendum 1: apply a smoothed-intent displacement with a budget gate
+# on its backward-along-target component. Forward and perpendicular components
+# pass through untouched; any backward-along component is clamped against the
+# remaining `backup_distance` budget (same contract as separation L625 and
+# unstick nudge L790). Closes the wall-clamp + orbit-flip limit-cycle bypass
+# identified in the strict-zero moonwalk seeds 5/8/80/83.
+func _apply_smoothed_displacement(b: BrottState, delta: Vector2) -> void:
+	if b.target == null or delta.length_squared() < 0.0001:
+		b.position += delta
+		return
+	var to_target_v: Vector2 = b.target._pos_snapshot - b.position
+	if to_target_v.length_squared() < 0.0001:
+		b.position += delta
+		return
+	var to_target_n: Vector2 = to_target_v.normalized()
+	var along: float = delta.dot(to_target_n)
+	if along >= 0.0:
+		b.position += delta  # forward or purely perpendicular — passthrough
+		return
+	var perp_delta: Vector2 = delta - to_target_n * along
+	var remaining_budget: float = maxf(0.0, TILE_SIZE - b.backup_distance)
+	var backward_mag: float = minf(-along, remaining_budget)
+	b.backup_distance += backward_mag
+	b.position += perp_delta + to_target_n * (-backward_mag)
+```
+
+**Replace every** `b.position += _smooth_velocity(b, desired, TICK_DELTA)` **with**:
+
+```gdscript
+_apply_smoothed_displacement(b, _smooth_velocity(b, desired, TICK_DELTA))
+```
+
+**Do not** modify the existing direct-write retreat sites — they already manage `backup_distance` correctly. **Do not** touch `_smooth_velocity` itself — this is a post-processing gate on its output.
+
+### 3.2 Why this is the right shape
+
+- Same contract as separation (L625) and unstick (L790): any backward-component write costs budget; forward/perp passes through.
+- Single new helper — no combat-logic branching.
+- Revision §3 categorization stands: the smoothed-intent lane still does smoothed-intent; the direct-write retreats still do direct-write. The budget contract becomes uniform across all lanes.
+- Zero effect in open-space fights: when `delta` has no backward component (normal orbit, forward-chase, in-band lateral without wall-clamp), `along >= 0` and the gate is a passthrough.
+- Effect appears only when wall-clamp or stale-velocity rotation produces an incidental backward component — exactly the bug surface.
+
+### 3.3 Expected result
+
+- `test_sprint11_2.gd::test_away_juke_cap_across_seeds`: 4/100 → 0/100.
+- `test_sprint11.gd::test_no_moonwalking`: 4/100 → ≤2/100 (may improve; some of those seeds likely hit the same mechanism).
+- `test_s17_2_scout_feel.gd`: 15/15 unchanged (AC-T4 is a per-bot displacement bound, not a rate bound; the fix only reduces backward displacement).
+- Mirror-WR @ N=200: should remain in-band. The fix only converts incidental backward motion (which cost time but not budget) into perpendicular+zero motion (same tick cost, lower backward travel). Expected to slightly reduce the draw rate observed after the halving (29/200), since bots no longer linger along walls as long.
+
+### 3.4 Alternative considered and rejected
+
+**Zero the clamped axis of `b.velocity` at the arena-clamp site.** Simpler (3 LoC). Breaks the specific wall-clamp limit cycle. But it does not close the general bypass — any future smoothed-lane backward-drift case (pillar-repel, close-quarters rotation with stale velocity, etc.) remains unbudgeted. The canonical fix (§3.1) closes the class; the axis-zero fix closes one instance. Choosing the canonical fix.
+
+## 4. Spec consequence
+
+Revision §3 table classified write sites as direct-write (budget-aware) or smoothed-intent (budget-unaware, presumed respectful of target-direction semantics). That classification stands as written, but the **invariant** tightens:
+
+> **Invariant (S17.2-003 Add-1):** Every `b.position` write with a backward-along-target component charges that component to `backup_distance`, regardless of lane. The smoothed-intent lane is budget-aware for its backward-component output via `_apply_smoothed_displacement`, even though the smoothing itself is unconstrained.
+
+No change to the two-lane architecture. No change to `RETREAT_SPEED_MULT`. No new sub-sprint.
+
+## 5. Open questions for HCD
+
+None. Diagnosis is conclusive, fix is bounded, no creative-direction ambiguity.

--- a/docs/design/s17.2-003-retreat-calibration.md
+++ b/docs/design/s17.2-003-retreat-calibration.md
@@ -1,0 +1,198 @@
+# [S17.2-003] Addendum: two-phase-tick retreat calibration
+
+**Author:** Gizmo (design)
+**Date:** 2026-04-21
+**Status:** Supplements `s17.2-003-scout-feel-revision.md`. Does NOT replace it. All §2 audit, §3 bypass categorization, and §5 two-lane model stand as written.
+**Trigger:** Riv's consult during S17.2-003 final verification surfaced three mirror-match test regressions after two-phase-tick (snapshot-read) landed. Two trace to a single simultaneous-physics calibration; one traces to N=30 noise. This addendum closes both.
+
+---
+
+## 1. Context
+
+### 1.1 The two-phase tick
+
+S17.2-003 final impl introduced `_pos_snapshot` and routed cross-bot movement reads through it (Option A two-phase tick). The bias fix is clean — Scout-mirror WR moved from 86.2% to 58.3% (in band), swap-check 51.1% confirms the bias is gone.
+
+The mechanism matters for what follows: pre-change, the fixed iteration order made movement updates **sequential** — when two bots were too-close-overlapping, bot 0 retreated first (live pos updated), then bot 1 read bot 0's NEW position and saw itself as no-longer-too-close, so bot 1 didn't retreat. Per too-close pair, only one bot retreated per tick. Post-change, snapshot-reads make updates **simultaneous** — both bots see each other's pre-tick snapshot, both read "too close," both retreat in the same tick. Per-bot backward displacement per tick, averaged across the too-close window, roughly doubles.
+
+### 1.2 Three test regressions Riv flagged
+
+1. `test_sprint11.gd::test_no_moonwalking` (naive post-tick metric, AC6 threshold ≤10/100): **30/100 violations.**
+2. `test_sprint11_2.gd::test_away_juke_cap_across_seeds` (S15.2-refined intent-frame + period-reset + budget-gated metric, threshold 0/100): **6/100 violations.**
+3. `test_sprint13_3.gd::_run_matchup` Brawler-vs-Brawler mirror (N=30, band 35–65%): **72.7% team-0 WR.**
+
+### 1.3 Scope of this addendum
+
+Two separable calls:
+- (A) AC6 / strict-zero: what's the right combination of runtime tune and test hygiene?
+- (B) Brawler-mirror: real bug, or N=30 noise?
+
+Each has independent evidence; each is ruled separately below. Neither widens any AC threshold. The §5 two-lane model is unchanged.
+
+---
+
+## 2. Ruling — AC6 and strict-zero moonwalk
+
+**Ruling: Hybrid (C-flavored).** Two coordinated moves:
+
+1. **Runtime: introduce `RETREAT_SPEED_MULT = 0.50` that scales retreat-only writes at the three authored retreat sites.** Preserves orbit lateral feel and approach/commit/disengage speeds; halves the per-tick retreat step to restore pair-relative-separation rate under simultaneous physics.
+2. **Test: migrate `test_sprint11.gd::test_no_moonwalking` to the S15.2 refined-metric pattern** (intent-frame pre-tick + period-boundary reset + budget-gated accumulator, already canonical in `test_sprint11_2.gd::test_away_juke_cap_across_seeds`). Threshold stays ≤10/100 (unchanged).
+
+**No threshold relaxation.** Strict-zero stays 0/100. AC6 stays ≤10/100.
+
+### 2.1 Rationale
+
+**On the runtime side (half-step retreat).** Riv's lean (A) is principled and I concur: `ORBIT_SPEED_MULT`-style constants are *exactly* the tuning surface that should compensate for an order-of-resolution change. The invariant the AC is defending — "a bot should not feel like it moonwalks more than ~1 tile away" — is about visual personal-space feel, which is a **per-bot** experience. Halving the per-bot retreat step under simultaneous physics returns the per-bot retreat-time-to-resolve to its sequential-physics baseline, which is the baseline the AC was authored against. The pair-relative separation rate also returns to baseline (both bots moving at half-step in the same tick = same relative rate as one-bot-at-full-step in alternating ticks). This preserves the S11 authored feel on both axes: per-bot retreat cadence AND pair-apart rate.
+
+Threshold relaxation (Riv's B) is asymmetric debt — once ≤35/100 becomes "passing," the metric loses its regression-detection power. Occam plus S15.2's own scope-discipline principle ("the test was measuring the wrong thing; fix the test, don't re-floor the threshold") argue against raising thresholds when a tuning knob exists.
+
+**On the test side (migration).** `test_sprint11.gd::test_no_moonwalking` is still on the **pre-S15.2 naive metric** — post-tick `to_target`, no period-reset, no budget-gating. The S15.2 ruling (docs/design/sprint15-moonwalk-metric-ruling.md, main ruling + Addendum 1 + Addendum 2) explicitly declared the naive metric an artifact and migrated `test_sprint11_2.gd`. `test_sprint11.gd` was apparently missed in that migration. S17.2-003's simultaneous physics is simply making a latent measurement gap visible — post-cap perpendicular-to-current-tick motion reads as backward against a stale post-tick `to_target`, inflating the violation count.
+
+This is not AC relaxation. It is **paying down S15.2 test-migration debt** that was deferred (accidentally or otherwise) and has now surfaced. The AC threshold stays ≤10/100; after migration plus the `RETREAT_SPEED_MULT` change, expected outcome is ≤1–2/100, well under.
+
+### 2.2 Expected outcomes after both changes
+
+- `test_sprint11.gd::test_no_moonwalking`: 30/100 → ≤2/100 (both the metric fix and the retreat halving contribute).
+- `test_sprint11_2.gd::test_away_juke_cap_across_seeds`: 6/100 → 0/100 (retreat halving alone, since this test is already on the refined metric).
+
+If either test still fails after both changes, **stop and escalate to me** — that means there is a genuine pre-cap budget-bypass issue beyond the known separation-overlap exception (S15.2 Addendum 2), and we need a fresh design pass, not more tuning.
+
+### 2.3 Implementation directives (for Nutts)
+
+**Runtime change — `godot/combat/combat_sim.gd`:**
+
+1. Add a new constant alongside `ORBIT_SPEED_MULT` (currently line 48):
+
+   ```gdscript
+   const ORBIT_SPEED_MULT: float = 0.55
+   const RETREAT_SPEED_MULT: float = 0.50  # S17.2-003 addendum: per-tick retreat step under two-phase tick.
+                                            # Applied only to direct-write retreat sites (TENSION-too-close,
+                                            # RECOVERY-retreat, stance-driven retreats). Preserves pair-relative
+                                            # separation rate under simultaneous physics. See
+                                            # docs/design/s17.2-003-retreat-calibration.md.
+   ```
+
+2. Apply `RETREAT_SPEED_MULT` at the three authored retreat sites identified in the revision §3 audit. Specifically:
+
+   - **TENSION-too-close retreat** (currently ~L940 — the `dist < ideal - tolerance` branch inside phase 0). Change:
+
+     ```gdscript
+     var step: float = minf(orbit_spd, TILE_SIZE - b.backup_distance)
+     b.position -= to_target_n_t * step
+     b.backup_distance += step
+     ```
+
+     to:
+
+     ```gdscript
+     var retreat_step: float = minf(orbit_spd * RETREAT_SPEED_MULT, TILE_SIZE - b.backup_distance)
+     b.position -= to_target_n_t * retreat_step
+     b.backup_distance += retreat_step
+     ```
+
+   - **RECOVERY retreat** (currently ~L1013 — phase 2, `dist < ideal and b.backup_distance < TILE_SIZE`). Same pattern: wrap `recovery_spd` in `recovery_spd * RETREAT_SPEED_MULT` at the `minf` call.
+
+   - **Stance-driven retreats** (`_move_brott` sites #5 and #7 in revision §3 audit — stance=1 defensive retreat, stance=2 kiting retreat). Apply `RETREAT_SPEED_MULT` to the per-tick backward step at both sites. Keep the existing backup-budget accounting intact.
+
+   **Do NOT apply `RETREAT_SPEED_MULT` to:**
+   - Separation force writes (L557–568) — those are overlap resolution, not retreat intent.
+   - Unstick nudge — geometry-repel, not retreat intent.
+   - Lateral/orbit writes — those are orbit cadence, not retreat.
+   - Forward-chase, COMMIT dash, approach writes — obviously not retreat.
+
+3. **Do not move any lateral/orbit motion to this constant.** Nutts may be tempted to halve `ORBIT_SPEED_MULT` too "for symmetry" — **don't.** The orbit cadence is authored per S13.3 TCR tuning and is independent of this calibration.
+
+**Test change — `godot/tests/test_sprint11.gd::test_no_moonwalking` (currently ~L174–208):**
+
+Migrate to the S15.2-refined metric. Concretely, replace the body of the per-seed inner loop with the pattern from `test_sprint11_2.gd::test_away_juke_cap_across_seeds` (L91–120):
+
+```gdscript
+var prev_pos := b0.position
+var backup_run := 0.0
+var prev_bd := 0.0
+
+for _t in range(300):
+    if sim.match_over:
+        break
+    # Pre-tick intent-frame sampling (S15.2 ruling, main).
+    var to_target_pre: Vector2 = Vector2.ZERO
+    if b0.alive and b0.target != null:
+        to_target_pre = b0.target.position - b0.position
+    sim.simulate_tick()
+    if b0.alive and b0.target != null:
+        # Period-boundary reset (S15.2 Addendum 1): bd drop → new retreat period.
+        if b0.backup_distance < prev_bd:
+            backup_run = 0.0
+        prev_bd = b0.backup_distance
+        var movement: Vector2 = b0.position - prev_pos
+        if to_target_pre.length() > 0.1 and movement.length() > 0.1:
+            var dot: float = movement.normalized().dot(to_target_pre.normalized())
+            if dot < -0.7:
+                # Budget-gated accumulator (S15.2 Addendum 2): only accumulate
+                # while retreat period is live.
+                if b0.backup_distance < CombatSim.TILE_SIZE:
+                    backup_run += movement.length()
+                # else: post-cap freeze; wait for period-boundary reset.
+            else:
+                backup_run = 0.0
+        prev_pos = b0.position
+        if backup_run > 32.0 * 1.2:
+            violations += 1
+            break
+```
+
+Threshold stays `violations <= 10`. Update the comment block below the assertion to reference this addendum and the S15.2 ruling.
+
+### 2.4 AC-T4 — add new AC for retreat-step invariance under snapshot tick
+
+Per revision §6 (AC-T4 was recommended as a new AC but not yet landed), add a focused unit test in `godot/tests/test_s17_2_scout_feel.gd`:
+
+- Spawn two Scouts at `(200, 256)` and `(220, 256)` (overlapping).
+- Run 20 ticks.
+- Assert: for each bot, total backward displacement (intent-frame, summed across all `dot < -0.7` ticks regardless of period breaks) is ≤ `TILE_SIZE * 2 + 2 px` (one TENSION retreat budget + one RECOVERY retreat budget + small margin for float).
+
+This is a **tuning-invariant guardrail** — if a future change to `RETREAT_SPEED_MULT` or the two-phase tick breaks the per-bot bound, this test catches it before it propagates into `test_sprint11_2.gd` as a violation spike.
+
+Nutts's lane: define the test. AC threshold and cycle budget are set above.
+
+---
+
+## 3. Ruling — Brawler-mirror 72.7% at N=30
+
+**Ruling: N=30 variance. No runtime fix required. Keep the existing `test_sprint13_3.gd` N=30 threshold; optionally note the variance floor in a comment.**
+
+### 3.1 Evidence
+
+I ran Brawler-vs-Brawler mirror at N=100 via a purpose-built diagnostic (`godot/tests/diag_brawler_mirror_n100.gd`, added this branch):
+
+```
+Brawler-mirror canonical (L=team0) N=100: team0=47 team1=35 draws=18 team0_WR=57.3%
+Brawler-mirror swapped  (L=team1) N=100: team0=35 team1=47 draws=18 team0_WR=42.7%
+```
+
+**Team-0 WR: 57.3% at N=100, in band [35%, 65%].** The swap is perfectly symmetric (57.3% ↔ 42.7%, same margin inverted) — confirming what the Scout-mirror swap test already confirmed: the two-phase tick removed team-id bias cleanly. The remaining left-spawn preference (~14 pt) is small and symmetric, explainable by minor RNG interactions with the fixed asymmetric spawn coordinates.
+
+### 3.2 Why N=30 misled us
+
+N=30 with a true win rate near ~55% has a 1-sigma standard error of ~9 percentage points. A ~72% observed WR is within ~2σ of a true 55% — unusual but not pathological. At this sample size, the 65% upper band is genuinely within reach for mirror matchups that have even a small left-spawn preference. The Brawler chassis's specific `max_angular_velocity = 270°/s` and `current_speed` profile don't materially change this — the chassis-specific hypotheses in Riv's brief (angular cap, stance-2 kiting fraction, range-tolerance oscillation) are not supported by the N=100 data.
+
+### 3.3 Why I'm not recommending a runtime chassis-tuning change
+
+Two reasons:
+
+1. **The data doesn't support one.** N=100 is well inside the 35–65% band. There is no symptom to fix.
+2. **Per-chassis angular-cap tuning is a §4.5 design surface** (per original scout-feel spec and Nutts's hand-tuned values in `brott_state.gd` L147–155). Touching it for a non-existent bug would violate scope discipline and could regress Scout-mirror balance as collateral damage.
+
+### 3.4 Nutts's task here
+
+None. Just note in the Brawler test's inline comment (if one exists) that the WR floor was verified at N=100 post-S17.2-003 and is 57.3% (within band).
+
+### 3.5 Open item for Ett / Riv (post-merge)
+
+Consider raising `test_sprint13_3.gd`'s `SIMS_PER_MATCHUP` from 30 to 60 or 100. The current 30-sample cap is a CI-time concession; we've been eating ~8-point variance as "noise" on every mirror matchup for five sprints. This is an S18 discussion, not an S17.2-003 blocker.
+
+---
+
+## 4. One-line summary for Riv
+
+AC6 / strict-zero: **C-flavored** — introduce `RETREAT_SPEED_MULT = 0.50` to halve per-tick retreat step (preserves pair-relative separation under simultaneous physics) AND migrate `test_sprint11.gd::test_no_moonwalking` to the S15.2-canonical intent-frame + period-reset + budget-gated metric (pays down deferred S15.2 migration debt). No threshold relaxation. Brawler-mirror: **N=30 noise**, N=100 verified at 57.3% in band. No runtime change.

--- a/godot/combat/brott_state.gd
+++ b/godot/combat/brott_state.gd
@@ -24,6 +24,9 @@ var dodge_chance: float = 0.0
 var hp: float = 0.0
 var energy: float = 100.0
 var position: Vector2 = Vector2.ZERO
+# S17.2-003: Real velocity vector. Previously vestigial; now the first-class
+# state written by CombatSim._smooth_velocity() on smoothed-intent ticks.
+# See docs/design/s17.2-scout-feel.md §4.1 and s17.2-003-scout-feel-revision.md §5.
 var velocity: Vector2 = Vector2.ZERO
 var current_speed: float = 0.0  # current movement speed (px/s)
 var facing_angle: float = 0.0  # visual sprite rotation (degrees)
@@ -69,6 +72,17 @@ var target: BrottState = null
 # Combat movement state
 var in_combat_movement: bool = false
 var orbit_direction: int = 1  # 1 = CW, -1 = CCW
+
+# S17.2-003: Per-chassis angular-velocity cap (rad/s). Derived at setup() from
+# chassis_type. Kept off `chassis_data.gd` to preserve the S17.2 scope gate on
+# godot/data/**. See docs/design/s17.2-scout-feel.md §4.1, §4.5.
+var max_angular_velocity: float = 0.0  # rad/s
+
+# S17.2-003: Reversal damping timer for the "plant foot" dip on hard > 120°
+# forward-intent reversals. Armed by _smooth_velocity when an intent reversal
+# is detected; decremented per tick; consumed by the magnitude blend step.
+# Bypass writes (retreat, separation, unstick) never arm this timer.
+var reversal_damping_timer: int = 0  # ticks remaining at REVERSAL_DAMPING_FACTOR
 
 # S14.1-B: Wall-stuck detection. Rolling history of last N positions sampled each
 # tick. If total displacement over the window is <STUCK_MIN_PX while alive+has
@@ -116,6 +130,21 @@ func setup() -> void:
 	dodge_chance = ch["dodge_chance"]
 	energy = 100.0
 	alive = true
+
+	# S17.2-003: hand-tuned angular caps (per spec §4.5). NOT data-driven —
+	# values live here instead of chassis_data.gd to keep the godot/data/**
+	# scope gate closed.
+	match chassis_type:
+		ChassisData.ChassisType.SCOUT:
+			max_angular_velocity = deg_to_rad(540.0)  # 1.5 turns/s
+		ChassisData.ChassisType.BRAWLER:
+			max_angular_velocity = deg_to_rad(270.0)
+		ChassisData.ChassisType.FORTRESS:
+			max_angular_velocity = deg_to_rad(150.0)
+		_:
+			max_angular_velocity = deg_to_rad(270.0)  # safe default
+	velocity = Vector2.ZERO
+	reversal_damping_timer = 0
 	
 	weapon_cooldowns.clear()
 	for _w in weapon_types:

--- a/godot/combat/brott_state.gd
+++ b/godot/combat/brott_state.gd
@@ -24,6 +24,16 @@ var dodge_chance: float = 0.0
 var hp: float = 0.0
 var energy: float = 100.0
 var position: Vector2 = Vector2.ZERO
+# S17.2-003 (phase 3 — mirror-symmetry fix): Pre-movement position snapshot,
+# written by CombatSim.simulate_tick() at the start of the movement loop and
+# read by cross-bot movement code in place of `target.position` / `other.position`.
+# This eliminates the sequential-update bias that caused team-0 WR = 80% in
+# Scout-vs-Scout mirror matches (each bot saw the current-tick-updated position
+# of bots that moved before it; team 0 always moved first). See
+# docs/design/s17.2-003-scout-feel-revision.md §3 and the [S17.2-003] commit
+# body on brott_state.gd that added this field. Separation still reads LIVE
+# positions (snapshotting breaks overlap resolution — see combat_sim.gd).
+var _pos_snapshot: Vector2 = Vector2.ZERO
 # S17.2-003: Real velocity vector. Previously vestigial; now the first-class
 # state written by CombatSim._smooth_velocity() on smoothed-intent ticks.
 # See docs/design/s17.2-scout-feel.md §4.1 and s17.2-003-scout-feel-revision.md §5.

--- a/godot/combat/combat_sim.gd
+++ b/godot/combat/combat_sim.gd
@@ -46,6 +46,12 @@ const COMMIT_SPEED_MULT: float = 1.4
 # are unaffected by the cap; only Scout's commit is clipped to 200 px/s.
 const COMMIT_SPEED_CAP: float = 200.0
 const ORBIT_SPEED_MULT: float = 0.55
+# S17.2-003 addendum: per-tick retreat step under two-phase tick.
+# Applied only to direct-write retreat sites (TENSION-too-close,
+# RECOVERY-retreat, stance-driven retreats). Preserves pair-relative
+# separation rate under simultaneous physics. See
+# docs/design/s17.2-003-retreat-calibration.md.
+const RETREAT_SPEED_MULT: float = 0.50
 const APPROACH_SPEED_MULT: float = 0.80
 const DISENGAGE_SPEED_MULT: float = 0.90
 const TENSION_DRIFT_INTERVAL: int = 10  # ticks (1.0s)
@@ -551,7 +557,8 @@ func _move_brott(b: BrottState) -> void:
 				1:  # Defensive
 					if dist < max_weapon_range * 0.8:
 						# Direct-write (#5): stance-driven retreat. Bypass smoothing.
-						b.position -= to_target_n_pre * approach_spd
+						# S17.2-003 addendum: halve retreat step under two-phase tick.
+						b.position -= to_target_n_pre * approach_spd * RETREAT_SPEED_MULT
 					elif dist > max_weapon_range:
 						# Smoothed (#6): forward-chase to range.
 						var desired_vel_d: Vector2 = to_target_n_pre * b.current_speed
@@ -561,7 +568,8 @@ func _move_brott(b: BrottState) -> void:
 					var perp_k: Vector2 = Vector2(-to_target.y, to_target.x).normalized()
 					if dist < ideal_k * 0.8:
 						# Split: retreat bypasses (#7), lateral is smoothed (#8).
-						b.position -= to_target_n_pre * approach_spd * 0.7
+						# S17.2-003 addendum: halve retreat step under two-phase tick.
+						b.position -= to_target_n_pre * approach_spd * 0.7 * RETREAT_SPEED_MULT
 						var desired_vel_kl: Vector2 = perp_k * b.current_speed * 0.3
 						if desired_vel_kl.length_squared() > 0.0001:
 							b.position += _smooth_velocity(b, desired_vel_kl, TICK_DELTA)
@@ -937,7 +945,8 @@ func _do_combat_movement(b: BrottState, base_spd: float) -> void:
 				if b.backup_distance < TILE_SIZE:
 					# Direct-write (#21): TENSION-too-close retreat. Bypass smoothing
 					# so backup_distance budget stays tick-accurate (revision §3.2).
-					var step: float = minf(orbit_spd, TILE_SIZE - b.backup_distance)
+					# S17.2-003 addendum: halve retreat step under two-phase tick.
+					var step: float = minf(orbit_spd * RETREAT_SPEED_MULT, TILE_SIZE - b.backup_distance)
 					b.position -= to_target_n_t * step
 					b.backup_distance += step
 				else:
@@ -1010,7 +1019,8 @@ func _do_combat_movement(b: BrottState, base_spd: float) -> void:
 			if dist < ideal and b.backup_distance < TILE_SIZE:
 				# Direct-write (#26): RECOVERY retreat. Bypass smoothing; same
 				# backup-budget invariant as #21.
-				var step: float = minf(recovery_spd, TILE_SIZE - b.backup_distance)
+				# S17.2-003 addendum: halve retreat step under two-phase tick.
+				var step: float = minf(recovery_spd * RETREAT_SPEED_MULT, TILE_SIZE - b.backup_distance)
 				b.position -= to_target_n_r * step
 				b.backup_distance += step
 			else:

--- a/godot/combat/combat_sim.gd
+++ b/godot/combat/combat_sim.gd
@@ -453,12 +453,17 @@ func _move_brott(b: BrottState) -> void:
 		var center := Vector2(8.0 * TILE_SIZE, 8.0 * TILE_SIZE)
 		var to_center := center - b.position
 		if to_center.length() > spd:
-			b.position += to_center.normalized() * spd
+			# Smoothed-intent lane (#1 per revision §2): forward-chase to center.
+			var desired_vel_c: Vector2 = to_center.normalized() * b.current_speed
+			b.position += _smooth_velocity(b, desired_vel_c, TICK_DELTA)
 		else:
+			# Direct-write lane (#2): absolute snap when within one step. Reset
+			# velocity so the next smoothed call doesn't inherit stale momentum.
 			b.position = center
+			b.velocity = Vector2.ZERO
 	elif move_override == "cover":
 		b.accelerate_toward_speed(target_speed, TICK_DELTA)
-		var spd: float = b.current_speed * TICK_DELTA
+		var _spd: float = b.current_speed * TICK_DELTA
 		var best_pillar := Vector2.ZERO
 		var best_dist := INF
 		for p in _get_pillar_positions():
@@ -467,7 +472,11 @@ func _move_brott(b: BrottState) -> void:
 				best_dist = d
 				best_pillar = p
 		if best_dist > 32.0:
-			b.position += (best_pillar - b.position).normalized() * spd
+			# Smoothed-intent lane (#3): forward-chase toward cover pillar.
+			var to_pillar_v: Vector2 = best_pillar - b.position
+			if to_pillar_v.length_squared() > 0.0001:
+				var desired_vel_p: Vector2 = to_pillar_v.normalized() * b.current_speed
+				b.position += _smooth_velocity(b, desired_vel_p, TICK_DELTA)
 	else:
 		var to_target: Vector2 = b.target.position - b.position
 		var dist: float = to_target.length()
@@ -504,27 +513,47 @@ func _move_brott(b: BrottState) -> void:
 			if wants_to_move:
 				b.accelerate_toward_speed(approach_target_speed, TICK_DELTA)
 			var approach_spd: float = b.current_speed * TICK_DELTA
-			# Stance-based pathfinding (pre-engagement or ambush)
+			# Stance-based pathfinding (pre-engagement or ambush). Forward-chase
+			# and lateral-orbit sites go through the smoothed-intent lane
+			# (revision §2 #4, #6, #8, #9, #10). Stance-driven retreat (#5, #7)
+			# bypasses smoothing: discrete "back off" decision; sharpness preserves
+			# stance feel S11/S13 tuned. Retreat writes touch b.position directly
+			# and do NOT update b.velocity.
+			var to_target_n_pre: Vector2 = Vector2.ZERO
+			if to_target.length_squared() > 0.0001:
+				to_target_n_pre = to_target.normalized()
 			match b.stance:
 				0:  # Aggressive — close to engagement distance
 					var engage: Dictionary = _get_engagement_distance(b)
 					if dist > engage["ideal"] + engage["tolerance"]:
-						b.position += to_target.normalized() * approach_spd
+						# Smoothed (#4).
+						var desired_vel_a: Vector2 = to_target_n_pre * b.current_speed
+						b.position += _smooth_velocity(b, desired_vel_a, TICK_DELTA)
 				1:  # Defensive
 					if dist < max_weapon_range * 0.8:
-						b.position -= to_target.normalized() * approach_spd
+						# Direct-write (#5): stance-driven retreat. Bypass smoothing.
+						b.position -= to_target_n_pre * approach_spd
 					elif dist > max_weapon_range:
-						b.position += to_target.normalized() * approach_spd
+						# Smoothed (#6): forward-chase to range.
+						var desired_vel_d: Vector2 = to_target_n_pre * b.current_speed
+						b.position += _smooth_velocity(b, desired_vel_d, TICK_DELTA)
 				2:  # Kiting
-					var ideal: float = max_weapon_range * 0.7
-					var perp: Vector2 = Vector2(-to_target.y, to_target.x).normalized()
-					if dist < ideal * 0.8:
-						b.position -= to_target.normalized() * approach_spd * 0.7
-						b.position += perp * approach_spd * 0.3
-					elif dist > ideal * 1.2:
-						b.position += to_target.normalized() * approach_spd
+					var ideal_k: float = max_weapon_range * 0.7
+					var perp_k: Vector2 = Vector2(-to_target.y, to_target.x).normalized()
+					if dist < ideal_k * 0.8:
+						# Split: retreat bypasses (#7), lateral is smoothed (#8).
+						b.position -= to_target_n_pre * approach_spd * 0.7
+						var desired_vel_kl: Vector2 = perp_k * b.current_speed * 0.3
+						if desired_vel_kl.length_squared() > 0.0001:
+							b.position += _smooth_velocity(b, desired_vel_kl, TICK_DELTA)
+					elif dist > ideal_k * 1.2:
+						# Smoothed (#9): forward-chase.
+						var desired_vel_ka: Vector2 = to_target_n_pre * b.current_speed
+						b.position += _smooth_velocity(b, desired_vel_ka, TICK_DELTA)
 					else:
-						b.position += perp * approach_spd
+						# Smoothed (#10): lateral-orbit.
+						var desired_vel_ko: Vector2 = perp_k * b.current_speed
+						b.position += _smooth_velocity(b, desired_vel_ko, TICK_DELTA)
 				3:  # Ambush
 					pass
 	
@@ -870,27 +899,62 @@ func _do_combat_movement(b: BrottState, base_spd: float) -> void:
 				b.tension_drift_timer = TENSION_DRIFT_INTERVAL
 				drift_offset = TENSION_DRIFT_AMOUNT * TILE_SIZE * (1.0 if rng.randf() < 0.5 else -1.0)
 			
+			# S17.2-003: smoothed-intent accumulator for this tick. Retreat writes
+			# (revision §2 #21) bypass this accumulator and write b.position
+			# directly so the backup_distance budget stays tick-accurate.
+			var desired_vel_t: Vector2 = Vector2.ZERO
+			var to_target_n_t: Vector2 = Vector2.ZERO
+			if to_target.length_squared() > 0.0001:
+				to_target_n_t = to_target.normalized()
+			var perp_t: Vector2 = Vector2(-to_target.y, to_target.x)
+			if perp_t.length_squared() > 0.0001:
+				perp_t = perp_t.normalized()
+			
 			if dist > ideal + tolerance:
-				b.position += to_target.normalized() * orbit_spd
+				# Smoothed (#20): forward-chase toward target.
+				desired_vel_t += to_target_n_t * b.current_speed
 				b.backup_distance = 0.0
 			elif dist < ideal - tolerance:
 				if b.backup_distance < TILE_SIZE:
+					# Direct-write (#21): TENSION-too-close retreat. Bypass smoothing
+					# so backup_distance budget stays tick-accurate (revision §3.2).
 					var step: float = minf(orbit_spd, TILE_SIZE - b.backup_distance)
-					b.position -= to_target.normalized() * step
+					b.position -= to_target_n_t * step
 					b.backup_distance += step
 				else:
-					var perp: Vector2 = Vector2(-to_target.y, to_target.x).normalized()
-					b.position += perp * float(b.orbit_direction) * orbit_spd
+					# Smoothed (#22): budget-exhausted lateral orbit.
+					desired_vel_t += perp_t * float(b.orbit_direction) * b.current_speed
 					b.backup_distance = 0.0
 			else:
-				var perp: Vector2 = Vector2(-to_target.y, to_target.x).normalized()
-				b.position += perp * float(b.orbit_direction) * orbit_spd
+				# Smoothed (#23): in-band lateral orbit.
+				desired_vel_t += perp_t * float(b.orbit_direction) * b.current_speed
 				b.backup_distance = 0.0
 			
-			# Apply drift perpendicular nudge
+			# S17.2-003 deviation from revision §5.3: drift nudge is NOT routed
+			# through the smoothed-intent accumulator.
+			#
+			# Background: the revision's §5.3 pseudocode lists the drift nudge as
+			# site #24 (smoothed). Implementing it that way drove the mirror
+			# Scout-vs-Scout WR from baseline 53% to 86% team-0 bias. Diagnosis
+			# (empirical, diag_mirror.gd): feeding drift through _smooth_velocity
+			# amplifies a ~0.3-tile one-shot displacement into ~2–3 ticks of
+			# persistent lateral momentum. Because the TENSION RNG draw for
+			# drift direction is consumed sequentially (team 0 first, team 1
+			# second) and velocity inherits across ticks, the lateral momentum
+			# compounds asymmetrically.
+			#
+			# Fix: zero the drift contribution for now. The drift effect is
+			# preserved in principle — it could be re-introduced by a Gizmo
+			# design pass that accounts for tick-order symmetry (e.g. paired RNG,
+			# or synchronized drift direction across both bots). That is out of
+			# scope for S17.2-003. Treating it as a direct-write at 0.3 tile is
+			# also asymmetric (tested: 81.5% bias), so full removal is the
+			# cleanest neutral state until the design question is answered.
 			if drift_offset != 0.0:
-				var perp: Vector2 = Vector2(-to_target.y, to_target.x).normalized()
-				b.position += perp * drift_offset
+				pass
+			
+			if desired_vel_t.length_squared() > 0.0001:
+				b.position += _smooth_velocity(b, desired_vel_t, TICK_DELTA)
 		
 		1:  # COMMIT — dash toward target at 140% base speed (capped at COMMIT_SPEED_CAP px/s, S13.3)
 			# Pre-afterburner/overtime commit target is min(base_speed * 1.4, COMMIT_SPEED_CAP).
@@ -902,13 +966,15 @@ func _do_combat_movement(b: BrottState, base_spd: float) -> void:
 			if overtime_active:
 				commit_target_speed *= OVERTIME_SPEED_MULT
 			b.accelerate_toward_speed(commit_target_speed, TICK_DELTA)
-			var commit_spd: float = b.current_speed * TICK_DELTA
+			var _commit_spd: float = b.current_speed * TICK_DELTA
 			
-			# Dash toward target, but don't get closer than 0.5 tiles
+			# Dash toward target, but don't get closer than 0.5 tiles.
+			# Smoothed (#25): canonical scout-feel forward-chase.
 			var min_dist: float = 0.5 * TILE_SIZE
 			var commit_target_dist: float = maxf(ideal - 1.5 * TILE_SIZE, min_dist)
-			if dist > commit_target_dist:
-				b.position += to_target.normalized() * commit_spd
+			if dist > commit_target_dist and to_target.length_squared() > 0.0001:
+				var desired_vel_c: Vector2 = to_target.normalized() * b.current_speed
+				b.position += _smooth_velocity(b, desired_vel_c, TICK_DELTA)
 		
 		2:  # RECOVERY — retreat back toward ideal engagement distance
 			var recovery_target_speed: float = b.base_speed * DISENGAGE_SPEED_MULT
@@ -919,16 +985,23 @@ func _do_combat_movement(b: BrottState, base_spd: float) -> void:
 			b.accelerate_toward_speed(recovery_target_speed, TICK_DELTA)
 			var recovery_spd: float = b.current_speed * TICK_DELTA
 			
-			# Move away from target back toward ideal distance
-			# Respect backup_distance cap (max 1 tile retreat before lateral)
+			var to_target_n_r: Vector2 = Vector2.ZERO
+			if to_target.length_squared() > 0.0001:
+				to_target_n_r = to_target.normalized()
 			if dist < ideal and b.backup_distance < TILE_SIZE:
+				# Direct-write (#26): RECOVERY retreat. Bypass smoothing; same
+				# backup-budget invariant as #21.
 				var step: float = minf(recovery_spd, TILE_SIZE - b.backup_distance)
-				b.position -= to_target.normalized() * step
+				b.position -= to_target_n_r * step
 				b.backup_distance += step
 			else:
-				# Lateral movement once backup cap reached
-				var perp: Vector2 = Vector2(-to_target.y, to_target.x).normalized()
-				b.position += perp * float(b.orbit_direction) * recovery_spd
+				# Smoothed (#27): lateral once backup budget is exhausted (or
+				# already at/beyond ideal).
+				var perp_r: Vector2 = Vector2(-to_target.y, to_target.x)
+				if perp_r.length_squared() > 0.0001:
+					perp_r = perp_r.normalized()
+					var desired_vel_r: Vector2 = perp_r * float(b.orbit_direction) * b.current_speed
+					b.position += _smooth_velocity(b, desired_vel_r, TICK_DELTA)
 
 func _get_max_weapon_range_px(b: BrottState) -> float:
 	var max_r: float = 0.0

--- a/godot/combat/combat_sim.gd
+++ b/godot/combat/combat_sim.gd
@@ -480,7 +480,7 @@ func _move_brott(b: BrottState) -> void:
 		if to_center.length() > spd:
 			# Smoothed-intent lane (#1 per revision §2): forward-chase to center.
 			var desired_vel_c: Vector2 = to_center.normalized() * b.current_speed
-			b.position += _smooth_velocity(b, desired_vel_c, TICK_DELTA)
+			_apply_smoothed_displacement(b, _smooth_velocity(b, desired_vel_c, TICK_DELTA))
 		else:
 			# Direct-write lane (#2): absolute snap when within one step. Reset
 			# velocity so the next smoothed call doesn't inherit stale momentum.
@@ -501,7 +501,7 @@ func _move_brott(b: BrottState) -> void:
 			var to_pillar_v: Vector2 = best_pillar - b.position
 			if to_pillar_v.length_squared() > 0.0001:
 				var desired_vel_p: Vector2 = to_pillar_v.normalized() * b.current_speed
-				b.position += _smooth_velocity(b, desired_vel_p, TICK_DELTA)
+				_apply_smoothed_displacement(b, _smooth_velocity(b, desired_vel_p, TICK_DELTA))
 	else:
 		var to_target: Vector2 = b.target._pos_snapshot - b.position
 		var dist: float = to_target.length()
@@ -553,7 +553,7 @@ func _move_brott(b: BrottState) -> void:
 					if dist > engage["ideal"] + engage["tolerance"]:
 						# Smoothed (#4).
 						var desired_vel_a: Vector2 = to_target_n_pre * b.current_speed
-						b.position += _smooth_velocity(b, desired_vel_a, TICK_DELTA)
+						_apply_smoothed_displacement(b, _smooth_velocity(b, desired_vel_a, TICK_DELTA))
 				1:  # Defensive
 					if dist < max_weapon_range * 0.8:
 						# Direct-write (#5): stance-driven retreat. Bypass smoothing.
@@ -562,7 +562,7 @@ func _move_brott(b: BrottState) -> void:
 					elif dist > max_weapon_range:
 						# Smoothed (#6): forward-chase to range.
 						var desired_vel_d: Vector2 = to_target_n_pre * b.current_speed
-						b.position += _smooth_velocity(b, desired_vel_d, TICK_DELTA)
+						_apply_smoothed_displacement(b, _smooth_velocity(b, desired_vel_d, TICK_DELTA))
 				2:  # Kiting
 					var ideal_k: float = max_weapon_range * 0.7
 					var perp_k: Vector2 = Vector2(-to_target.y, to_target.x).normalized()
@@ -572,15 +572,15 @@ func _move_brott(b: BrottState) -> void:
 						b.position -= to_target_n_pre * approach_spd * 0.7 * RETREAT_SPEED_MULT
 						var desired_vel_kl: Vector2 = perp_k * b.current_speed * 0.3
 						if desired_vel_kl.length_squared() > 0.0001:
-							b.position += _smooth_velocity(b, desired_vel_kl, TICK_DELTA)
+							_apply_smoothed_displacement(b, _smooth_velocity(b, desired_vel_kl, TICK_DELTA))
 					elif dist > ideal_k * 1.2:
 						# Smoothed (#9): forward-chase.
 						var desired_vel_ka: Vector2 = to_target_n_pre * b.current_speed
-						b.position += _smooth_velocity(b, desired_vel_ka, TICK_DELTA)
+						_apply_smoothed_displacement(b, _smooth_velocity(b, desired_vel_ka, TICK_DELTA))
 					else:
 						# Smoothed (#10): lateral-orbit.
 						var desired_vel_ko: Vector2 = perp_k * b.current_speed
-						b.position += _smooth_velocity(b, desired_vel_ko, TICK_DELTA)
+						_apply_smoothed_displacement(b, _smooth_velocity(b, desired_vel_ko, TICK_DELTA))
 				3:  # Ambush
 					pass
 	
@@ -875,6 +875,31 @@ func _smooth_velocity(b: BrottState, desired: Vector2, dt: float) -> Vector2:
 
 	return b.velocity * dt
 
+# S17.2-003 Addendum 1: apply a smoothed-intent displacement with a budget gate
+# on its backward-along-target component. Forward and perpendicular components
+# pass through untouched; any backward-along component is clamped against the
+# remaining `backup_distance` budget (same contract as separation L625 and
+# unstick nudge L790). Closes the wall-clamp + orbit-flip limit-cycle bypass
+# identified in the strict-zero moonwalk seeds 5/8/80/83.
+func _apply_smoothed_displacement(b: BrottState, delta: Vector2) -> void:
+	if b.target == null or delta.length_squared() < 0.0001:
+		b.position += delta
+		return
+	var to_target_v: Vector2 = b.target._pos_snapshot - b.position
+	if to_target_v.length_squared() < 0.0001:
+		b.position += delta
+		return
+	var to_target_n: Vector2 = to_target_v.normalized()
+	var along: float = delta.dot(to_target_n)
+	if along >= 0.0:
+		b.position += delta  # forward or purely perpendicular — passthrough
+		return
+	var perp_delta: Vector2 = delta - to_target_n * along
+	var remaining_budget: float = maxf(0.0, TILE_SIZE - b.backup_distance)
+	var backward_mag: float = minf(-along, remaining_budget)
+	b.backup_distance += backward_mag
+	b.position += perp_delta + to_target_n * (-backward_mag)
+
 func _do_combat_movement(b: BrottState, base_spd: float) -> void:
 	var to_target: Vector2 = b.target._pos_snapshot - b.position
 	var dist: float = to_target.length()
@@ -982,7 +1007,7 @@ func _do_combat_movement(b: BrottState, base_spd: float) -> void:
 				pass
 			
 			if desired_vel_t.length_squared() > 0.0001:
-				b.position += _smooth_velocity(b, desired_vel_t, TICK_DELTA)
+				_apply_smoothed_displacement(b, _smooth_velocity(b, desired_vel_t, TICK_DELTA))
 		
 		1:  # COMMIT — dash toward target at 140% base speed (capped at COMMIT_SPEED_CAP px/s, S13.3)
 			# Pre-afterburner/overtime commit target is min(base_speed * 1.4, COMMIT_SPEED_CAP).
@@ -1002,7 +1027,7 @@ func _do_combat_movement(b: BrottState, base_spd: float) -> void:
 			var commit_target_dist: float = maxf(ideal - 1.5 * TILE_SIZE, min_dist)
 			if dist > commit_target_dist and to_target.length_squared() > 0.0001:
 				var desired_vel_c: Vector2 = to_target.normalized() * b.current_speed
-				b.position += _smooth_velocity(b, desired_vel_c, TICK_DELTA)
+				_apply_smoothed_displacement(b, _smooth_velocity(b, desired_vel_c, TICK_DELTA))
 		
 		2:  # RECOVERY — retreat back toward ideal engagement distance
 			var recovery_target_speed: float = b.base_speed * DISENGAGE_SPEED_MULT
@@ -1030,7 +1055,7 @@ func _do_combat_movement(b: BrottState, base_spd: float) -> void:
 				if perp_r.length_squared() > 0.0001:
 					perp_r = perp_r.normalized()
 					var desired_vel_r: Vector2 = perp_r * float(b.orbit_direction) * b.current_speed
-					b.position += _smooth_velocity(b, desired_vel_r, TICK_DELTA)
+					_apply_smoothed_displacement(b, _smooth_velocity(b, desired_vel_r, TICK_DELTA))
 
 func _get_max_weapon_range_px(b: BrottState) -> float:
 	var max_r: float = 0.0

--- a/godot/combat/combat_sim.gd
+++ b/godot/combat/combat_sim.gd
@@ -51,6 +51,13 @@ const DISENGAGE_SPEED_MULT: float = 0.90
 const TENSION_DRIFT_INTERVAL: int = 10  # ticks (1.0s)
 const TENSION_DRIFT_AMOUNT: float = 0.3  # tiles
 
+# S17.2-003: Scout-feel velocity-smoothing constants. Kept in combat_sim.gd
+# (not chassis_data.gd) to preserve the godot/data/** scope gate. See
+# docs/design/s17.2-scout-feel.md §4.5 and s17.2-003-scout-feel-revision.md.
+const REVERSAL_ANGLE_THRESHOLD_DEG: float = 120.0
+const REVERSAL_DAMPING_FACTOR: float = 0.35
+const REVERSAL_DAMPING_TICKS: int = 2
+
 var brotts: Array[BrottState] = []
 var projectiles: Array[Projectile] = []
 var rng: RandomNumberGenerator
@@ -745,6 +752,72 @@ func _apply_unstick_nudge(b: BrottState, push: Vector2) -> void:
 	var arena_px2: float = 16.0 * TILE_SIZE
 	b.position.x = clampf(b.position.x, BOT_HITBOX_RADIUS, arena_px2 - BOT_HITBOX_RADIUS)
 	b.position.y = clampf(b.position.y, BOT_HITBOX_RADIUS, arena_px2 - BOT_HITBOX_RADIUS)
+
+# S17.2-003: Velocity-smoothing helper. Single writer of b.velocity.
+#
+# Math per docs/design/s17.2-scout-feel.md §4.2:
+#   1. Rotate current velocity toward desired direction, capped by per-tick
+#      max_angular_velocity. Large rotations (> REVERSAL_ANGLE_THRESHOLD_DEG)
+#      arm a short damping timer.
+#   2. Blend magnitude toward |desired| using chassis accel/decel. While the
+#      damping timer is active, the target magnitude is scaled by
+#      REVERSAL_DAMPING_FACTOR to produce the visible "plant foot" dip.
+#   3. Write the blended vector back to b.velocity and return realized
+#      displacement (velocity * dt) for the caller to apply to b.position.
+#
+# IMPORTANT: this is the SMOOTHED-INTENT lane only. Retreat, separation,
+# pillar-repel, arena clamp, and unstick writes all BYPASS this helper and
+# write b.position directly without touching b.velocity. See the revision doc
+# (docs/design/s17.2-003-scout-feel-revision.md) §2 for the full site table.
+func _smooth_velocity(b: BrottState, desired: Vector2, dt: float) -> Vector2:
+	var cur: Vector2 = b.velocity
+	var des: Vector2 = desired
+	var cur_len_sq: float = cur.length_squared()
+	var des_len_sq: float = des.length_squared()
+
+	# Step 1: rotate current velocity toward desired direction (angular cap).
+	var large_reversal: bool = false
+	if cur_len_sq > 0.0001 and des_len_sq > 0.0001:
+		var cur_angle: float = cur.angle()
+		var des_angle: float = des.angle()
+		var angle_diff: float = wrapf(des_angle - cur_angle, -PI, PI)
+		var max_rot: float = b.max_angular_velocity * dt
+		var rot: float = clampf(angle_diff, -max_rot, max_rot)
+		cur = cur.rotated(rot)
+		if absf(angle_diff) > deg_to_rad(REVERSAL_ANGLE_THRESHOLD_DEG):
+			large_reversal = true
+
+	# Arm reversal damping on large intent reversals. The timer is consumed by
+	# the magnitude step below; bypass writes (retreat, etc.) never arm it.
+	if large_reversal and b.reversal_damping_timer <= 0:
+		b.reversal_damping_timer = REVERSAL_DAMPING_TICKS
+
+	# Step 2: blend magnitude toward |des| at chassis accel/decel.
+	var cur_mag: float = cur.length()
+	var des_mag: float = des.length()
+	var target_mag: float = des_mag
+	if b.reversal_damping_timer > 0:
+		target_mag = des_mag * REVERSAL_DAMPING_FACTOR
+	var mag_delta: float
+	if target_mag > cur_mag:
+		mag_delta = minf(b.get_effective_accel() * dt, target_mag - cur_mag)
+	else:
+		mag_delta = -minf(b.get_effective_decel() * dt, cur_mag - target_mag)
+	var new_mag: float = cur_mag + mag_delta
+	var new_dir: Vector2
+	if cur.length_squared() > 0.0001:
+		new_dir = cur.normalized()
+	elif des_len_sq > 0.0001:
+		new_dir = des.normalized()
+	else:
+		new_dir = Vector2.ZERO
+	b.velocity = new_dir * new_mag
+
+	# Consume one tick of the damping timer at the end.
+	if b.reversal_damping_timer > 0:
+		b.reversal_damping_timer -= 1
+
+	return b.velocity * dt
 
 func _do_combat_movement(b: BrottState, base_spd: float) -> void:
 	var to_target: Vector2 = b.target.position - b.position

--- a/godot/combat/combat_sim.gd
+++ b/godot/combat/combat_sim.gd
@@ -492,10 +492,10 @@ func _move_brott(b: BrottState) -> void:
 				var desired_vel_p: Vector2 = to_pillar_v.normalized() * b.current_speed
 				b.position += _smooth_velocity(b, desired_vel_p, TICK_DELTA)
 	else:
-		var to_target: Vector2 = b.target.position - b.position
+		var to_target: Vector2 = b.target._pos_snapshot - b.position
 		var dist: float = to_target.length()
 		var max_weapon_range: float = _get_max_weapon_range_px(b)
-		var has_los: bool = _has_los(b.position, b.target.position)
+		var has_los: bool = _has_los(b.position, b.target._pos_snapshot)
 		
 		# Determine if bot is actively moving this tick
 		var wants_to_move: bool = true
@@ -573,7 +573,7 @@ func _move_brott(b: BrottState) -> void:
 	
 	# Update visual facing angle (turn speed is visual-only)
 	if b.target != null:
-		var desired_angle: float = rad_to_deg((b.target.position - b.position).angle())
+		var desired_angle: float = rad_to_deg((b.target._pos_snapshot - b.position).angle())
 		var angle_diff: float = fmod(desired_angle - b.facing_angle + 540.0, 360.0) - 180.0
 		var max_turn: float = b.turn_speed * TICK_DELTA
 		if absf(angle_diff) <= max_turn:
@@ -756,7 +756,7 @@ func _wall_escape_direction(b: BrottState) -> Vector2:
 	if e.length() >= ESCAPE_MAGNITUDE_MIN:
 		return e.normalized()
 	if b.target != null and b.target.alive:
-		var tt: Vector2 = b.target.position - b.position
+		var tt: Vector2 = b.target._pos_snapshot - b.position
 		if tt.length() > 0.01:
 			return tt.normalized()
 	return Vector2.ZERO
@@ -776,7 +776,7 @@ func _apply_unstick_nudge(b: BrottState, push: Vector2) -> void:
 	# untouched — the unstick maneuver's job is to escape geometry, not to
 	# out-retreat the moonwalk invariant. See docs/kb/juke-bypass-movement-caps.md.
 	if b.target != null:
-		var to_target_u: Vector2 = b.target.position - b.position
+		var to_target_u: Vector2 = b.target._pos_snapshot - b.position
 		if to_target_u.length_squared() > 0.0001:
 			var to_target_n: Vector2 = to_target_u.normalized()
 			var along: float = push.dot(to_target_n)
@@ -863,7 +863,7 @@ func _smooth_velocity(b: BrottState, desired: Vector2, dt: float) -> Vector2:
 	return b.velocity * dt
 
 func _do_combat_movement(b: BrottState, base_spd: float) -> void:
-	var to_target: Vector2 = b.target.position - b.position
+	var to_target: Vector2 = b.target._pos_snapshot - b.position
 	var dist: float = to_target.length()
 	var engage: Dictionary = _get_engagement_distance(b)
 	var ideal: float = engage["ideal"]

--- a/godot/combat/combat_sim.gd
+++ b/godot/combat/combat_sim.gd
@@ -113,6 +113,11 @@ func _init(seed_val: int = 0) -> void:
 
 func add_brott(brott: BrottState) -> void:
 	brotts.append(brott)
+	# S17.2-003 phase 3: seed _pos_snapshot with the current position so code
+	# that reads cross-bot `target._pos_snapshot` before the first simulate_tick
+	# call (e.g. tests exercising helpers like _wall_escape_direction directly)
+	# observes a sensible initial world state instead of Vector2.ZERO.
+	brott._pos_snapshot = brott.position
 
 func get_json_log() -> Array:
 	return _json_log

--- a/godot/combat/combat_sim.gd
+++ b/godot/combat/combat_sim.gd
@@ -178,6 +178,20 @@ func simulate_tick() -> void:
 			continue
 		_tick_modules(b)
 	
+	# S17.2-003 (phase 3): pre-movement position snapshot. Cross-bot reads in
+	# _move_brott (target.position, unstick-nudge target, etc.) use this snapshot
+	# instead of the live `.position` so every bot in this tick sees the same
+	# pre-move world state. Without this, the fixed iteration order leaks into
+	# gameplay: team 0 always moves first, team 1 then reacts to team 0's
+	# already-updated position, which cascades into an ~80% team-0 WR in
+	# Scout-vs-Scout mirror matches (diag_mirror_n200 @ N=200). Separation
+	# continues to read LIVE positions (see _move_brott) — snapshotting there
+	# breaks overlap resolution because both bots then push against the stale
+	# same-distance pair and never actually separate.
+	for b in brotts:
+		if b.alive:
+			b._pos_snapshot = b.position
+	
 	for b in brotts:
 		if not b.alive:
 			continue

--- a/godot/tests/diag_brawler_mirror_n100.gd
+++ b/godot/tests/diag_brawler_mirror_n100.gd
@@ -1,0 +1,50 @@
+## Diagnostic: Brawler-vs-Brawler mirror WR at N=100 and swapped-spawn N=100
+## to determine whether the sprint13_3 Brawler-mirror 72.7% is a real bias
+## or N=30 variance. Gizmo S17.2-003 design memo.
+extends SceneTree
+
+const N_MATCHES: int = 100
+
+func _mk(team: int, name_: String) -> BrottState:
+	var b := BrottState.new()
+	b.chassis_type = ChassisData.ChassisType.BRAWLER
+	b.weapon_types = [WeaponData.WeaponType.SHOTGUN]
+	b.armor_type = ArmorData.ArmorType.NONE
+	b.module_types = []
+	b.team = team
+	b.bot_name = name_
+	b.setup()
+	return b
+
+func _run(n: int, left_team: int, right_team: int, label: String) -> void:
+	var t0_wins: int = 0
+	var t1_wins: int = 0
+	var draws: int = 0
+	for seed_val in range(n):
+		var sim := CombatSim.new(seed_val)
+		var a := _mk(left_team, "L")
+		var b := _mk(right_team, "R")
+		a.position = Vector2(64.0, 256.0)
+		b.position = Vector2(448.0, 256.0)
+		sim.add_brott(a)
+		sim.add_brott(b)
+		for _i in range(1200):
+			if sim.match_over:
+				break
+			sim.simulate_tick()
+		if sim.winner_team == 0:
+			t0_wins += 1
+		elif sim.winner_team == 1:
+			t1_wins += 1
+		else:
+			draws += 1
+	var decided: int = t0_wins + t1_wins
+	var wr: float = (float(t0_wins) / float(decided)) * 100.0 if decided > 0 else 0.0
+	print("%s N=%d: team0=%d team1=%d draws=%d team0_WR=%.1f%%" % [label, n, t0_wins, t1_wins, draws, wr])
+
+func _initialize() -> void:
+	# Canonical: team 0 on LEFT, team 1 on RIGHT.
+	_run(N_MATCHES, 0, 1, "Brawler-mirror canonical (L=team0)")
+	# Swapped: team 0 on RIGHT.
+	_run(N_MATCHES, 1, 0, "Brawler-mirror swapped  (L=team1)")
+	quit(0)

--- a/godot/tests/diag_mirror_n200.gd
+++ b/godot/tests/diag_mirror_n200.gd
@@ -1,0 +1,73 @@
+## Diagnostic: Scout-vs-Scout mirror match WR at N=200 to tighten confidence
+## on the test_sprint13_3 Scout-mirror pass (normally N=30 per file).
+## Usage: godot --headless --path . --script res://tests/diag_mirror_n200.gd
+extends SceneTree
+
+const TILE: float = 32.0
+const N_MATCHES: int = 200
+
+func _mk(team: int, name_: String) -> BrottState:
+	var b := BrottState.new()
+	b.chassis_type = ChassisData.ChassisType.SCOUT
+	b.weapon_types = [WeaponData.WeaponType.PLASMA_CUTTER]  # matches test_sprint13_3
+	b.armor_type = ArmorData.ArmorType.NONE
+	b.module_types = []
+	b.team = team
+	b.bot_name = name_
+	b.setup()
+	return b
+
+func _initialize() -> void:
+	var t0_wins: int = 0
+	var t1_wins: int = 0
+	var draws: int = 0
+	for seed_val in range(N_MATCHES):
+		var sim := CombatSim.new(seed_val)
+		var a := _mk(0, "A")
+		var b := _mk(1, "B")
+		# Symmetric spawn around arena center.
+		a.position = Vector2(64.0, 256.0)
+		b.position = Vector2(448.0, 256.0)
+		sim.add_brott(a)
+		sim.add_brott(b)
+		for _i in range(1200):
+			if sim.match_over:
+				break
+			sim.simulate_tick()
+		if sim.winner_team == 0:
+			t0_wins += 1
+		elif sim.winner_team == 1:
+			t1_wins += 1
+		else:
+			draws += 1
+	var total_decided: int = t0_wins + t1_wins
+	var wr: float = (float(t0_wins) / float(total_decided)) * 100.0 if total_decided > 0 else 0.0
+	print("Scout-vs-Scout mirror N=%d: team0=%d team1=%d draws=%d WR=%.1f%%" % [N_MATCHES, t0_wins, t1_wins, draws, wr])
+	# Also run swapped team order — a and b swap spawn positions / team ids.
+	var sa_t0: int = 0
+	var sa_t1: int = 0
+	var sa_d: int = 0
+	for seed_val in range(N_MATCHES):
+		var sim := CombatSim.new(seed_val)
+		var a := _mk(0, "A")
+		var b := _mk(1, "B")
+		# Swapped: team 0 now on the RIGHT, team 1 on the LEFT.
+		# Swap: team 0 now on the RIGHT.
+		a.position = Vector2(448.0, 256.0)
+		b.position = Vector2(64.0, 256.0)
+		sim.add_brott(a)
+		sim.add_brott(b)
+		for _i in range(1200):
+			if sim.match_over:
+				break
+			sim.simulate_tick()
+		if sim.winner_team == 0:
+			sa_t0 += 1
+		elif sim.winner_team == 1:
+			sa_t1 += 1
+		else:
+			sa_d += 1
+	var sa_total: int = sa_t0 + sa_t1
+	var sa_wr: float = (float(sa_t0) / float(sa_total)) * 100.0 if sa_total > 0 else 0.0
+	print("SWAPPED spawn N=%d: team0=%d team1=%d draws=%d WR=%.1f%%" % [N_MATCHES, sa_t0, sa_t1, sa_d, sa_wr])
+	quit(0)

--- a/godot/tests/test_runner.gd
+++ b/godot/tests/test_runner.gd
@@ -52,6 +52,8 @@ const SPRINT_TEST_FILES := [
 	"res://tests/test_sprint17_1_random_event_popup.gd",
 	"res://tests/test_sprint17_1_first_run_crate.gd",
 	"res://tests/test_sprint17_2_wall_stuck.gd",
+	"res://tests/test_s17_2_scout_feel.gd",
+	"res://tests/test_s17_2_scout_feel.gd",
 ]
 
 var file_pass_count := 0

--- a/godot/tests/test_s17_2_scout_feel.gd
+++ b/godot/tests/test_s17_2_scout_feel.gd
@@ -1,0 +1,198 @@
+## [S17.2-003] Scout movement feel: velocity smoothing + angular cap.
+## Usage: godot --headless --script tests/test_s17_2_scout_feel.gd
+##
+## Specs:
+##   docs/design/s17.2-scout-feel.md (original)
+##   docs/design/s17.2-003-scout-feel-revision.md (write-site partition)
+##
+## Covers:
+##   AC-T1 — _smooth_velocity enforces the chassis angular-velocity cap on
+##           forward-intent rotations. 180° intent on a Scout requires
+##           ceil(180 / (540 * 0.1)) = 4 ticks of rotation.
+##   AC-T2 — Replay determinism: two runs with the same seed produce
+##           byte-identical event streams. This is the AC Nutts' first impl
+##           pass failed on; the retreat-bypass design is the fix.
+##   AC-1/AC-4 — Reversal damping: on a forward-intent reversal, velocity
+##           magnitude dips ≥ 35% for REVERSAL_DAMPING_TICKS ticks (visible
+##           "plant foot" arc). Sampled via the helper directly.
+extends SceneTree
+
+var pass_count := 0
+var fail_count := 0
+var test_count := 0
+
+const TILE: float = 32.0
+
+func _initialize() -> void:
+	print("=== S17.2-003 Scout-feel smoothing tests ===\n")
+	_test_angular_cap_scout_180_takes_multiple_ticks()
+	_test_angular_cap_fortress_slower_than_scout()
+	_test_reversal_damping_magnitude_dip()
+	_test_determinism_same_seed_byte_identical_logs()
+	_test_retreat_writes_do_not_touch_velocity_state()
+	print("\n=== Results: %d passed, %d failed, %d total ===" % [pass_count, fail_count, test_count])
+	quit(1 if fail_count > 0 else 0)
+
+func _assert(cond: bool, msg: String) -> void:
+	test_count += 1
+	if cond:
+		pass_count += 1
+		print("  PASS: %s" % msg)
+	else:
+		fail_count += 1
+		print("  FAIL: %s" % msg)
+
+func _mk(chassis: ChassisData.ChassisType, team: int, n: String) -> BrottState:
+	var b := BrottState.new()
+	b.chassis_type = chassis
+	b.weapon_types = [WeaponData.WeaponType.MINIGUN]
+	b.armor_type = ArmorData.ArmorType.NONE
+	b.module_types = []
+	b.team = team
+	b.bot_name = n
+	b.setup()
+	return b
+
+## AC-T1 — Scout 180° rotation must take ≥ 3 ticks (per revision §6 AC-1).
+## With MAX_ANGULAR_VELOCITY_SCOUT_DEG = 540, dt = 0.1, max_rot_per_tick = 54°.
+## 180° / 54° = 3.33 → 4 ticks before velocity direction fully aligns.
+func _test_angular_cap_scout_180_takes_multiple_ticks() -> void:
+	print("\n-- AC-T1: Scout angular cap on 180° reversal --")
+	var sim := CombatSim.new(1)
+	var b := _mk(ChassisData.ChassisType.SCOUT, 0, "S")
+	# Seed velocity pointing +x at full commit speed (200 px/s).
+	b.velocity = Vector2(200.0, 0.0)
+	# Desired intent: reverse to -x at same magnitude.
+	var desired: Vector2 = Vector2(-200.0, 0.0)
+	var ticks_to_align: int = 0
+	for i in range(20):
+		sim._smooth_velocity(b, desired, 0.1)
+		ticks_to_align += 1
+		# Aligned when velocity direction is within 5° of desired direction.
+		if b.velocity.length_squared() > 0.0001 and desired.normalized().dot(b.velocity.normalized()) > cos(deg_to_rad(5.0)):
+			break
+	# Expect at least 3 ticks of visible arc (AC-1).
+	_assert(ticks_to_align >= 3, "Scout 180° takes ≥ 3 ticks (got %d)" % ticks_to_align)
+	_assert(ticks_to_align <= 5, "Scout 180° completes in ≤ 5 ticks (got %d)" % ticks_to_align)
+
+## Fortress must be strictly slower to rotate than Scout at the same intent.
+## MAX_ANGULAR_VELOCITY_FORTRESS_DEG = 150, Scout = 540 — 3.6× ratio.
+func _test_angular_cap_fortress_slower_than_scout() -> void:
+	print("\n-- AC-T1b: Fortress angular cap vs Scout --")
+	var sim := CombatSim.new(1)
+	var scout := _mk(ChassisData.ChassisType.SCOUT, 0, "S")
+	var fort := _mk(ChassisData.ChassisType.FORTRESS, 0, "F")
+	scout.velocity = Vector2(200.0, 0.0)
+	fort.velocity = Vector2(200.0, 0.0)
+	var desired: Vector2 = Vector2(-200.0, 0.0)
+	var scout_ticks := -1
+	var fort_ticks := -1
+	for i in range(30):
+		sim._smooth_velocity(scout, desired, 0.1)
+		sim._smooth_velocity(fort, desired, 0.1)
+		if scout_ticks < 0 and desired.normalized().dot(scout.velocity.normalized()) > cos(deg_to_rad(5.0)):
+			scout_ticks = i + 1
+		if fort_ticks < 0 and desired.normalized().dot(fort.velocity.normalized()) > cos(deg_to_rad(5.0)):
+			fort_ticks = i + 1
+			break
+	_assert(scout_ticks > 0 and fort_ticks > 0, "both converged (scout=%d fort=%d)" % [scout_ticks, fort_ticks])
+	_assert(fort_ticks > scout_ticks, "Fortress rotates slower than Scout (fort=%d > scout=%d)" % [fort_ticks, scout_ticks])
+	# Roughly 3× slower (150 vs 540 deg/s). Allow wide tolerance for integer tick rounding.
+	_assert(fort_ticks >= scout_ticks * 2, "Fortress ≥ 2× Scout tick count (fort=%d scout=%d)" % [fort_ticks, scout_ticks])
+
+## AC-1 / AC-4 — Reversal damping. On a forward-intent flip, velocity magnitude
+## must drop by REVERSAL_DAMPING_FACTOR for REVERSAL_DAMPING_TICKS ticks. We
+## sample the helper directly: seed velocity at +x @ 200, flip intent to -x,
+## observe magnitude dip on the next tick.
+func _test_reversal_damping_magnitude_dip() -> void:
+	print("\n-- AC-4: Reversal damping magnitude dip --")
+	var sim := CombatSim.new(1)
+	var b := _mk(ChassisData.ChassisType.SCOUT, 0, "S")
+	b.velocity = Vector2(200.0, 0.0)
+	var desired: Vector2 = Vector2(-200.0, 0.0)
+	# First call to _smooth_velocity detects the 180° reversal and arms damping.
+	sim._smooth_velocity(b, desired, 0.1)
+	var mag_t1: float = b.velocity.length()
+	var expected_damped: float = 200.0 * CombatSim.REVERSAL_DAMPING_FACTOR
+	# Magnitude on tick 1 is the result of one decel step from 200 toward the
+	# damped target; it doesn't snap to target_damped immediately. The
+	# per-tick decel for a Scout is ~88 px, so tick 1 magnitude is ~112.
+	# The important invariant is the ≥35% dip, asserted below; this loose
+	# check just verifies we're monotonically moving toward the target.
+	_assert(mag_t1 < 200.0 and mag_t1 > expected_damped * 0.9,
+		"Tick 1 mag between damped target and start (%.1f in (%.1f, 200))" % [mag_t1, expected_damped * 0.9])
+	# Second tick — damping still active (REVERSAL_DAMPING_TICKS = 2).
+	sim._smooth_velocity(b, desired, 0.1)
+	var mag_t2: float = b.velocity.length()
+	_assert(absf(mag_t2 - expected_damped) < expected_damped * 0.2, "Tick 2 mag still damped (%.1f)" % mag_t2)
+	# Verify the ≥35% dip invariant explicitly (AC-4).
+	_assert(mag_t1 <= 200.0 * 0.65, "Tick 1 magnitude dips ≥ 35%% (%.1f / 200.0)" % mag_t1)
+	_assert(mag_t2 <= 200.0 * 0.65, "Tick 2 magnitude dips ≥ 35%% (%.1f / 200.0)" % mag_t2)
+
+## AC-T2 — Replay determinism. Two runs with the same RNG seed and identical
+## starting conditions must produce byte-identical event streams. This is the
+## regression Nutts' first impl failed on; it's guarded by the retreat-bypass
+## pattern (retreat writes don't feed `desired_vel`, so realized backward
+## displacement equals the commanded step exactly — no velocity leak past the
+## backup_distance budget).
+func _test_determinism_same_seed_byte_identical_logs() -> void:
+	print("\n-- AC-T2: Replay determinism --")
+	var log_a: String = _run_fixed_sim(424242)
+	var log_b: String = _run_fixed_sim(424242)
+	_assert(log_a == log_b, "Same-seed logs are byte-identical (len_a=%d len_b=%d diff@=%d)" % [log_a.length(), log_b.length(), _first_diff(log_a, log_b)])
+	# And a DIFFERENT seed must produce a DIFFERENT log — otherwise the test
+	# above is trivially true because both logs are empty.
+	var log_c: String = _run_fixed_sim(424243)
+	_assert(log_a != log_c, "Different-seed logs differ (sanity check on determinism test)")
+	_assert(log_a.length() > 200, "Log is non-trivial (len=%d)" % log_a.length())
+
+func _run_fixed_sim(seed_val: int) -> String:
+	var sim := CombatSim.new(seed_val)
+	# Scout vs Scout, asymmetric positions so they actually engage / disengage
+	# / retreat / smooth-and-rotate. Cover all TCR phases within 200 ticks.
+	var a := _mk(ChassisData.ChassisType.SCOUT, 0, "A")
+	var b := _mk(ChassisData.ChassisType.SCOUT, 1, "B")
+	a.position = Vector2(3.0 * TILE, 4.0 * TILE)
+	b.position = Vector2(12.0 * TILE, 4.0 * TILE)
+	a.target = b
+	b.target = a
+	sim.add_brott(a)
+	sim.add_brott(b)
+	var lines: Array[String] = []
+	for i in range(200):
+		if sim.match_over:
+			break
+		sim.simulate_tick()
+		# Log the full per-tick state so any floating-point drift is visible.
+		lines.append("%d|%.4f|%.4f|%.4f|%.4f|%.4f|%.4f|%.4f|%.4f|%d|%d|%d|%d" % [
+			i,
+			a.position.x, a.position.y,
+			b.position.x, b.position.y,
+			a.velocity.x, a.velocity.y,
+			b.velocity.x, b.velocity.y,
+			a.combat_phase, b.combat_phase,
+			a.reversal_damping_timer, b.reversal_damping_timer,
+		])
+	return "\n".join(lines)
+
+func _first_diff(x: String, y: String) -> int:
+	var n: int = mini(x.length(), y.length())
+	for i in range(n):
+		if x[i] != y[i]:
+			return i
+	return n
+
+## Retreat writes must NOT touch b.velocity. This is the revision §4 invariant
+## that keeps the backup_distance budget math tick-accurate. We verify the
+## invariant at the helper boundary: if _smooth_velocity is never called,
+## b.velocity never changes. (The hard-plant `b.velocity = Vector2.ZERO` on
+## retreat write-sites is a separate moonwalk-guard carve-out, covered by
+## test_sprint11 AC6 in the existing suite.)
+func _test_retreat_writes_do_not_touch_velocity_state() -> void:
+	print("\n-- AC: Retreat-bypass invariant (no smoothed helper → no velocity write) --")
+	var b := _mk(ChassisData.ChassisType.SCOUT, 0, "S")
+	b.velocity = Vector2(-123.45, 67.89)
+	# Mutate position directly, as retreat sites do.
+	var before: Vector2 = b.velocity
+	b.position += Vector2(-10.0, 0.0)
+	_assert(b.velocity == before, "b.position write does not alter b.velocity")

--- a/godot/tests/test_s17_2_scout_feel.gd
+++ b/godot/tests/test_s17_2_scout_feel.gd
@@ -30,6 +30,7 @@ func _initialize() -> void:
 	_test_reversal_damping_magnitude_dip()
 	_test_determinism_same_seed_byte_identical_logs()
 	_test_retreat_writes_do_not_touch_velocity_state()
+	_test_retreat_step_bounded_per_bot_under_snapshot_tick()
 	print("\n=== Results: %d passed, %d failed, %d total ===" % [pass_count, fail_count, test_count])
 	quit(1 if fail_count > 0 else 0)
 
@@ -196,3 +197,57 @@ func _test_retreat_writes_do_not_touch_velocity_state() -> void:
 	var before: Vector2 = b.velocity
 	b.position += Vector2(-10.0, 0.0)
 	_assert(b.velocity == before, "b.position write does not alter b.velocity")
+
+## AC-T4 — Retreat-step per-bot bound under simultaneous (two-phase) physics.
+## Spawn two Scouts overlapping inside TENSION-too-close range; run 20 ticks.
+## Assert each bot's cumulative backward displacement (intent-frame, dot < -0.7,
+## summed across all retreat ticks regardless of period boundaries) is
+## ≤ TILE_SIZE * 2 + 2 px (one TENSION retreat budget + one RECOVERY retreat
+## budget + small float margin). This is a tuning-invariant guardrail: it
+## catches future regressions in the retreat-bypass lane (e.g., a change to
+## RETREAT_SPEED_MULT or the two-phase tick breaking the per-bot bound) before
+## they propagate into test_sprint11_2.gd as violation spikes. Spec:
+## docs/design/s17.2-003-retreat-calibration.md §2.4.
+func _test_retreat_step_bounded_per_bot_under_snapshot_tick() -> void:
+	print("\n-- AC-T4: Per-bot backward-displacement bound under two-phase tick --")
+	var b0 := _mk(ChassisData.ChassisType.SCOUT, 0, "S0")
+	var b1 := _mk(ChassisData.ChassisType.SCOUT, 1, "S1")
+	var sim := CombatSim.new(42)
+	b0.position = Vector2(200, 256)
+	b1.position = Vector2(220, 256)
+	sim.add_brott(b0)
+	sim.add_brott(b1)
+	
+	var bots := [b0, b1]
+	var prev_pos := [b0.position, b1.position]
+	var backward_sum := [0.0, 0.0]
+	
+	for _t in range(20):
+		if sim.match_over:
+			break
+		# Pre-tick intent-frame sampling per bot.
+		var to_target_pre := [Vector2.ZERO, Vector2.ZERO]
+		for i in range(2):
+			var b: BrottState = bots[i]
+			if b.alive and b.target != null:
+				to_target_pre[i] = b.target.position - b.position
+		sim.simulate_tick()
+		for i in range(2):
+			var b: BrottState = bots[i]
+			if not b.alive:
+				continue
+			var movement: Vector2 = b.position - prev_pos[i]
+			var tt_pre: Vector2 = to_target_pre[i]
+			if tt_pre.length() > 0.1 and movement.length() > 0.1:
+				var dot: float = movement.normalized().dot(tt_pre.normalized())
+				if dot < -0.7:
+					# Magnitude of the backward (anti-to_target) projection.
+					var back_mag: float = absf(movement.dot(tt_pre.normalized()))
+					backward_sum[i] += back_mag
+			prev_pos[i] = b.position
+	
+	var bound: float = CombatSim.TILE_SIZE * 2.0 + 2.0
+	_assert(backward_sum[0] <= bound,
+		"Bot 0 backward displacement %.2f <= %.2f (2 tiles + 2px)" % [backward_sum[0], bound])
+	_assert(backward_sum[1] <= bound,
+		"Bot 1 backward displacement %.2f <= %.2f (2 tiles + 2px)" % [backward_sum[1], bound])

--- a/godot/tests/test_sprint11.gd
+++ b/godot/tests/test_sprint11.gd
@@ -173,6 +173,15 @@ func test_position_change_frequency() -> void:
 
 func test_no_moonwalking() -> void:
 	print("\n-- AC6: No Moonwalking (backup >1 tile) --")
+	# S17.2-003 addendum (docs/design/s17.2-003-retreat-calibration.md §2.3):
+	# migrated from naive post-tick metric to the S15.2-canonical intent-frame
+	# pre-tick + period-boundary reset + budget-gated accumulator pattern already
+	# used by test_sprint11_2.gd::test_away_juke_cap_across_seeds. Under the
+	# two-phase tick introduced in S17.2-003, the post-tick metric produced
+	# false positives because post-cap perpendicular/lateral motion read as
+	# backward against a stale post-tick `to_target` frame. Threshold stays
+	# `<= 10` (unchanged); no AC relaxation. See S15.2 ruling
+	# (docs/design/sprint15-moonwalk-metric-ruling.md, main + Addendum 1 + 2).
 	var violations := 0
 	for seed_val in range(100):
 		var b0 := _make_scout(0)
@@ -185,19 +194,30 @@ func test_no_moonwalking() -> void:
 		
 		var prev_pos := b0.position
 		var backup_run := 0.0
+		var prev_bd := 0.0
 		
 		for _t in range(300):
 			if sim.match_over:
 				break
+			# Pre-tick intent-frame sampling (S15.2 ruling, main).
+			var to_target_pre: Vector2 = Vector2.ZERO
+			if b0.alive and b0.target != null:
+				to_target_pre = b0.target.position - b0.position
 			sim.simulate_tick()
 			if b0.alive and b0.target != null:
-				var to_target: Vector2 = b0.target.position - b0.position
+				# Period-boundary reset (S15.2 Addendum 1): bd drop → new retreat period.
+				if b0.backup_distance < prev_bd:
+					backup_run = 0.0
+				prev_bd = b0.backup_distance
 				var movement: Vector2 = b0.position - prev_pos
-				# Check if moving away from target (dot product < 0 means backing up)
-				if to_target.length() > 0.1 and movement.length() > 0.1:
-					var dot: float = movement.normalized().dot(to_target.normalized())
+				if to_target_pre.length() > 0.1 and movement.length() > 0.1:
+					var dot: float = movement.normalized().dot(to_target_pre.normalized())
 					if dot < -0.7:  # Mostly backing away
-						backup_run += movement.length()
+						# Budget-gated accumulator (S15.2 Addendum 2): only accumulate
+						# while retreat period is live.
+						if b0.backup_distance < CombatSim.TILE_SIZE:
+							backup_run += movement.length()
+						# else: post-cap freeze; wait for period-boundary reset.
 					else:
 						backup_run = 0.0
 				prev_pos = b0.position
@@ -206,12 +226,11 @@ func test_no_moonwalking() -> void:
 					break
 	
 	_assert(violations <= 10, "No moonwalking violations (%d/100)" % violations)
-	# S14.1-B2 re-tune (PR #74): main baseline is 4/100 flaky; with the wall-stuck
-	# nav fix armed near geometry, the 6-8px/tick escape nudge occasionally
-	# registers as >38.4px straight backup when combined with tight Scout orbits
-	# through the pillar quadrant. Tolerance of ≤10 reflects nav-fix cost; the
-	# actual playtest wall-freeze bug is regression-tested in test_sprint14_1_nav.gd
-	# (T1 "no >2s freeze" is the hard bar). See docs/design/sprint14-arc-shape.md.
+	# Threshold retained at ≤10 per Gizmo's S17.2-003 addendum ruling §2 (no AC
+	# relaxation; the combination of `RETREAT_SPEED_MULT = 0.50` + metric
+	# migration is expected to land at ≤1–2/100). The wall-stuck nav nudge tail
+	# documented in the prior comment block is still present as the dominant
+	# residual source of violations, which is why the ≤10 floor remains.
 
 func test_stances_preserved() -> void:
 	print("\n-- AC7: Existing Stances Preserved --")


### PR DESCRIPTION
## Summary

Sprint 17.2-003 lands the Scout-feel pass: per-chassis **velocity smoothing + angular cap** (smoothed-intent lane) layered over a **two-phase tick** (`_pos_snapshot` freezes cross-bot target reads at tick start; separation + fire_weapons intentionally stay live against mutating positions). Retreat speed halved at all authored retreat sites per simul-physics calibration. The smoothed-intent lane is now **budget-gated** against `backup_distance`: any backward-along-target displacement charges the same 1-tile-per-period budget as separation and unstick, closing the wall-clamp + orbit-flip limit-cycle leak (Addendum 1).

## Sprint 15 metric debt paid

`test_sprint11.gd::test_no_moonwalking` was migrated from a post-tick displacement metric to a pre-tick intent-frame metric per Gizmo's S15.2 ruling. That migration was deferred during the S15.2 pass; this sprint pays it down alongside the retreat calibration.

## Design docs touched / added

- `docs/design/s17.2-scout-feel.md` — original spec (main)
- `docs/design/s17.2-003-scout-feel-revision.md` — two-lane architecture (landed via #184)
- `docs/design/s17.2-003-retreat-calibration.md` — retreat-speed halving + S15.2 debt (landed via #191)
- `docs/design/s17.2-003-retreat-calibration-addendum1.md` — smoothed-lane budget gate (landed via #192)

## Regression resolution matrix

| Regression | Root cause | Fix | Final |
|---|---|---|---|
| Moonwalk (sprint11 AC6) | pre-existing ~7/100 baseline | — | **0/100** |
| Moonwalk AC6 post-two-phase | bilateral retreat × un-gated metric | halve retreat + pre-tick metric migration | **0/100** (≤ 10 contract) |
| Mirror bias 86% → 56.8% | sequential-update iteration + velocity inertia | `_pos_snapshot` two-phase tick | Scout 48.0% @ N=200 (48.6% swap) |
| Strict-zero 4/100 | wall-clamp + orbit-flip limit cycle bypassing budget | smoothed-lane budget gate (Addendum 1) | **0/100** |

## AC verification

- **AC-1 through AC-6** (original spec): pass — moonwalk 0/100, combat movement intact, existing stances preserved.
- **AC-T1 / AC-T1b** (angular cap): pass — Scout 180° in 4 ticks, Fortress in 12, ≥2× ratio enforced.
- **AC-T2** (replay determinism): pass — same-seed logs byte-identical (len=16265), different-seed logs differ.
- **AC-T4** (per-bot backward-displacement bound under two-phase tick): pass — 18.80 px / 25.95 px (bound = 66 px).
- Strict-zero `test_away_juke_cap_across_seeds`: **0/100** violations.
- Sprint13_3 mirror-WR all chassis in [35%, 65%]: Scout 45.8%, Brawler 50.0%, Fortress 51.7%.
- Mirror-WR verification @ N=200 (`diag_mirror_n200.gd`): Scout-mirror **48.0% forward / 48.6% swap** — both well inside 35-65% band, draws dropped to 25 from 29 as Addendum §3.3 predicted.
- S14.1-nav goldens: pass (byte-identical replay → `test_sprint14_1_nav.gd` green in full runner).
- Canonical runner (`test_runner.gd`): **33 files passed, 0 files failed. OVERALL PASS.**

## Reversible calls noted

- **Helper location**: `_apply_smoothed_displacement` placed directly below `_smooth_velocity` (between it and `_do_combat_movement`), grouped with the smoothed-lane primitives it post-processes. Alt: could live near the retreat helpers; chose co-location with `_smooth_velocity` for cache-of-thought adjacency.
- **`minf(-along, remaining_budget)` idiom**: matches the separation (L625) and unstick (L790) gates verbatim. `-along` is guaranteed positive inside the `along < 0` branch.
- **`_pos_snapshot` for target direction in the gate**: matches the rest of the smoothed-lane's cross-bot read discipline. Using live `b.target.position` would re-introduce the two-phase-tick bias the snapshot exists to prevent.

## Scope-gate clean

`godot/combat/combat_sim.gd` only (implementation) + `godot/tests/**` only (via earlier phase commits). No touches in this PR to `godot/data/**`, `godot/arena/**`, `docs/gdd.md`. Design-doc changes already merged via separate PRs (#184, #191, #192) into this impl branch.
