### PR TITLE
[S17.2-003] docs: addendum — two-phase-tick retreat calibration + Brawler N=100 diag

### DIFF
--- a/docs/design/s17.2-003-retreat-calibration.md
+++ b/docs/design/s17.2-003-retreat-calibration.md
@@ -1,0 +1,198 @@
+# [S17.2-003] Addendum: two-phase-tick retreat calibration
+
+**Author:** Gizmo (design)
+**Date:** 2026-04-21
+**Status:** Supplements `s17.2-003-scout-feel-revision.md`. Does NOT replace it. All §2 audit, §3 bypass categorization, and §5 two-lane model stand as written.
+**Trigger:** Riv's consult during S17.2-003 final verification surfaced three mirror-match test regressions after two-phase-tick (snapshot-read) landed. Two trace to a single simultaneous-physics calibration; one traces to N=30 noise. This addendum closes both.
+
+---
+
+## 1. Context
+
+### 1.1 The two-phase tick
+
+S17.2-003 final impl introduced `_pos_snapshot` and routed cross-bot movement reads through it (Option A two-phase tick). The bias fix is clean — Scout-mirror WR moved from 86.2% to 58.3% (in band), swap-check 51.1% confirms the bias is gone.
+
+The mechanism matters for what follows: pre-change, the fixed iteration order made movement updates **sequential** — when two bots were too-close-overlapping, bot 0 retreated first (live pos updated), then bot 1 read bot 0's NEW position and saw itself as no-longer-too-close, so bot 1 didn't retreat. Per too-close pair, only one bot retreated per tick. Post-change, snapshot-reads make updates **simultaneous** — both bots see each other's pre-tick snapshot, both read "too close," both retreat in the same tick. Per-bot backward displacement per tick, averaged across the too-close window, roughly doubles.
+
+### 1.2 Three test regressions Riv flagged
+
+1. `test_sprint11.gd::test_no_moonwalking` (naive post-tick metric, AC6 threshold ≤10/100): **30/100 violations.**
+2. `test_sprint11_2.gd::test_away_juke_cap_across_seeds` (S15.2-refined intent-frame + period-reset + budget-gated metric, threshold 0/100): **6/100 violations.**
+3. `test_sprint13_3.gd::_run_matchup` Brawler-vs-Brawler mirror (N=30, band 35–65%): **72.7% team-0 WR.**
+
+### 1.3 Scope of this addendum
+
+Two separable calls:
+- (A) AC6 / strict-zero: what's the right combination of runtime tune and test hygiene?
+- (B) Brawler-mirror: real bug, or N=30 noise?
+
+Each has independent evidence; each is ruled separately below. Neither widens any AC threshold. The §5 two-lane model is unchanged.
+
+---
+
+## 2. Ruling — AC6 and strict-zero moonwalk
+
+**Ruling: Hybrid (C-flavored).** Two coordinated moves:
+
+1. **Runtime: introduce `RETREAT_SPEED_MULT = 0.50` that scales retreat-only writes at the three authored retreat sites.** Preserves orbit lateral feel and approach/commit/disengage speeds; halves the per-tick retreat step to restore pair-relative-separation rate under simultaneous physics.
+2. **Test: migrate `test_sprint11.gd::test_no_moonwalking` to the S15.2 refined-metric pattern** (intent-frame pre-tick + period-boundary reset + budget-gated accumulator, already canonical in `test_sprint11_2.gd::test_away_juke_cap_across_seeds`). Threshold stays ≤10/100 (unchanged).
+
+**No threshold relaxation.** Strict-zero stays 0/100. AC6 stays ≤10/100.
+
+### 2.1 Rationale
+
+**On the runtime side (half-step retreat).** Riv's lean (A) is principled and I concur: `ORBIT_SPEED_MULT`-style constants are *exactly* the tuning surface that should compensate for an order-of-resolution change. The invariant the AC is defending — "a bot should not feel like it moonwalks more than ~1 tile away" — is about visual personal-space feel, which is a **per-bot** experience. Halving the per-bot retreat step under simultaneous physics returns the per-bot retreat-time-to-resolve to its sequential-physics baseline, which is the baseline the AC was authored against. The pair-relative separation rate also returns to baseline (both bots moving at half-step in the same tick = same relative rate as one-bot-at-full-step in alternating ticks). This preserves the S11 authored feel on both axes: per-bot retreat cadence AND pair-apart rate.
+
+Threshold relaxation (Riv's B) is asymmetric debt — once ≤35/100 becomes "passing," the metric loses its regression-detection power. Occam plus S15.2's own scope-discipline principle ("the test was measuring the wrong thing; fix the test, don't re-floor the threshold") argue against raising thresholds when a tuning knob exists.
+
+**On the test side (migration).** `test_sprint11.gd::test_no_moonwalking` is still on the **pre-S15.2 naive metric** — post-tick `to_target`, no period-reset, no budget-gating. The S15.2 ruling (docs/design/sprint15-moonwalk-metric-ruling.md, main ruling + Addendum 1 + Addendum 2) explicitly declared the naive metric an artifact and migrated `test_sprint11_2.gd`. `test_sprint11.gd` was apparently missed in that migration. S17.2-003's simultaneous physics is simply making a latent measurement gap visible — post-cap perpendicular-to-current-tick motion reads as backward against a stale post-tick `to_target`, inflating the violation count.
+
+This is not AC relaxation. It is **paying down S15.2 test-migration debt** that was deferred (accidentally or otherwise) and has now surfaced. The AC threshold stays ≤10/100; after migration plus the `RETREAT_SPEED_MULT` change, expected outcome is ≤1–2/100, well under.
+
+### 2.2 Expected outcomes after both changes
+
+- `test_sprint11.gd::test_no_moonwalking`: 30/100 → ≤2/100 (both the metric fix and the retreat halving contribute).
+- `test_sprint11_2.gd::test_away_juke_cap_across_seeds`: 6/100 → 0/100 (retreat halving alone, since this test is already on the refined metric).
+
+If either test still fails after both changes, **stop and escalate to me** — that means there is a genuine pre-cap budget-bypass issue beyond the known separation-overlap exception (S15.2 Addendum 2), and we need a fresh design pass, not more tuning.
+
+### 2.3 Implementation directives (for Nutts)
+
+**Runtime change — `godot/combat/combat_sim.gd`:**
+
+1. Add a new constant alongside `ORBIT_SPEED_MULT` (currently line 48):
+
+   ```gdscript
+   const ORBIT_SPEED_MULT: float = 0.55
+   const RETREAT_SPEED_MULT: float = 0.50  # S17.2-003 addendum: per-tick retreat step under two-phase tick.
+                                            # Applied only to direct-write retreat sites (TENSION-too-close,
+                                            # RECOVERY-retreat, stance-driven retreats). Preserves pair-relative
+                                            # separation rate under simultaneous physics. See
+                                            # docs/design/s17.2-003-retreat-calibration.md.
+   ```
+
+2. Apply `RETREAT_SPEED_MULT` at the three authored retreat sites identified in the revision §3 audit. Specifically:
+
+   - **TENSION-too-close retreat** (currently ~L940 — the `dist < ideal - tolerance` branch inside phase 0). Change:
+
+     ```gdscript
+     var step: float = minf(orbit_spd, TILE_SIZE - b.backup_distance)
+     b.position -= to_target_n_t * step
+     b.backup_distance += step
+     ```
+
+     to:
+
+     ```gdscript
+     var retreat_step: float = minf(orbit_spd * RETREAT_SPEED_MULT, TILE_SIZE - b.backup_distance)
+     b.position -= to_target_n_t * retreat_step
+     b.backup_distance += retreat_step
+     ```
+
+   - **RECOVERY retreat** (currently ~L1013 — phase 2, `dist < ideal and b.backup_distance < TILE_SIZE`). Same pattern: wrap `recovery_spd` in `recovery_spd * RETREAT_SPEED_MULT` at the `minf` call.
+
+   - **Stance-driven retreats** (`_move_brott` sites #5 and #7 in revision §3 audit — stance=1 defensive retreat, stance=2 kiting retreat). Apply `RETREAT_SPEED_MULT` to the per-tick backward step at both sites. Keep the existing backup-budget accounting intact.
+
+   **Do NOT apply `RETREAT_SPEED_MULT` to:**
+   - Separation force writes (L557–568) — those are overlap resolution, not retreat intent.
+   - Unstick nudge — geometry-repel, not retreat intent.
+   - Lateral/orbit writes — those are orbit cadence, not retreat.
+   - Forward-chase, COMMIT dash, approach writes — obviously not retreat.
+
+3. **Do not move any lateral/orbit motion to this constant.** Nutts may be tempted to halve `ORBIT_SPEED_MULT` too "for symmetry" — **don't.** The orbit cadence is authored per S13.3 TCR tuning and is independent of this calibration.
+
+**Test change — `godot/tests/test_sprint11.gd::test_no_moonwalking` (currently ~L174–208):**
+
+Migrate to the S15.2-refined metric. Concretely, replace the body of the per-seed inner loop with the pattern from `test_sprint11_2.gd::test_away_juke_cap_across_seeds` (L91–120):
+
+```gdscript
+var prev_pos := b0.position
+var backup_run := 0.0
+var prev_bd := 0.0
+
+for _t in range(300):
+    if sim.match_over:
+        break
+    # Pre-tick intent-frame sampling (S15.2 ruling, main).
+    var to_target_pre: Vector2 = Vector2.ZERO
+    if b0.alive and b0.target != null:
+        to_target_pre = b0.target.position - b0.position
+    sim.simulate_tick()
+    if b0.alive and b0.target != null:
+        # Period-boundary reset (S15.2 Addendum 1): bd drop → new retreat period.
+        if b0.backup_distance < prev_bd:
+            backup_run = 0.0
+        prev_bd = b0.backup_distance
+        var movement: Vector2 = b0.position - prev_pos
+        if to_target_pre.length() > 0.1 and movement.length() > 0.1:
+            var dot: float = movement.normalized().dot(to_target_pre.normalized())
+            if dot < -0.7:
+                # Budget-gated accumulator (S15.2 Addendum 2): only accumulate
+                # while retreat period is live.
+                if b0.backup_distance < CombatSim.TILE_SIZE:
+                    backup_run += movement.length()
+                # else: post-cap freeze; wait for period-boundary reset.
+            else:
+                backup_run = 0.0
+        prev_pos = b0.position
+        if backup_run > 32.0 * 1.2:
+            violations += 1
+            break
+```
+
+Threshold stays `violations <= 10`. Update the comment block below the assertion to reference this addendum and the S15.2 ruling.
+
+### 2.4 AC-T4 — add new AC for retreat-step invariance under snapshot tick
+
+Per revision §6 (AC-T4 was recommended as a new AC but not yet landed), add a focused unit test in `godot/tests/test_s17_2_scout_feel.gd`:
+
+- Spawn two Scouts at `(200, 256)` and `(220, 256)` (overlapping).
+- Run 20 ticks.
+- Assert: for each bot, total backward displacement (intent-frame, summed across all `dot < -0.7` ticks regardless of period breaks) is ≤ `TILE_SIZE * 2 + 2 px` (one TENSION retreat budget + one RECOVERY retreat budget + small margin for float).
+
+This is a **tuning-invariant guardrail** — if a future change to `RETREAT_SPEED_MULT` or the two-phase tick breaks the per-bot bound, this test catches it before it propagates into `test_sprint11_2.gd` as a violation spike.
+
+Nutts's lane: define the test. AC threshold and cycle budget are set above.
+
+---
+
+## 3. Ruling — Brawler-mirror 72.7% at N=30
+
+**Ruling: N=30 variance. No runtime fix required. Keep the existing `test_sprint13_3.gd` N=30 threshold; optionally note the variance floor in a comment.**
+
+### 3.1 Evidence
+
+I ran Brawler-vs-Brawler mirror at N=100 via a purpose-built diagnostic (`godot/tests/diag_brawler_mirror_n100.gd`, added this branch):
+
+```
+Brawler-mirror canonical (L=team0) N=100: team0=47 team1=35 draws=18 team0_WR=57.3%
+Brawler-mirror swapped  (L=team1) N=100: team0=35 team1=47 draws=18 team0_WR=42.7%
+```
+
+**Team-0 WR: 57.3% at N=100, in band [35%, 65%].** The swap is perfectly symmetric (57.3% ↔ 42.7%, same margin inverted) — confirming what the Scout-mirror swap test already confirmed: the two-phase tick removed team-id bias cleanly. The remaining left-spawn preference (~14 pt) is small and symmetric, explainable by minor RNG interactions with the fixed asymmetric spawn coordinates.
+
+### 3.2 Why N=30 misled us
+
+N=30 with a true win rate near ~55% has a 1-sigma standard error of ~9 percentage points. A ~72% observed WR is within ~2σ of a true 55% — unusual but not pathological. At this sample size, the 65% upper band is genuinely within reach for mirror matchups that have even a small left-spawn preference. The Brawler chassis's specific `max_angular_velocity = 270°/s` and `current_speed` profile don't materially change this — the chassis-specific hypotheses in Riv's brief (angular cap, stance-2 kiting fraction, range-tolerance oscillation) are not supported by the N=100 data.
+
+### 3.3 Why I'm not recommending a runtime chassis-tuning change
+
+Two reasons:
+
+1. **The data doesn't support one.** N=100 is well inside the 35–65% band. There is no symptom to fix.
+2. **Per-chassis angular-cap tuning is a §4.5 design surface** (per original scout-feel spec and Nutts's hand-tuned values in `brott_state.gd` L147–155). Touching it for a non-existent bug would violate scope discipline and could regress Scout-mirror balance as collateral damage.
+
+### 3.4 Nutts's task here
+
+None. Just note in the Brawler test's inline comment (if one exists) that the WR floor was verified at N=100 post-S17.2-003 and is 57.3% (within band).
+
+### 3.5 Open item for Ett / Riv (post-merge)
+
+Consider raising `test_sprint13_3.gd`'s `SIMS_PER_MATCHUP` from 30 to 60 or 100. The current 30-sample cap is a CI-time concession; we've been eating ~8-point variance as "noise" on every mirror matchup for five sprints. This is an S18 discussion, not an S17.2-003 blocker.
+
+---
+
+## 4. One-line summary for Riv
+
+AC6 / strict-zero: **C-flavored** — introduce `RETREAT_SPEED_MULT = 0.50` to halve per-tick retreat step (preserves pair-relative separation under simultaneous physics) AND migrate `test_sprint11.gd::test_no_moonwalking` to the S15.2-canonical intent-frame + period-reset + budget-gated metric (pays down deferred S15.2 migration debt). No threshold relaxation. Brawler-mirror: **N=30 noise**, N=100 verified at 57.3% in band. No runtime change.

--- a/godot/tests/diag_brawler_mirror_n100.gd
+++ b/godot/tests/diag_brawler_mirror_n100.gd
@@ -1,0 +1,50 @@
+## Diagnostic: Brawler-vs-Brawler mirror WR at N=100 and swapped-spawn N=100
+## to determine whether the sprint13_3 Brawler-mirror 72.7% is a real bias
+## or N=30 variance. Gizmo S17.2-003 design memo.
+extends SceneTree
+
+const N_MATCHES: int = 100
+
+func _mk(team: int, name_: String) -> BrottState:
+	var b := BrottState.new()
+	b.chassis_type = ChassisData.ChassisType.BRAWLER
+	b.weapon_types = [WeaponData.WeaponType.SHOTGUN]
+	b.armor_type = ArmorData.ArmorType.NONE
+	b.module_types = []
+	b.team = team
+	b.bot_name = name_
+	b.setup()
+	return b
+
+func _run(n: int, left_team: int, right_team: int, label: String) -> void:
+	var t0_wins: int = 0
+	var t1_wins: int = 0
+	var draws: int = 0
+	for seed_val in range(n):
+		var sim := CombatSim.new(seed_val)
+		var a := _mk(left_team, "L")
+		var b := _mk(right_team, "R")
+		a.position = Vector2(64.0, 256.0)
+		b.position = Vector2(448.0, 256.0)
+		sim.add_brott(a)
+		sim.add_brott(b)
+		for _i in range(1200):
+			if sim.match_over:
+				break
+			sim.simulate_tick()
+		if sim.winner_team == 0:
+			t0_wins += 1
+		elif sim.winner_team == 1:
+			t1_wins += 1
+		else:
+			draws += 1
+	var decided: int = t0_wins + t1_wins
+	var wr: float = (float(t0_wins) / float(decided)) * 100.0 if decided > 0 else 0.0
+	print("%s N=%d: team0=%d team1=%d draws=%d team0_WR=%.1f%%" % [label, n, t0_wins, t1_wins, draws, wr])
+
+func _initialize() -> void:
+	# Canonical: team 0 on LEFT, team 1 on RIGHT.
+	_run(N_MATCHES, 0, 1, "Brawler-mirror canonical (L=team0)")
+	# Swapped: team 0 on RIGHT.
+	_run(N_MATCHES, 1, 0, "Brawler-mirror swapped  (L=team1)")
+	quit(0)


### PR DESCRIPTION
Design addendum resolving three test regressions surfaced during S17.2-003 final verification.

## Summary

1. **AC6 (naive moonwalk, 30/100) + strict-zero (refined, 6/100):** Hybrid ruling — introduce `RETREAT_SPEED_MULT = 0.50` applied at three authored retreat sites to preserve pair-relative separation rate under simultaneous physics (Option A from Riv), **and** migrate `test_sprint11.gd::test_no_moonwalking` to the S15.2-canonical intent-frame + period-reset + budget-gated metric (pays down deferred S15.2 test-migration debt). No threshold relaxation.

2. **Brawler-mirror (72.7% at N=30):** N=30 variance. Verified at N=100 via new diag script: **team0_WR=57.3%** (in band [35%, 65%]), swap=42.7% (symmetric). No runtime change required.

## Files

- `docs/design/s17.2-003-retreat-calibration.md` — design ruling with full rationale, implementation directives for Nutts, and AC-T4 proposal.
- `godot/tests/diag_brawler_mirror_n100.gd` — Brawler-mirror diagnostic harness (parallel to existing `diag_mirror_n200.gd`).

## Scope

- `combat/**` changes are **directives for Nutts**, not landed here. This PR is design-doc + diag-script only.
- Runtime scope gate preserved.
- S15.2 metric ruling pattern preserved.

## Expected outcomes after Nutts implements directives

- `test_sprint11.gd::test_no_moonwalking`: 30/100 → ≤2/100.
- `test_sprint11_2.gd::test_away_juke_cap_across_seeds`: 6/100 → 0/100.
- `test_sprint13_3.gd` Brawler-mirror: no change expected; already within band at N=100.

Authored by Gizmo (design authority per Riv delegation, HCD asleep).