### PR TITLE
[S17.2-003] Addendum 1: smoothed-lane budget gate (strict-zero re-ruling)

### DIFF
--- a/docs/design/s17.2-003-retreat-calibration-addendum1.md
+++ b/docs/design/s17.2-003-retreat-calibration-addendum1.md
@@ -1,0 +1,146 @@
+# [S17.2-003] Addendum 1: smoothed-intent lane budget-gating
+
+**Author:** Gizmo (design)
+**Date:** 2026-04-21
+**Status:** Supplements `s17.2-003-retreat-calibration.md` (the two-phase-tick addendum) and closes the strict-zero moonwalk gap Riv flagged per §2.2 escalation.
+**Trigger:** After the halving + S15.2-migration landed (commits `c8df9b9`, `2e30547`, `e95ff83`), `test_sprint11_2.gd::test_away_juke_cap_across_seeds` still reported 4/100 violations where the contract is 0/100. Per the §2.2 pre-commit, that means a pre-cap budget-bypass outside the known separation-overlap exception. This addendum diagnoses it and rules on the fix.
+
+---
+
+## 1. Diagnosis
+
+### 1.1 Failing seeds
+
+Instrumented the test (temporary `print` on violation, restored before PR). Four failing seeds:
+
+| Seed | Tick | `pos` at violate | `bd` | Phase | Stance | Notes |
+|---|---|---|---|---|---|---|
+| 5 | 85 | (160.78, **12.0**) | 18.15 | 0 (TENSION) | 0 (Aggressive) | Top wall (y=12) |
+| 8 | 95 | (**500.0**, 334.20) | 6.05 | 0 (TENSION) | 0 (Aggressive) | Right wall (x=500) |
+| 80 | 64 | (**12.0**, 175.52) | 0.00 | 0 (TENSION) | 0 (Aggressive) | Left wall (x=12) |
+| 83 | 53 | (400.63, **500.0**) | 30.25 | 0 (TENSION) | 0 (Aggressive) | Bottom wall (y=500) |
+
+**Common pattern:** every violation occurs while bot 0 is arena-clamped against a wall, in stance=0 aggressive, phase=0 TENSION, with unstick inactive. All four hit the same mechanism.
+
+### 1.2 Tick-by-tick trace (seed 80, representative)
+
+Bot 0 pinned at x=12 (left wall), target (bot 1) directly below at (12, ~240). `to_target = (0, +y)`. Ticks 50–64 show a perfect limit cycle:
+
+```
+T50  mv=(0, -3.52)  dot=-1.000  bd=0   vel=(-23.48, -35.24)  orbit=+1
+T51  mv=(0, -0.17)  dot=-1.000  bd=0   vel=(-42.32,  -1.72)  orbit=-1
+T52  mv=(0, -3.52)  dot=-1.000  bd=0   vel=(-23.48, -35.24)  orbit=+1
+T53  mv=(0, -0.17)  dot=-1.000  bd=0   vel=(-42.32,  -1.72)  orbit=-1
+...  (15 ticks, bot drifts 3.52 px/pair upward)
+T64  mv=(0, -3.52)  dot=-1.000  bd=0   backup_run=38.73  VIOLATE
+```
+
+Every tick is 100% anti-target. `backup_distance` stays at **0.00** throughout — the moonwalk is entirely invisible to the authored-retreat budget.
+
+### 1.3 Mechanism
+
+In-band TENSION orbit at close range sets `desired_vel_t = perp_t * orbit_direction * current_speed`. Because `to_target` is pure vertical here, `perp_t` is pure horizontal. Intent is `(-220, 0)` or `(+220, 0)` — **no backward component by design.**
+
+Two compounding effects produce the backward drift anyway:
+
+1. **Arena clamp strips position, not velocity.** `combat_sim.gd` L642–644:
+   ```gdscript
+   b.position.x = clampf(b.position.x, BOT_HITBOX_RADIUS, arena_px - BOT_HITBOX_RADIUS)
+   ```
+   When the bot is pinned against the left wall, its x-position is clamped back to 12 every tick. But `b.velocity.x` retains the -220-ish value. Next tick, `_smooth_velocity` rotates that velocity toward the new intent. Because the **x-component is capped at the wall but the y-component is free**, rotation effectively leaks lateral energy into a persistent y-velocity.
+
+2. **Orbit-direction flip on wall collision.** L648 flips `orbit_direction *= -1` every tick the clamp fires. That flips `desired_vel_t` sign every tick. `_smooth_velocity` sees a 180° intent reversal, fires `REVERSAL_DAMPING_TICKS`, but the magnitude never fully decays because intent keeps re-arming. The two alternating velocity vectors `(-23.5, -35.2)` and `(-42.3, -1.7)` are the steady-state of this coupled-oscillator system — and both have **negative y**. Net y-drift per tick pair: -3.69 px.
+
+Neither the intent vector nor the authored-retreat writes charge this backward drift to `backup_distance`. The smoothed-intent lane is the last unbudgeted bypass. (Separation was gated in S15 → L630; unstick was gated in S15 → L797. Smoothed-intent was not, because its intent vector was presumed to respect target-direction semantics.)
+
+**Wall-stuck detection does not catch this case** because the bot is "moving" at ~3.7 px/tick — far above the `STUCK_MIN_PX / STUCK_WINDOW_TICKS` = 10px/15-tick stuck threshold. The bot is moving freely, just backward.
+
+### 1.4 Seed 83 variant
+
+Seed 83 shows a slightly different fingerprint: `bd` climbs 6.05 → 12.10 → 18.15 → 24.20 → 30.25 over 5 consecutive ticks at `mvLen = 6.05`. That's the authored TENSION-too-close retreat writing correctly and consuming budget as designed. Five ticks of pure authored retreat = 30.25 px, then the 6th tick's smoothed-lateral (post-cap freeze) leaks an additional ~8 px backward via the same wall-clamp-velocity mechanism, pushing `backup_run` over 38.4.
+
+Same root cause — smoothed-lane bypasses the budget — just with a longer authored-retreat prefix.
+
+## 2. Ruling
+
+**Root cause: Riv's hypothesis #1, activated by wall-clamp.**
+
+Velocity-smoothing integrates state across ticks, and the arena-clamp removes the spatial consequence of that state on one axis without removing the velocity itself. The coupled oscillator created by the wall-clamp + orbit-direction-flip produces persistent backward drift that is never charged to `backup_distance`. This is not a calibration issue; it is a structural budget-bypass.
+
+**The invariant violated:** `backup_distance` was supposed to bound total per-period backward motion across all lanes. It does not. The smoothed-intent lane leaks.
+
+## 3. Fix directive for Nutts
+
+### 3.1 Change (canonical: close the smoothed-lane leak)
+
+**File:** `godot/combat/combat_sim.gd`
+
+**Where:** at every call site that writes `b.position += _smooth_velocity(b, desired, TICK_DELTA)` — there are ten of these (L483, L504, L556, L565, L579, L583, L985, L1005, L1033; plus the partial at L575 in stance-2 kiting). Route them all through a new helper.
+
+**New helper** (add near `_smooth_velocity`, below L876):
+
+```gdscript
+# S17.2-003 Addendum 1: apply a smoothed-intent displacement with a budget gate
+# on its backward-along-target component. Forward and perpendicular components
+# pass through untouched; any backward-along component is clamped against the
+# remaining `backup_distance` budget (same contract as separation L625 and
+# unstick nudge L790). Closes the wall-clamp + orbit-flip limit-cycle bypass
+# identified in the strict-zero moonwalk seeds 5/8/80/83.
+func _apply_smoothed_displacement(b: BrottState, delta: Vector2) -> void:
+	if b.target == null or delta.length_squared() < 0.0001:
+		b.position += delta
+		return
+	var to_target_v: Vector2 = b.target._pos_snapshot - b.position
+	if to_target_v.length_squared() < 0.0001:
+		b.position += delta
+		return
+	var to_target_n: Vector2 = to_target_v.normalized()
+	var along: float = delta.dot(to_target_n)
+	if along >= 0.0:
+		b.position += delta  # forward or purely perpendicular — passthrough
+		return
+	var perp_delta: Vector2 = delta - to_target_n * along
+	var remaining_budget: float = maxf(0.0, TILE_SIZE - b.backup_distance)
+	var backward_mag: float = minf(-along, remaining_budget)
+	b.backup_distance += backward_mag
+	b.position += perp_delta + to_target_n * (-backward_mag)
+```
+
+**Replace every** `b.position += _smooth_velocity(b, desired, TICK_DELTA)` **with**:
+
+```gdscript
+_apply_smoothed_displacement(b, _smooth_velocity(b, desired, TICK_DELTA))
+```
+
+**Do not** modify the existing direct-write retreat sites — they already manage `backup_distance` correctly. **Do not** touch `_smooth_velocity` itself — this is a post-processing gate on its output.
+
+### 3.2 Why this is the right shape
+
+- Same contract as separation (L625) and unstick (L790): any backward-component write costs budget; forward/perp passes through.
+- Single new helper — no combat-logic branching.
+- Revision §3 categorization stands: the smoothed-intent lane still does smoothed-intent; the direct-write retreats still do direct-write. The budget contract becomes uniform across all lanes.
+- Zero effect in open-space fights: when `delta` has no backward component (normal orbit, forward-chase, in-band lateral without wall-clamp), `along >= 0` and the gate is a passthrough.
+- Effect appears only when wall-clamp or stale-velocity rotation produces an incidental backward component — exactly the bug surface.
+
+### 3.3 Expected result
+
+- `test_sprint11_2.gd::test_away_juke_cap_across_seeds`: 4/100 → 0/100.
+- `test_sprint11.gd::test_no_moonwalking`: 4/100 → ≤2/100 (may improve; some of those seeds likely hit the same mechanism).
+- `test_s17_2_scout_feel.gd`: 15/15 unchanged (AC-T4 is a per-bot displacement bound, not a rate bound; the fix only reduces backward displacement).
+- Mirror-WR @ N=200: should remain in-band. The fix only converts incidental backward motion (which cost time but not budget) into perpendicular+zero motion (same tick cost, lower backward travel). Expected to slightly reduce the draw rate observed after the halving (29/200), since bots no longer linger along walls as long.
+
+### 3.4 Alternative considered and rejected
+
+**Zero the clamped axis of `b.velocity` at the arena-clamp site.** Simpler (3 LoC). Breaks the specific wall-clamp limit cycle. But it does not close the general bypass — any future smoothed-lane backward-drift case (pillar-repel, close-quarters rotation with stale velocity, etc.) remains unbudgeted. The canonical fix (§3.1) closes the class; the axis-zero fix closes one instance. Choosing the canonical fix.
+
+## 4. Spec consequence
+
+Revision §3 table classified write sites as direct-write (budget-aware) or smoothed-intent (budget-unaware, presumed respectful of target-direction semantics). That classification stands as written, but the **invariant** tightens:
+
+> **Invariant (S17.2-003 Add-1):** Every `b.position` write with a backward-along-target component charges that component to `backup_distance`, regardless of lane. The smoothed-intent lane is budget-aware for its backward-component output via `_apply_smoothed_displacement`, even though the smoothing itself is unconstrained.
+
+No change to the two-lane architecture. No change to `RETREAT_SPEED_MULT`. No new sub-sprint.
+
+## 5. Open questions for HCD
+
+None. Diagnosis is conclusive, fix is bounded, no creative-direction ambiguity.


### PR DESCRIPTION
Docs-only. Design addendum closing the 4/100 residual on `test_away_juke_cap_across_seeds` per §2.2 escalation of the prior calibration addendum.

## Diagnosis

Instrumented the test. Failing seeds: 5, 8, 80, 83. Every violation is stance=0 / phase=0 / unstick=0, with bot 0 arena-clamped against a wall. Trace of seed 80 shows a perfect limit cycle: `backup_distance` stays at 0.00 while `backup_run` accumulates to 38.73 px over 15 ticks of pure anti-target motion.

**Mechanism:** arena-clamp strips `b.position` but not `b.velocity`. Orbit-direction flips on wall collision. The coupled oscillator produces persistent backward drift through the smoothed-intent lane — unbudgeted by `backup_distance`. This is the last unbudgeted bypass in the retreat system (separation was gated in S15 L625; unstick was gated in S15 L790).

## Ruling

Riv's hypothesis #1 (stale velocity carryover), activated by wall-clamp. Structural budget-bypass, not a calibration issue. The `backup_distance` invariant was supposed to bound total per-period backward motion across all lanes; the smoothed-intent lane leaks.

## Fix directive (for Nutts, separate PR)

Route every `b.position += _smooth_velocity(...)` write through a new `_apply_smoothed_displacement` helper that charges the backward-along-target component to `backup_distance`. Forward / perpendicular pass through untouched. Same contract as existing separation and unstick gates.

Expected: 4/100 → 0/100. See §3 of the addendum for the exact helper and call-site replacements.

No combat-logic changes; no revision to the two-lane architecture; no change to `RETREAT_SPEED_MULT`.