### PR TITLE
[S17.1-003] Design: visible-by-default tooltips

### DIFF
--- a/docs/design/s17.1-003-visible-tooltips.md
+++ b/docs/design/s17.1-003-visible-tooltips.md
@@ -1,0 +1,478 @@
+# [S17.1-003] Visible-by-default Tooltips — Design
+
+**Status:** Design handoff — Gizmo → Nutts
+**Sub-sprint:** [S17.1](../../sprints/sprint-17.1.md) (Shop/Loadout/Event UX fixes)
+**Arc:** [S17 Eve Polish](../../sprints/sprint-17.md)
+**Complexity:** **M** (two surfaces: Loadout item cards + arena-HUD energy label; touches every Loadout item render path)
+**Sacred paths (unchanged):** `godot/combat/**`, `godot/data/**`, `godot/arena/**`, `docs/gdd.md`
+
+---
+
+## 0. Scope discipline (read first)
+
+- **Files to change:**
+  - `godot/ui/loadout_screen.gd` — item-card row gains an always-visible one-line descriptor (name + archetype line already exists; add description line beneath).
+  - `godot/game_main.gd` — arena HUD energy readout gains a clear label + one-line legend Control.
+- **New test file:** `godot/tests/test_sprint17_1_visible_tooltips.gd`.
+- **LoC budget:**
+  - `loadout_screen.gd`: ≤ ~40 lines added/changed (in `_create_item_card` and two constants).
+  - `game_main.gd`: ≤ ~25 lines added/changed (in `_create_arena_hud` and `_update_arena_ui`).
+- **No new scenes, no data changes, no signal-contract changes, no new balance fields.** All surfaced info reads from existing `WeaponData` / `ArmorData` / `ModuleData` / `ChassisData` / `BrottState.energy` fields.
+- This is UI presentation only. If Nutts finds themselves editing `godot/data/**`, `godot/arena/**`, or `godot/combat/**`, stop and flag Riv.
+
+---
+
+## 1. Task restatement + cited complaints
+
+Fix two discoverability gaps surfaced in the 2026-04-18 playtest:
+
+> #103: "in loadout view there's no way to double check what an item is or does" *(HCD later found hover works, but the hover affordance was undiscoverable)*
+
+> #107: "i'm confused what the blue bar is — is that energy? What is energy for?"
+
+Backlog: [#103](https://github.com/brott-studio/battlebrotts-v2/issues/103) — *UX: Tooltips visible by default (not hover-only)* (prio:high). [#107](https://github.com/brott-studio/battlebrotts-v2/issues/107) — *UX: First-encounter explanation for every HUD element* (prio:mid; the persistent-label slice lives here, the first-run overlay slice lives in S17.1-004).
+
+Out of scope for this task (explicitly): Shop card info (already visible on expanded card — see §2.3), every non-energy HUD element's first-run explainer (→ S17.1-004), hover-based rich tooltips beyond the HCD-visible essentials (keep existing `tooltip_text` as a no-op fallback; redundancy is fine).
+
+---
+
+## 2. Root-cause analysis
+
+### 2.1 Loadout item cards — current rendering
+
+`godot/ui/loadout_screen.gd` → `_create_item_card(item_name, archetype, description, equipped)` at L239–291.
+
+Each card is a 500×32 `PanelContainer` containing one `Button`. The button's visible text is:
+
+```
+✓ Minigun — 🔫 Rapid Fire       (equipped, first glyph is tick)
+  Minigun — 🔫 Rapid Fire       (unequipped)
+```
+
+i.e. **name + archetype only**. The full `description` string (e.g. *"Sprays a stream of bullets — low damage, constant pressure. Death by a thousand cuts."*) is attached via Godot's built-in `btn.tooltip_text = description` (L281) — hover-only, no visual cue that a tooltip exists.
+
+**Why this fails for discoverability:** the Button looks like a plain row of text. There is no underline, no `?` icon, no hover hint, no cursor-change affordance that signals "hover for more." A first-time player reads the row, sees "Minigun — 🔫 Rapid Fire," and has no reason to suspect a tooltip is hiding the actual weapon behavior.
+
+Callers (all in `_build_ui()`): L142 (weapons), L149 (armor "None"), L155 (armor), L167 (modules). Each reads `wd["name"]`, `wd["archetype"]`, `wd["description"]` from existing data — **every relevant item dict already has a `description` field** (verified in `godot/data/weapon_data.gd`, `armor_data.gd`, `module_data.gd`; spot-check at §2.5).
+
+No new data needed. The description text already exists — it's just gated behind hover.
+
+### 2.2 Empty-slot indicators
+
+`_create_empty_slot_indicator(slot_type)` renders "  + Empty weapon slot" etc. These are self-explanatory — no tooltip issue. They are unchanged by this task.
+
+### 2.3 Shop cards — already visible-by-default (no change)
+
+Shop cards (`godot/ui/shop_screen.gd` `_build_expanded_card()` ~L540–610) already show name, archetype, full stats grid, and description text directly on the expanded card. The hover-only problem does **not** apply to Shop — the playtest complaint was specifically about Loadout view.
+
+Collapsed shop cards (200×240 with placeholder art) show the price and category tag; clicking a card toggles expand to reveal full info. That's a discoverable click affordance, not a hover affordance. Leave Shop as-is.
+
+**Confirmed with S17.1-001 author's design (§2 of `s17.1-001-shop-scroll.md`):** Shop card structure is unchanged. Our change does not affect Shop row heights, which means S17.1-001's scroll save/restore (`_save_scroll` / `_restore_scroll`) is untouched.
+
+### 2.4 Energy bar — current rendering (two surfaces)
+
+The "blue bar" the HCD is asking about is drawn in **two places**:
+
+1. **Per-bot inline bar** — `godot/arena/arena_renderer.gd` L770–774. A 3-px-tall `draw_rect` below each bot sprite, `COLOR_ENERGY = Color(0.2, 0.7, 1.0)` (the "blue"). **Sacred path.** We do not touch this.
+2. **HUD numeric readout** — `godot/game_main.gd` `_update_arena_ui()` L362–367. Formats `"PLAYER [name] HP: %d/%d  EN: %d"` into `player_info` / `enemy_info` Labels pinned at `(20,10)` and `(700,10)`.
+
+The HUD label says "EN: 42" — compact, not self-documenting. Combined with the tiny blue bar in the arena, a first-time player has no way to connect (a) the letters "EN" to (b) the word "energy" to (c) what energy actually does. The sacred-path constraint means we cannot add in-arena text; the fix has to live in `game_main.gd` (the HUD layer).
+
+Energy data source: `BrottState.energy: float` (L25 of `godot/combat/brott_state.gd`). Max is 100.0 (`MAX_ENERGY`), regens at 5/s (`ENERGY_REGEN_PER_TICK`). Weapons subtract `weapon_data[w]["energy_cost"]` on fire. All existing values — no new fields.
+
+### 2.5 Data spot-checks (all existing fields)
+
+- `WeaponData.WEAPONS[MINIGUN]`: `"name"`, `"archetype": "🔫 Rapid Fire"`, `"description": "Sprays a stream of bullets — low damage, constant pressure. Death by a thousand cuts."`
+- `WeaponData.WEAPONS[SHOTGUN]`: archetype `"💥 Shotgun"`, description `"Get close, pull the trigger..."`
+- `ArmorData` / `ModuleData` / `ChassisData`: same pattern (name/archetype/description). Verified at repo HEAD = `27b1a02`.
+
+Confirmed: no data file edits required.
+
+---
+
+## 3. ux-vision.md alignment
+
+From `docs/kb/ux-vision.md` (Eve-from-WALL-E UX target):
+
+> **Anti-patterns (do NOT ship):** *"Hover-only affordances (already flagged in playtest — tooltips must be visible by default)."*
+>
+> **Pillars:** *Professional, Clean, Polished — strong negative space, minimal ornament, typography-led hierarchy. One voice per screen.*
+>
+> **Writing guidance:** *"Labels short. Tooltips one sentence. Explanations live in dedicated info screens, not shoved into controls."*
+
+The vision explicitly anti-patterns hover-only tooltips and favors typography-led hierarchy. Among the four interpretations of "visible by default" in Ett's scope note, the one that lines up with Eve is **Option 1: inline descriptor — a small, restrained second line of text under each item's name/archetype**. It uses typography (size + color) to establish hierarchy (name = primary, description = secondary), adds zero ornament (no icons, no badges, no hover-reveal chrome), and preserves one voice per screen. It's the calmest of the four options.
+
+Rejected alternatives and why:
+
+- **Icon-with-stat row (e.g. `⚡5 🛡3`)** — reads busy, adds ornament, fights the Eve pillar of "restrained color, intentional accent." Also regresses against the anti-pattern *"cluttered HUDs with 8+ simultaneous badges/numbers."*
+- **Summary card for selected item + hover for others** — still leaves non-selected items hover-gated; doesn't resolve #103.
+- **Combo (icons + inline + hover)** — maximalist; directly violates "one voice per screen."
+
+For the **HUD energy label**, the vision checklist line `[ ] Energy bar (and every HUD element) has in-game explanation on first encounter` authorizes the explainer. The *first-encounter overlay* slice is S17.1-004. This task ships the persistent visible label that makes `EN: 42` read as `⚡ Energy 42/100` plus a single short legend line — per the vision's *"labels short, tooltips one sentence"* rule.
+
+---
+
+## 4. Proposed design
+
+### 4.1 Loadout item cards — add inline description line
+
+**Before (per-item card, 500×32):**
+
+```
+┌────────────────────────────────────────────┐
+│  ✓ Minigun — 🔫 Rapid Fire                 │  (hover reveals description)
+└────────────────────────────────────────────┘
+```
+
+**After (per-item card, 500×56):**
+
+```
+┌────────────────────────────────────────────┐
+│  ✓ Minigun — 🔫 Rapid Fire                 │  ← name+archetype line, 14pt cream
+│     Sprays bullets — low damage, constant  │  ← description line, 11pt muted,
+│     pressure.                              │     single-line truncate or wrap-1
+└────────────────────────────────────────────┘
+```
+
+**Tier split ("critical info" = always-visible):**
+
+| Info | Before | After |
+|---|---|---|
+| Item name | visible | visible (unchanged, primary typography) |
+| Archetype tag (emoji + role) | visible | visible (unchanged, same line) |
+| One-line description | hover-only | **visible (new second line, muted/small)** |
+| Equipped/unequipped state | visible (✓ glyph + border + color) | visible (unchanged) |
+| Full numeric stats | not shown in Loadout | not shown (still Shop-only — keeps Loadout decision-focused, not data-heavy) |
+| `[Equipped]` prefix for screen readers | present via `tooltip_text` | present via `tooltip_text` (unchanged accessibility hook; see §6.5) |
+
+**Why not also surface numeric stats inline:** Loadout's job is "pick what to equip," not "audit numbers" — the Shop's expanded card is the data-heavy surface. Keeping Loadout typography-light reinforces the pillar of "one voice per screen." If a later playtest shows HCD wanting stats in Loadout, that's a carry-forward, not this task.
+
+### 4.2 Loadout item card — concrete layout
+
+Replace the single `Button` child of the card `PanelContainer` with a `Button` + `Label` stacked in a `VBoxContainer`:
+
+```
+PanelContainer (500×~56, styled as today)
+└── VBoxContainer (separation=2)
+    ├── Button (flat, 500×28)      "✓ Minigun — 🔫 Rapid Fire"   (14pt)
+    │     pressed → existing handler binding (_select_chassis/_toggle_weapon/etc.)
+    └── Label (500×~22)             "  Sprays bullets — low damage..."  (11pt, muted)
+          autowrap_mode = AUTOWRAP_OFF   (single line, truncate with ellipsis)
+          clip_text = true
+          mouse_filter = MOUSE_FILTER_IGNORE   (don't steal Button clicks)
+```
+
+Key constraints:
+
+- **Row height grows from 32 px to ~56 px.** S17.1-002 design §7.1 explicitly pre-authorized 60–80 px headroom inside the new `ScrollArea`. We land inside that budget. Scroll region absorbs the growth; footer stays pinned at y=650; no overlap regression possible (§7.2).
+- **Description label truncates, doesn't wrap.** Multi-line descriptions would inflate row height unpredictably and hurt scannability. Single-line truncate + ellipsis keeps rows uniform. Hover `tooltip_text` still carries the full description for anyone who wants the complete sentence.
+- **`mouse_filter = MOUSE_FILTER_IGNORE` on the description label** so clicks pass through to the Button underneath. Without this, clicking the description text would do nothing, which is worse than today.
+- **Empty-slot indicators are not affected** (no description to show — they already say "+ Empty weapon slot"). `_create_empty_slot_indicator` stays at 500×32.
+
+### 4.3 Items with no description (edge case)
+
+If `description == ""`, omit the description Label entirely and let the card collapse back to ~32 px. This keeps visual uniformity per item type: if an item type happens to ship without a description, it reads as a single-line row — not a suspicious empty gap. (Verified all current `WeaponData`/`ArmorData`/`ModuleData`/`ChassisData` entries have non-empty descriptions, so this is a defensive-coding path, not an expected case.)
+
+### 4.4 Energy HUD — label + legend
+
+**Change 1 — reword the numeric readout** in `_update_arena_ui()`:
+
+```gdscript
+# BEFORE (L363):
+player_info.text = "PLAYER [%s] HP: %d/%d  EN: %d" % [
+    player_brott.bot_name, int(player_brott.hp), player_brott.max_hp, int(player_brott.energy)]
+
+# AFTER:
+player_info.text = "PLAYER [%s]   ❤ HP %d/%d   ⚡ Energy %d/100" % [
+    player_brott.bot_name, int(player_brott.hp), player_brott.max_hp, int(player_brott.energy)]
+```
+
+Same shape for `enemy_info`. Replacing `"EN:"` with `"⚡ Energy"` makes the word "Energy" always on-screen next to the live value — a first-time player can immediately connect the blue in-arena bar to "energy." The ⚡ glyph is the same intentional-accent style as existing archetype tags (`🔫`, `💥`). HP gets a matching ❤ glyph so both stats read parallel.
+
+**Change 2 — add a persistent one-line legend** under the player HUD row:
+
+```gdscript
+# In _create_arena_hud(), after creating player_info and enemy_info:
+var hud_legend := Label.new()
+hud_legend.name = "HudLegend"
+hud_legend.text = "⚡ Energy fuels weapons & modules — regenerates over time."
+hud_legend.position = Vector2(20, 38)     # directly under player_info at (20,10)
+hud_legend.size = Vector2(600, 20)
+hud_legend.add_theme_font_size_override("font_size", 11)
+hud_legend.add_theme_color_override("font_color", Color(0.7, 0.75, 0.8, 0.85))  # muted
+add_child(hud_legend)
+```
+
+**Exact proposed copy (≤ one sentence, ≤ 12 words):**
+
+> *⚡ Energy fuels weapons & modules — regenerates over time.*
+
+Rationale: (1) names the thing ("Energy"), (2) answers the playtester's actual question ("What is energy for?") in one clause, (3) hints at the regen mechanic without going into numbers, (4) matches BrottBrain voice — concise, present tense — per `docs/kb/ux-vision.md` writing guidance.
+
+**Why a separate legend Label, not stuffing it into the main HUD row:** keeps the main HUD row compact and scannable; the legend is a one-time-read orientation line that recedes visually (muted color, smaller font) once the player has absorbed it.
+
+### 4.5 Handoff to S17.1-004 (first-encounter overlay)
+
+S17.1-004 adds a *dismissible first-run overlay* that highlights the energy bar and explains it with more ceremony. That overlay is ephemeral. **This task's persistent label stays rendered at all times** — even after the first-run overlay is dismissed. The two layer cleanly:
+
+- Session N=1: first-run overlay fires once, player dismisses → legend remains as the persistent reminder.
+- Session N≥2: no overlay → legend is still there, quietly answering "what was that blue bar again?"
+
+See §8 for the explicit coordination line.
+
+### 4.6 Layout safety vs [S17.1-002]
+
+Checked against `docs/design/s17.1-002-loadout-overlap.md` §7.1:
+
+- ✅ Row height 32 → 56 px is inside the pre-authorized 60–80 px headroom.
+- ✅ All rendering stays inside `ScrollArea/Content: VBoxContainer`.
+- ✅ Footer (`back_btn` @ (20,650), `_equip_button` @ (1050,650)) is untouched — no Y shift, no resize.
+- ✅ No new UI between scroll region and footer.
+- ✅ No floating popovers (we use inline text, not a popover — so `show_on_top()` sibling pattern is not needed for this task).
+
+---
+
+## 5. Files / symbols to change (concrete list for Nutts)
+
+| File | Change | Approx LoC |
+|---|---|---|
+| `godot/ui/loadout_screen.gd` | In `_create_item_card(...)`: replace the single-`Button`-child structure with a `VBoxContainer` wrapping the existing `Button` plus a new `Label` for the description. Grow `panel.size.y` from 32 to 56. Keep `Button` size at 500×28 (shrunk from 500×32 to make room). Skip the description `Label` entirely when `description == ""`. Leave `tooltip_text` line as-is (redundant accessibility fallback). | +25 / −3 |
+| `godot/ui/loadout_screen.gd` | Add two constants near the top-of-file style constants: `const DESC_FONT_SIZE := 11` and `const DESC_COLOR := Color(0.7, 0.75, 0.8, 0.9)` (matches the muted-label tone used by shop_screen's description labels). | +2 |
+| `godot/game_main.gd` | In `_update_arena_ui()` L362–367: change both format strings from `"... HP: %d/%d  EN: %d"` to `"...   ❤ HP %d/%d   ⚡ Energy %d/100"`. | ±4 |
+| `godot/game_main.gd` | In `_create_arena_hud()`: after `add_child(player_info)` / `add_child(enemy_info)`, create a new `hud_legend` Label at `(20, 38)`, size `(600, 20)`, font_size 11, muted color, text `"⚡ Energy fuels weapons & modules — regenerates over time."`, and `add_child(hud_legend)`. Store as `var hud_legend: Label` on the script if clearing in `_clear_screen()` requires it (check: `_clear_screen()` already clears all Label children, so a local var is sufficient — no field needed). | +10 |
+| `godot/tests/test_sprint17_1_visible_tooltips.gd` | New test file (see §7). | +100–140 |
+
+**Do NOT touch:**
+
+- `_create_empty_slot_indicator()` — empty-slot rows stay at 500×32, no description to add.
+- `_build_ui()` structure — item-card callers (L142 / L149 / L155 / L167) keep the same signature `_create_item_card(name, archetype, description, equipped)`. The change is fully inside `_create_item_card`.
+- `shop_screen.gd` — Shop cards already show description on expanded card; no change.
+- `arena_renderer.gd` — sacred. The in-arena blue bar is untouched; we only change the HUD layer.
+- `brott_state.gd`, `combat_sim.gd`, any `godot/data/**` — sacred.
+- `_update_arena_ui()` field order beyond the format-string swap — the Label nodes (player_info, enemy_info, time_label, speed_label) keep their positions and sizes.
+- `_clear_screen()` — existing loop `for child in get_children(): if child is Label: child.queue_free()` already reaps the new `hud_legend` Label. No change needed.
+
+**Estimated total delta:** ~40 net lines across two files (excluding tests). Within both per-file caps in §0. If Nutts trends past +60 lines or starts restructuring `_build_ui()` or `_create_arena_hud()` flow, stop and flag Riv.
+
+---
+
+## 6. Edge cases
+
+### 6.1 Items with no description (defensive only)
+
+Covered in §4.3. Current data has no empty-description entries, but guard `if description == ""` and skip the Label node to collapse the card back to ~32 px.
+
+### 6.2 Edge items (consumables / cosmetics)
+
+No consumable/cosmetic item type exists in the current data model (`WeaponData`, `ArmorData`, `ModuleData`, `ChassisData` is the full taxonomy per `godot/data/`). If a future arc introduces them, they'll be built via the same `_create_item_card` helper and will auto-inherit visible-by-default descriptions as long as their data dicts include a `"description"` field. No special-casing needed now.
+
+### 6.3 Mobile / smaller viewports
+
+`project.godot` sets `window/stretch/mode = "canvas_items"` + `aspect = "keep"`; the UI always sees a 1280×720 viewport regardless of window size (letterboxed). 11 pt at effective 720-px viewport height is ~15 px physical at a 1080-row window — readable. No mobile/touch target in this arc; the ergonomic check is "desktop at 1280×720" and the description Label passes.
+
+If mobile ever becomes a target, the description's single-line truncate may need to become 2-line wrap at smaller widths. Document as carry-forward; not this task.
+
+### 6.4 Font / line-height impact on Shop scroll (S17.1-001)
+
+**No impact.** Shop cards (`shop_screen.gd`) are not touched by this task. Shop row heights are unchanged (`CARD_H = 240` collapsed, expanded sizes unchanged). S17.1-001's `_save_scroll` / `_restore_scroll` pattern keys off `scroll.scroll_vertical` and does not depend on per-row height — the save/restore still functions whether rows are 240 or any other value, as long as total content height is stable across the rebuild (which it is — we're not changing Shop at all).
+
+Confirmed by reading `docs/design/s17.1-001-shop-scroll.md` §3 (the save/restore patches the scroll value directly, not a computed row index).
+
+### 6.5 Localization hooks
+
+Audited repo: there is no existing i18n helper (no `tr("...")` calls, no translation CSV, no `.po` pipeline). All UI strings are hard-coded in the `.gd` files. This task follows the existing convention — hard-coded English strings in `loadout_screen.gd` and `game_main.gd`. **Do not introduce an i18n helper here** — that's an arc-level decision, not a polish-task decision.
+
+Noted for a future localization arc: item descriptions live in `godot/data/*_data.gd` dicts (sacred for this task, but naturally central for a future `tr()` pass), and the new HUD legend string is a single literal in `game_main.gd` — both are easy to route through an i18n layer later.
+
+### 6.6 Accessibility / screen readers
+
+Godot 4 has no native screen-reader support. The existing `btn.tooltip_text = "[Equipped] " + description` (L286) is kept as-is — a redundant accessibility hook for any future AT integration. The new visible description Label also implicitly surfaces the info to anyone using a screen-scraping or OCR-based tool. Net accessibility posture: better than today (description is now visually present, not just hover-gated).
+
+### 6.7 Rebuild-on-equip
+
+`_toggle_weapon` / `_select_armor` / `_toggle_module` call `_build_ui()`, which tears down all children and re-runs `_create_item_card` for every item. The new `VBoxContainer` + `Label` structure is rebuilt cleanly on every equip — no orphaned nodes, no leaks. Unchanged behavior beyond the one-time cost of creating one extra Label per item (trivial — worst-case ~30 items = 30 extra node allocations per rebuild).
+
+### 6.8 Long descriptions (truncation correctness)
+
+Longest current description: ~95 characters (`WeaponData.MISSILE_POD`). At 11 pt, a 500-px label fits roughly 75–85 characters before truncating. Truncation with `clip_text = true` + `text_overrun_behavior = OVERRUN_TRIM_ELLIPSIS` (if available — Godot 4's `Label.text_overrun_behavior` property) produces clean ellipsis. The hover `tooltip_text` still carries the full untruncated string.
+
+If `text_overrun_behavior` is not usable on the current Godot version, fall back to `clip_text = true` (hard clip, no ellipsis) — still acceptable for this task. Nutts picks at implementation time.
+
+---
+
+## 7. Acceptance tests
+
+New test file: `godot/tests/test_sprint17_1_visible_tooltips.gd`. Same `extends SceneTree` pattern as `test_sprint17_1_loadout_overlap.gd`. Fixtures reuse `build_fixture_state(inv_size)` from the S17.1-002 test helper if it's present and exported; otherwise Nutts ports the minimal builder into the new file.
+
+### 7.1 [AC-1] Loadout item card has visible description Label (no hover required)
+
+```
+1. Build LoadoutScreen with a GameState that owns ≥1 weapon, ≥1 armor, ≥1 module.
+2. screen.setup(state).
+3. Locate one item card PanelContainer for each of weapon/armor/module.
+4. For each: assert the PanelContainer contains both a Button AND a Label child
+   (nested inside one VBoxContainer).
+5. Assert the Label's text is the expected description string from the item's
+   data dict (e.g. WeaponData.WEAPONS[MINIGUN]["description"]).
+6. Assert the Label.visible == true and Label.modulate.a >= 0.8
+   (not hidden, not transparent).
+7. Assert Label.mouse_filter == MOUSE_FILTER_IGNORE.
+```
+
+Run for at least 3 distinct item types (weapon, armor, module) per the S17.1-003 acceptance criteria.
+
+### 7.2 [AC-2] Card height grew to ~56 px, hasn't exceeded S17.1-002's 80 px headroom
+
+```
+1. Build screen, locate any populated item card.
+2. Assert card.size.y >= 48   (grew from 32)
+3. Assert card.size.y <= 80   (stays inside S17.1-002's pre-authorized headroom)
+```
+
+### 7.3 [AC-3] Empty-slot indicators unchanged at 32 px
+
+```
+1. Build screen with a chassis that has weapon_slots > owned_weapons.size()
+   (i.e. at least one empty weapon slot).
+2. Locate the empty-slot PanelContainer.
+3. Assert its size.y == 32.
+4. Assert it does NOT contain a description Label (only the "+ Empty ... slot" label).
+```
+
+### 7.4 [AC-4] Loadout footer still reachable at inv_size = 0, 5, 20, 50
+
+Regression guard against S17.1-002:
+
+```
+for inv_size in [0, 5, 20, 50]:
+    screen = LoadoutScreen.new()
+    screen.setup(build_fixture_state(inv_size))
+    await_one_frame()
+
+    back_btn = _find_button_starting_with(screen, "← Shop")
+    equip_btn = _find_button_starting_with(screen, "Continue")
+
+    assert back_btn.position == Vector2(20, 650)
+    assert equip_btn.position == Vector2(1050, 650)
+
+    # No scroll content overlaps footer in global-rect terms.
+    scroll = screen.get_node("ScrollArea")
+    for row in scroll.get_node("Content").get_children():
+        assert not _global_rects_overlap(back_btn, row)
+        assert not _global_rects_overlap(equip_btn, row)
+```
+
+Footer remains pinned, no item-card description push causes overlap. This is the explicit regression check Ett's plan required.
+
+### 7.5 [AC-5] Energy HUD text contains the word "Energy"
+
+```
+1. Trigger an arena match (game_main._start_demo_match or equivalent test entry).
+2. await_one_frame() so _update_arena_ui() runs once.
+3. Assert "Energy" in player_info.text.
+4. Assert "Energy" in enemy_info.text.
+5. Assert "/100" in player_info.text  (full max shown, not bare number).
+```
+
+### 7.6 [AC-6] HUD legend Label exists and explains energy in one sentence
+
+```
+1. Same arena-match entry as AC-5.
+2. Locate a Label child of game_main with name == "HudLegend".
+3. Assert label != null.
+4. Assert label.visible == true.
+5. Assert "Energy" in label.text.
+6. Assert label.text.length() <= 80   (one-sentence guardrail).
+7. Assert label.position.y < 60   (directly under the main HUD row, not at screen bottom).
+```
+
+### 7.7 [AC-7] Signal-contract regression (Loadout)
+
+Same as S17.1-002 AC-5: `back_pressed` and `continue_pressed` still emit correctly when their buttons are pressed. Item-card Button click still invokes its bound handler (`_select_chassis` / `_toggle_weapon` / `_select_armor` / `_toggle_module`) — the description Label must not intercept clicks.
+
+```
+1. Build screen.
+2. Locate a weapon item card Button.
+3. Click at a point inside the description Label's rect
+   (but overlapping the card).
+4. Assert _toggle_weapon was invoked (or its bound handler fired).
+```
+
+This locks down the `mouse_filter = MOUSE_FILTER_IGNORE` requirement on the description Label.
+
+### 7.8 [AC-8 — Optic manual / Playwright visual] Screen readability at 1280×720
+
+Optic captures a Playwright-style screenshot of:
+
+- Loadout screen with a representative inventory — visually confirms each item row shows name+archetype line AND a second description line without any hover interaction.
+- Arena HUD — visually confirms `⚡ Energy NN/100` readout plus the one-line legend below it, both legible at 1280×720.
+
+Subjective pass/fail, captured in Optic's S17.1-003 verification doc alongside AC-1 through AC-7 unit results.
+
+---
+
+## 8. Coordination notes
+
+### 8.1 [S17.1-001] Shop scroll — confirmed no interaction
+
+This task does not touch `shop_screen.gd`. Shop row heights, scroll container, and the `_save_scroll` / `_restore_scroll` pattern from S17.1-001 are untouched. No regression risk. Confirmed by read of `docs/design/s17.1-001-shop-scroll.md` §3 — the save/restore keys off `scroll.scroll_vertical` (pixel value), not row-count math.
+
+### 8.2 [S17.1-002] Loadout scroll region — stay inside the ScrollArea
+
+Per S17.1-002 design §7.1:
+
+- ✅ Row height grows 32 → 56 px, inside the pre-authorized 60–80 px headroom. Scroll region absorbs the increase.
+- ✅ Description Labels render as children of the existing item-card PanelContainer, which is a child of `ScrollArea/Content: VBoxContainer`. Nothing new outside the scroll region.
+- ✅ Footer (`back_btn` at (20,650), `_equip_button` at (1050,650)) is untouched. Positions, sizes, z-order preserved.
+- ✅ No space is consumed between the scroll region and the footer (there isn't any to consume).
+- ❌ No `show_on_top()` siblings introduced — we chose inline descriptors (§3), not floating popovers, so the sibling-of-ScrollArea pattern is not needed here.
+
+AC-4 (§7.4) locks this invariant down with tests at inv_size = 50 (the S17.1-002 stress case).
+
+### 8.3 [S17.1-004] First-encounter HUD overlay — clean layering
+
+S17.1-004 will add a **one-shot, dismissible, first-run overlay** that calls attention to the energy bar with more ceremony (arrow/callout/explainer card). That overlay is ephemeral — shown once, dismissed, persisted-as-seen in user profile.
+
+**This task (S17.1-003) ships a persistent, always-visible legend Label.** The two layer cleanly:
+
+- Session N=1: first-run overlay fires → HCD reads it → dismisses → legend Label remains below HUD as a quiet reminder.
+- Session N≥2: no overlay → legend Label still there, answering any residual "what was that again?" the HCD might have.
+- No overlap: the first-run overlay should *anchor visually* near the in-arena blue bar (that's S17.1-004's design call). The legend Label is in the HUD row at top-left. Different screen regions.
+
+**Explicit line for S17.1-004's design:** the legend Label named `HudLegend` is present at all times when `in_arena == true`. If S17.1-004's overlay wants to reuse the same copy (`"⚡ Energy fuels weapons & modules — regenerates over time."`), extract it to a `const ENERGY_LEGEND_COPY` in `game_main.gd` so both surfaces share one string. Not required this task — flag for S17.1-004's file list.
+
+### 8.4 Depersonalization
+
+Doc and PR body use "HCD" / "Human Creative Director." The verbatim playtest quotes in §1 retain original wording per studio convention.
+
+---
+
+## 9. Complexity + effort estimate
+
+**Complexity: M (Medium).**
+
+**Rationale:**
+
+- Two surfaces (Loadout item cards + arena HUD), but each is small and well-scoped.
+- Loadout change is a structural tweak to one helper (`_create_item_card`) plus two new constants. No logic change.
+- HUD change is a format-string swap plus one new Label node creation. No data change, no signal change.
+- One new test file with 7 required unit ACs + 1 manual Optic AC.
+- Zero risk to combat, balance, arena, or data surfaces (all sacred, all untouched).
+- Interaction with S17.1-002 is absorbed by the pre-authorized 60–80 px headroom — no new layout work.
+- No interaction with S17.1-001 (different file). No premature coupling with S17.1-004 (different trigger model).
+- Estimated Nutts spawn budget: **1 spawn**, ≤ 60 min wall-clock. Slightly more than S17.1-002 because two files change and the test file exercises both surfaces. If Nutts exceeds 90 min or LoC delta trends past +60 (excluding tests), escalate to Riv.
+
+**Risk tier: LOW.** The only non-obvious piece is keeping the description Label's `mouse_filter` set to IGNORE so it doesn't steal clicks from the Button — AC-7 guards this. Everything else is additive typography and one new Label.
+
+---
+
+## 10. Open questions
+
+None blocking. Two flagged for possible follow-up (NOT in this PR):
+
+- **🟢 Stats-in-Loadout.** If HCD wants numeric stats (damage / range / energy cost) inline in Loadout rows alongside the description, that's a carry-forward. Current design keeps Loadout decision-focused and pushes data-heavy info to Shop's expanded card.
+- **🟢 Shared `ENERGY_LEGEND_COPY` constant between S17.1-003 and S17.1-004.** Extract when S17.1-004 lands its overlay copy; not worth doing here with only one consumer.
+
+---
+
+**Design authored by Gizmo, 2026-04-21. Handoff to Nutts via Riv.**


### PR DESCRIPTION
## [S17.1-003] Design: visible-by-default tooltips

**Task:** `sprints/sprint-17.1.md` §[S17.1-003] — tooltips visible-by-default for critical info.
**Arc:** S17 Eve Polish — `sprints/sprint-17.md`.
**Backlog:** #103 (prio:high — tooltips visible by default), #107 (prio:mid — first-encounter HUD explainer; persistent-label slice lives here, first-run overlay is S17.1-004).

## Summary

Doc-only PR. Adds `docs/design/s17.1-003-visible-tooltips.md` (478 lines, matching the S17.1-001/002 format). Specifies the Nutts-facing technical plan for fixing two playtest discoverability gaps flagged by HCD on 2026-04-18:

- *"in loadout view there's no way to double check what an item is or does"* (hover worked but was undiscoverable)
- *"i'm confused what the blue bar is — is that energy? What is energy for?"*

## Root cause (one-liner)

Loadout item cards show only `name + archetype` and gate `description` behind Godot's built-in `Button.tooltip_text` — a hover affordance with no visual cue. Arena HUD writes `"EN: 42"` with no word "Energy" anywhere on-screen, so the blue in-arena bar (drawn by the sacred `arena_renderer.gd`) has no HUD-layer legend to anchor it.

## Chosen style + rationale

**Inline descriptor (Option 1), not icon-stat rows / summary cards / combo.** Matches the `docs/kb/ux-vision.md` Eve-from-WALL-E pillars (typography-led hierarchy, restrained, no badge clutter) and the anti-pattern list (no hover-only affordances). Item rows gain a small muted second line with the existing `description` string; HUD gains `⚡ Energy %d/100` plus a one-sentence legend Label. Zero new data, zero new balance fields, zero sacred-path edits.

## Scope

- **Touches:** `godot/ui/loadout_screen.gd` (~+25 LoC in `_create_item_card`), `godot/game_main.gd` (~+15 LoC in `_create_arena_hud` + `_update_arena_ui`), one new test file.
- **Untouched:** `godot/combat/**`, `godot/data/**`, `godot/arena/**`, `docs/gdd.md`, `shop_screen.gd`.
- All surfaced info reads from existing `WeaponData` / `ArmorData` / `ModuleData` / `ChassisData` / `BrottState.energy` fields.

## Coordination

- **[S17.1-001] Shop scroll:** no interaction. Shop rows unchanged; `_save_scroll` / `_restore_scroll` keys off pixel `scroll_vertical`, not row height. No regression.
- **[S17.1-002] Loadout overlap:** row height grows 32 → 56 px, inside the 60–80 px headroom explicitly pre-authorized in that doc's §7.1. Scroll region absorbs. Footer at y=650 untouched. AC-4 locks the invariant at inv_size = 50.
- **[S17.1-004] First-encounter HUD overlay:** clean layering. This task ships the persistent legend Label (`HudLegend`); S17.1-004 will ship the one-shot dismissible overlay. Different lifetimes, different screen regions. Doc flags a future shared `ENERGY_LEGEND_COPY` constant when S17.1-004 lands.

## Complexity

**M (Medium)** — two surfaces but each is small. Nutts budget: 1 spawn, ≤ 60 min wall-clock, LoC delta ≤ +60 excluding tests. Risk tier: LOW. AC-7 locks down the one non-obvious piece (description Label's `mouse_filter = MOUSE_FILTER_IGNORE` so clicks pass through to the underlying Button).

## Acceptance

- 7 Godot unit ACs + 1 Optic Playwright/visual AC in `docs/design/s17.1-003-visible-tooltips.md` §7.
- Key regression guard: AC-4 (Loadout footer reachable at inv_size ∈ {0, 5, 20, 50}) — direct check against S17.1-002's guarantee.

## Reviewer

Per sub-sprint plan: Specc App audits design-doc PRs. Doc-only change, CI should pass trivially.

---

*Design authored by Gizmo, 2026-04-21.*
