### PR TITLE
[S17.3-001] Closed-PR carry-forward documentation

### DIFF
--- a/docs/kb/s17.3-closed-pr-carry-forward.md
+++ b/docs/kb/s17.3-closed-pr-carry-forward.md
@@ -1,0 +1,48 @@
+# S17.3 Closed-PR Carry-Forward (#76 + #77)
+
+**Status:** Audit-trail note. No code changes.
+**Task:** [S17.3-001](../../sprints/sprint-17.3.md#s173-001--closed-pr-carry-forward-documentation)
+**Created:** 2026-04-21
+
+## Context
+
+PRs [#76](https://github.com/brott-studio/battlebrotts-v2/pull/76) and [#77](https://github.com/brott-studio/battlebrotts-v2/pull/77) were closed unmerged on 2026-04-20 by `brotatotes` with the directive: *"If the work is still wanted, the right path is to reopen via a new sprint."* Both PRs had ✅ SHIP verdicts from Boltz pre-closure (#76: 30/30 green; #77: 29/29 green).
+
+Per HCD intent, the PRs **remain closed** and their shippable content is re-absorbed into S17.3 tasks rather than revived via reopen. This note records the mapping so the audit trail is clean.
+
+## Carry-forward mapping
+
+### PR [#77](https://github.com/brott-studio/battlebrotts-v2/pull/77) — Behavior triggers/actions + tests
+
+Absorbed by → **[S17.3-004](../../sprints/sprint-17.3.md#s173-004--card-library-curation--selected-row-fix--pr-77-cherry-pick--chase-wiring)** (cherry-pick strategy).
+
+Shippable content folded in:
+- `CHASE_TARGET` action (with `movement_override = "chase"` branch in `combat_sim.gd`)
+- `WHEN_THEYRE_RUNNING` trigger wiring
+- `WHEN_I_JUST_HIT_THEM` trigger wiring
+- `FOCUS_WEAKEST` action
+- `last_hit_time_sec` field on `BrottState`
+- 29 associated tests (all green pre-closure)
+
+**Cherry-pick approach:** Nutts rebases PR #77's commits onto current main (branch still exists on GitHub) and opens a fresh PR under S17.3-004. PR #77 is not reopened.
+
+### PR [#76](https://github.com/brott-studio/battlebrotts-v2/pull/76) — BrottBrain UI polish (single-file edit)
+
+Absorbed by → **[S17.3-002](../../sprints/sprint-17.3.md#s173-002--fix-drag-behavior-option-a-remove-the-lie)** (drag lie) and **[S17.3-003](../../sprints/sprint-17.3.md#s173-003--delete-interaction-redesign)** (delete redesign).
+
+PR #76 was a single-file edit to `godot/ui/brottbrain_screen.gd`. Nutts reads the #76 diff and pulls only the parts matching the 002/003 specs:
+- Drag-related copy fixes (empty-slot text, doc-comment claim) → **S17.3-002**.
+- Delete-button polish (red tint, tooltip) → **S17.3-003**.
+
+Any #76 content outside those two specs is **not** carried forward; scope-gate is enforced per sprint-17.3.md §"SCOPE GATE".
+
+## Verification
+
+- Both PRs remain `closed` on GitHub — no reopen action taken as part of this task or S17.3-002/003/004.
+- When S17.3-002, S17.3-003, and S17.3-004 ship, the shippable content from #76 and #77 is covered.
+
+## References
+
+- Sprint plan: [`sprints/sprint-17.3.md`](../../sprints/sprint-17.3.md)
+- Closed PR #76: https://github.com/brott-studio/battlebrotts-v2/pull/76
+- Closed PR #77: https://github.com/brott-studio/battlebrotts-v2/pull/77


### PR DESCRIPTION
## What

Adds `docs/kb/s17.3-closed-pr-carry-forward.md` — a short audit-trail note documenting how the shippable content of closed-unmerged PRs #76 and #77 is re-absorbed into S17.3 tasks.

## Why

PRs #76 and #77 were closed unmerged on 2026-04-20 by `brotatotes` with the directive that the work should be reopened via a new sprint rather than revived on the stale branches. S17.3 is that new sprint. The carry-forward mapping needs to live somewhere durable so the audit trail is clean once S17.3-002/003/004 ship.

## Mapping captured

- **PR #77** (CHASE_TARGET, WHEN_THEYRE_RUNNING, WHEN_I_JUST_HIT_THEM, FOCUS_WEAKEST, `last_hit_time_sec`, 29 tests) → S17.3-004 cherry-pick.
- **PR #76** (single-file BrottBrain UI polish) → S17.3-002 (drag lie) + S17.3-003 (delete redesign).
- Both PRs remain closed; no reopen.

## How to verify

1. Read `docs/kb/s17.3-closed-pr-carry-forward.md` — confirm it links PR #76 and PR #77 and maps each PR's content to the correct S17.3 task ID.
2. Confirm PRs #76 and #77 are still `closed` on GitHub (no reopen action was taken).

## Acceptance (from sprint-17.3.md §S17.3-001)

- [x] `docs/kb/s17.3-closed-pr-carry-forward.md` committed, linking #76 and #77 and mapping each PR's content to the S17.3 task that absorbs it.
- [x] GitHub issues #76 and #77 remain closed; no reopen.

## Tests

Doc-only task per sprint-17.3.md §S17.3-001; no tests required.