### PR TITLE
[S17.3-002] Fix drag behavior — remove the lie

### DIFF
--- a/godot/tests/test_runner.gd
+++ b/godot/tests/test_runner.gd
@@ -54,6 +54,7 @@ const SPRINT_TEST_FILES := [
 	"res://tests/test_sprint17_2_wall_stuck.gd",
 	"res://tests/test_s17_2_scout_feel.gd",
 	"res://tests/test_s17_2_scout_feel.gd",
+	"res://tests/test_s17_3_002_drag_lie.gd",
 ]
 
 var file_pass_count := 0

--- a/godot/tests/test_s17_3_002_drag_lie.gd
+++ b/godot/tests/test_s17_3_002_drag_lie.gd
@@ -1,0 +1,44 @@
+## Sprint 17.3-002 — Drag-lie fix (option A)
+## Usage: godot --headless --script tests/test_s17_3_002_drag_lie.gd
+## Spec: sprints/sprint-17.3.md §"Task specs" → "S17.3-002"
+##
+## Covers:
+##   AC-1 — Empty-slot prompt text constant contains no "drag" (case-insensitive).
+##   AC-2 — Empty-slot prompt uses click/tap copy.
+##
+## Doc-comment removal of "drag-to-reorder" is verified by file inspection
+## (see commit diff); this test covers the runtime-visible string seam.
+extends SceneTree
+
+const BrottBrainScreenRef = preload("res://ui/brottbrain_screen.gd")
+
+var pass_count := 0
+var fail_count := 0
+var test_count := 0
+
+func _initialize() -> void:
+	print("=== S17.3-002 Drag-Lie Fix Tests ===\n")
+	_test_empty_slot_text_has_no_drag()
+	_test_empty_slot_text_uses_tap_copy()
+	print("\n=== Results: %d passed, %d failed, %d total ===" % [pass_count, fail_count, test_count])
+	quit(1 if fail_count > 0 else 0)
+
+func _assert(cond: bool, msg: String) -> void:
+	test_count += 1
+	if cond:
+		pass_count += 1
+	else:
+		fail_count += 1
+		print("  FAIL: %s" % msg)
+
+func _test_empty_slot_text_has_no_drag() -> void:
+	var text: String = BrottBrainScreenRef.EMPTY_SLOT_TEXT_TEMPLATE
+	_assert(not text.to_lower().contains("drag"),
+		"AC-1 empty-slot prompt has no 'drag' (got: %s)" % text)
+
+func _test_empty_slot_text_uses_tap_copy() -> void:
+	var text: String = BrottBrainScreenRef.EMPTY_SLOT_TEXT_TEMPLATE.to_lower()
+	var has_click_or_tap := text.contains("tap") or text.contains("click")
+	_assert(has_click_or_tap,
+		"AC-2 empty-slot prompt uses click/tap copy (got: %s)"
+			% BrottBrainScreenRef.EMPTY_SLOT_TEXT_TEMPLATE)

--- a/godot/tests/test_s17_3_002_drag_lie.gd.uid
+++ b/godot/tests/test_s17_3_002_drag_lie.gd.uid
@@ -1,0 +1,1 @@
+uid://etk1d7vpjmpm

--- a/godot/ui/brottbrain_screen.gd
+++ b/godot/ui/brottbrain_screen.gd
@@ -1,6 +1,8 @@
-## BrottBrain editor — Sprint 4: Card-based visual editor with drag-to-reorder
+## BrottBrain editor — card-based visual editor (Sprint 4).
+## Reorder model is button-based: tap a card to select, then use ▲/▼ to move it.
 ## Each card: [emoji] "When..." → [emoji] "Then..."
-## 8 slots, up/down buttons for reorder, smart defaults, tutorial on first visit
+## 8 slots, button-based reorder, smart defaults, tutorial on first visit.
+## [S17.3-002] Removed "drag-to-reorder" claim — UI has no drag handlers; click/tap is the honest UX.
 class_name BrottBrainScreen
 extends Control
 
@@ -39,6 +41,11 @@ const ACTION_DISPLAY := [
 const STANCE_NAMES := ["🔥 Go Get 'Em!", "🛡️ Play it Safe", "🔄 Hit & Run", "🕳️ Lie in Wait"]
 const TARGET_MODES := ["nearest", "weakest", "biggest_threat"]
 const WEAPON_MODES := ["all_fire", "conserve", "hold_fire"]
+
+# [S17.3-002] Empty-slot prompt text. Must not contain the word "drag" —
+# reordering is button-based, cards are added by tapping a WHEN then a THEN.
+# Tested by tests/test_s17_3_002_drag_lie.gd.
+const EMPTY_SLOT_TEXT_TEMPLATE := "  %d. ┌ ─ ─  + Tap to add card  ─ ─ ┐"
 
 var selected_card_index: int = -1
 
@@ -111,7 +118,7 @@ func _build_ui() -> void:
 	# Empty slot indicator
 	if brain.cards.size() < BrottBrain.MAX_CARDS:
 		var empty := Label.new()
-		empty.text = "  %d. ┌ ─ ─  + Drag a card here  ─ ─ ┐" % (brain.cards.size() + 1)
+		empty.text = EMPTY_SLOT_TEXT_TEMPLATE % (brain.cards.size() + 1)
 		empty.add_theme_font_size_override("font_size", 12)
 		empty.add_theme_color_override("font_color", Color(0.4, 0.4, 0.4))
 		empty.position = Vector2(30, y)


### PR DESCRIPTION
Implements [S17.3-002] from `sprints/sprint-17.3.md` §"Task specs" → "S17.3-002".

## What

BrottBrain screen claimed "drag-to-reorder" in a doc-comment and displayed `+ Drag a card here` on empty slots, but had **zero** `Control.gui_input` / drag-start / drop handlers. Playtest 2026-04-18 caught the lie. Per Gizmo S17.3 design spec §5, **Option A** (remove the lie) was chosen over Option B (implement real drag — deferred to a future polish arc).

## Why

Honest UX beats aspirational UX. Click/tap-to-add already works; the "drag" copy was just misdirection.

## Changes

**`godot/ui/brottbrain_screen.gd`**
- File-level doc-comment no longer claims "drag-to-reorder". Updated comment documents the actual button-based reorder model (tap to select, ▲/▼ to move).
- Empty-slot prompt text extracted into a new display constant `EMPTY_SLOT_TEXT_TEMPLATE` and reworded `+ Tap to add card` (per spec's suggested copy). Provides a clean test seam.

**`godot/tests/test_s17_3_002_drag_lie.gd` (new, 2 tests)**
- AC-1: `EMPTY_SLOT_TEXT_TEMPLATE` contains no "drag" (case-insensitive).
- AC-2: prompt uses click/tap copy.
- Registered in `test_runner.gd`.

**No behavior changes. No drag handlers added. No other files touched.**

## PR #76 cherry-pick

PR #76 (BrottBrain UI polish, closed unmerged) included a much larger diff (AC1 selected-row modulate, AC2 reorder-button disabled state, AC3 delete-button redesign, AC4 tray overlap, AC5 tutorial copy, 226-line test suite). Per the S17.3 plan, most of #76 belongs to **S17.3-003** (delete redesign). This PR only folds the parts that match S17.3-002's scope:

- #76's doc-comment rewrite (kept the intent, simplified the wording).
- #76's empty-slot text change (different wording: `+ Tap to add card` per spec suggestion vs. #76's `tap a WHEN then a THEN to add`; both honest, the shorter copy is the stronger "empty state" hint).

Everything else from #76 is deferred to S17.3-003.

## How to verify

```bash
cd godot
godot --headless --path . --import 2>&1 | tail -2
godot --headless --path . --script res://tests/test_s17_3_002_drag_lie.gd
# Expected: === Results: 2 passed, 0 failed, 2 total ===
```

Or via the full runner:
```bash
godot --headless --path godot/ --script res://tests/test_runner.gd
```

Manual verification: open BrottBrain screen on a brain with <8 cards → empty-slot label reads `+ Tap to add card`, no mention of "drag" anywhere in the file.

## Acceptance

- [x] Doc-comment claim "drag-to-reorder" is removed from `brottbrain_screen.gd` (line 1 rewritten; remaining mentions of the word "drag" are in the new removal-rationale comments and test-reference pointer, not in any user-facing or behavioral claim).
- [x] Empty-slot prompt text no longer uses the word "drag" (now `+ Tap to add card`).
- [x] Carry-forward issue filed: #201 (labeled `backlog`, references plan + Gizmo spec §5 option B).

## Carry-forward

Real drag-to-reorder is tracked as #201 (label:backlog). Not urgent — click/tap is honest, works, and is accessible.

Refs #201.