### PR TITLE
[S17.3-003] Delete interaction redesign — red tint + tooltip

### DIFF
--- a/godot/tests/test_runner.gd
+++ b/godot/tests/test_runner.gd
@@ -55,6 +55,7 @@ const SPRINT_TEST_FILES := [
 	"res://tests/test_s17_2_scout_feel.gd",
 	"res://tests/test_s17_2_scout_feel.gd",
 	"res://tests/test_s17_3_002_drag_lie.gd",
+	"res://tests/test_s17_3_003_delete_redesign.gd",
 ]
 
 var file_pass_count := 0

--- a/godot/tests/test_s17_3_003_delete_redesign.gd
+++ b/godot/tests/test_s17_3_003_delete_redesign.gd
@@ -1,0 +1,135 @@
+## Sprint 17.3-003 — Delete interaction redesign (red tint + tooltip + pointer cursor)
+## Usage: godot --headless --script tests/test_s17_3_003_delete_redesign.gd
+## Spec: sprints/sprint-17.3.md §"Task specs" → "S17.3-003"
+##
+## Covers (acceptance):
+##   AC-1a — Delete button resting modulate is Color(1.0, 0.4, 0.4).
+##   AC-1b — Hover handler sets modulate to Color(1.0, 0.2, 0.2).
+##   AC-2  — Cursor is CURSOR_POINTING_HAND on the delete button.
+##   AC-3  — Tooltip text is "Delete this card" (no hotkey text).
+##
+## Strategy: build a real BrottBrainScreen with a handful of cards, locate each
+## delete button by its text "✕", and assert the properties set in
+## `_draw_card`. Hover state is verified by calling the hover-in/hover-out
+## handlers directly (the live `mouse_entered` signal would require a real
+## cursor over the control, which headless SceneTree can't simulate).
+extends SceneTree
+
+const BrottBrainScreenRef = preload("res://ui/brottbrain_screen.gd")
+
+var pass_count := 0
+var fail_count := 0
+var test_count := 0
+
+func _initialize() -> void:
+	print("=== S17.3-003 Delete Redesign Tests ===\n")
+	_test_constants()
+	_test_rest_modulate_on_live_button()
+	_test_tooltip_on_live_button()
+	_test_cursor_on_live_button()
+	_test_hover_handler_sets_hover_color()
+	_test_exit_handler_restores_rest_color()
+	print("\n=== Results: %d passed, %d failed, %d total ===" % [pass_count, fail_count, test_count])
+	quit(1 if fail_count > 0 else 0)
+
+func _assert(cond: bool, msg: String) -> void:
+	test_count += 1
+	if cond:
+		pass_count += 1
+	else:
+		fail_count += 1
+		print("  FAIL: %s" % msg)
+
+# --- helpers ---
+
+func _mk_screen(card_count: int) -> BrottBrainScreen:
+	var gs := GameState.new()
+	gs.equipped_chassis = ChassisData.ChassisType.BRAWLER
+	gs.equipped_modules = []
+	var brain := BrottBrain.default_for_chassis(gs.equipped_chassis)
+	while brain.cards.size() < card_count and brain.cards.size() < BrottBrain.MAX_CARDS:
+		brain.cards.append(BrottBrain.BehaviorCard.new(0, 0.4, 0, 0))
+	while brain.cards.size() > card_count:
+		brain.cards.pop_back()
+	var screen := BrottBrainScreen.new()
+	screen.size = Vector2(1280, 720)
+	root.add_child(screen)
+	screen.tutorial_dismissed = true
+	screen.setup(gs, brain)
+	return screen
+
+func _delete_buttons(screen: BrottBrainScreen) -> Array:
+	var out := []
+	for c in screen.get_children():
+		if c is Button and c.text == "✕":
+			out.append(c)
+	return out
+
+# --- tests ---
+
+func _test_constants() -> void:
+	_assert(BrottBrainScreenRef.DELETE_BTN_MODULATE_REST == Color(1.0, 0.4, 0.4),
+		"AC-1a constant DELETE_BTN_MODULATE_REST == Color(1.0, 0.4, 0.4) (got %s)"
+			% str(BrottBrainScreenRef.DELETE_BTN_MODULATE_REST))
+	_assert(BrottBrainScreenRef.DELETE_BTN_MODULATE_HOVER == Color(1.0, 0.2, 0.2),
+		"AC-1b constant DELETE_BTN_MODULATE_HOVER == Color(1.0, 0.2, 0.2) (got %s)"
+			% str(BrottBrainScreenRef.DELETE_BTN_MODULATE_HOVER))
+	_assert(BrottBrainScreenRef.DELETE_BTN_TOOLTIP == "Delete this card",
+		"AC-3 constant DELETE_BTN_TOOLTIP == 'Delete this card' (got: %s)"
+			% BrottBrainScreenRef.DELETE_BTN_TOOLTIP)
+
+func _test_rest_modulate_on_live_button() -> void:
+	var screen := _mk_screen(3)
+	var dels := _delete_buttons(screen)
+	_assert(dels.size() == 3, "three delete buttons rendered (got %d)" % dels.size())
+	for b in dels:
+		_assert(b.modulate == Color(1.0, 0.4, 0.4),
+			"AC-1a live button resting modulate == Color(1.0, 0.4, 0.4) (got %s)"
+				% str(b.modulate))
+	screen.queue_free()
+
+func _test_tooltip_on_live_button() -> void:
+	var screen := _mk_screen(2)
+	for b in _delete_buttons(screen):
+		_assert(b.tooltip_text == "Delete this card",
+			"AC-3 tooltip_text == 'Delete this card' (got: %s)" % b.tooltip_text)
+		# No hotkey copy smell: tooltip should not contain 'del', 'key', 'ctrl',
+		# or parentheses commonly used for hotkey hints.
+		var t: String = b.tooltip_text.to_lower()
+		_assert(not t.contains("("), "AC-3 tooltip has no hotkey-style parentheses")
+	screen.queue_free()
+
+func _test_cursor_on_live_button() -> void:
+	var screen := _mk_screen(2)
+	for b in _delete_buttons(screen):
+		_assert(b.mouse_default_cursor_shape == Control.CURSOR_POINTING_HAND,
+			"AC-2 mouse_default_cursor_shape == CURSOR_POINTING_HAND (got %d)"
+				% b.mouse_default_cursor_shape)
+	screen.queue_free()
+
+func _test_hover_handler_sets_hover_color() -> void:
+	var screen := _mk_screen(1)
+	var dels := _delete_buttons(screen)
+	_assert(dels.size() == 1, "one delete button rendered for hover test")
+	if dels.size() < 1:
+		screen.queue_free()
+		return
+	var b: Button = dels[0]
+	screen._on_delete_btn_mouse_entered(b)
+	_assert(b.modulate == Color(1.0, 0.2, 0.2),
+		"AC-1b hover handler sets modulate to Color(1.0, 0.2, 0.2) (got %s)"
+			% str(b.modulate))
+	screen.queue_free()
+
+func _test_exit_handler_restores_rest_color() -> void:
+	var screen := _mk_screen(1)
+	var dels := _delete_buttons(screen)
+	if dels.size() < 1:
+		screen.queue_free()
+		return
+	var b: Button = dels[0]
+	screen._on_delete_btn_mouse_entered(b)
+	screen._on_delete_btn_mouse_exited(b)
+	_assert(b.modulate == Color(1.0, 0.4, 0.4),
+		"mouse_exited handler restores resting modulate (got %s)" % str(b.modulate))
+	screen.queue_free()

--- a/godot/tests/test_s17_3_003_delete_redesign.gd.uid
+++ b/godot/tests/test_s17_3_003_delete_redesign.gd.uid
@@ -1,0 +1,1 @@
+uid://b8ilihrjuo4an

--- a/godot/ui/brottbrain_screen.gd
+++ b/godot/ui/brottbrain_screen.gd
@@ -47,6 +47,12 @@ const WEAPON_MODES := ["all_fire", "conserve", "hold_fire"]
 # Tested by tests/test_s17_3_002_drag_lie.gd.
 const EMPTY_SLOT_TEXT_TEMPLATE := "  %d. ┌ ─ ─  + Tap to add card  ─ ─ ┐"
 
+# [S17.3-003] Delete button affordance — red tint at rest, darker red on hover.
+# Pulled directly from sprint-17.3.md §"Task specs" → "S17.3-003".
+const DELETE_BTN_MODULATE_REST: Color = Color(1.0, 0.4, 0.4)
+const DELETE_BTN_MODULATE_HOVER: Color = Color(1.0, 0.2, 0.2)
+const DELETE_BTN_TOOLTIP: String = "Delete this card"
+
 var selected_card_index: int = -1
 
 func setup(state: GameState, existing_brain: BrottBrain = null) -> void:
@@ -283,11 +289,17 @@ func _draw_card(index: int, y: int) -> int:
 	hint.size = Vector2(200, 15)
 	add_child(hint)
 	
-	# Delete button
+	# Delete button — [S17.3-003] red tint + tooltip + pointer cursor.
+	# Spec: sprints/sprint-17.3.md §"Task specs" → "S17.3-003".
 	var del_btn := Button.new()
 	del_btn.text = "✕"
 	del_btn.position = Vector2(625, y + 10)
 	del_btn.size = Vector2(35, 28)
+	del_btn.modulate = DELETE_BTN_MODULATE_REST
+	del_btn.tooltip_text = DELETE_BTN_TOOLTIP
+	del_btn.mouse_default_cursor_shape = Control.CURSOR_POINTING_HAND
+	del_btn.mouse_entered.connect(_on_delete_btn_mouse_entered.bind(del_btn))
+	del_btn.mouse_exited.connect(_on_delete_btn_mouse_exited.bind(del_btn))
 	del_btn.pressed.connect(_remove_card.bind(index))
 	add_child(del_btn)
 	
@@ -366,6 +378,15 @@ func _remove_card(index: int) -> void:
 	if selected_card_index >= brain.cards.size():
 		selected_card_index = brain.cards.size() - 1
 	_build_ui()
+
+# [S17.3-003] Hover handlers for the per-row delete button. Kept as named
+# funcs (not inline lambdas) so tests can invoke them directly without having
+# to synthesize a mouse_entered signal against a live viewport.
+func _on_delete_btn_mouse_entered(btn: Button) -> void:
+	btn.modulate = DELETE_BTN_MODULATE_HOVER
+
+func _on_delete_btn_mouse_exited(btn: Button) -> void:
+	btn.modulate = DELETE_BTN_MODULATE_REST
 
 func _move_card_up() -> void:
 	if selected_card_index <= 0 or selected_card_index >= brain.cards.size():


### PR DESCRIPTION
## What
Redesign the BrottBrain per-row delete (`✕`) button so it's visually obviously destructive and discoverable.

- Red tint at rest: `modulate = Color(1.0, 0.4, 0.4)` (readable on the white panel).
- Hover tint: `Color(1.0, 0.2, 0.2)` via `mouse_entered` / `mouse_exited` signal handlers.
- Pointer cursor on hover: `mouse_default_cursor_shape = CURSOR_POINTING_HAND`.
- Tooltip: `"Delete this card"` (text-only, no hotkey copy).
- **No confirm dialog** — per spec, undo-via-re-add is cheaper and BrottBrain edits are non-destructive to runtime state.

## Why
Playtest feedback (Gizmo spec §5): "delete button was very unintuitive." Bare `✕` with no color, tooltip, or cursor affordance doesn't read as destructive and doesn't invite the click.

Spec source: `sprints/sprint-17.3.md` §"Task specs" → "S17.3-003".

## How to verify
Automated (runs in CI via `test_runner.gd`):
```
godot --headless --path godot --script res://tests/test_s17_3_003_delete_redesign.gd
```
16 assertions covering: constants match spec, live button resting modulate, tooltip text, cursor shape, hover handler sets hover color, exit handler restores rest color.

Manual: open the BrottBrain screen with at least one card placed. Each row's `✕` should be visibly red at rest. Hover → darker red + pointer cursor + tooltip "Delete this card". Click → card removed (no dialog).

## Acceptance (from sprint plan)
- [x] Delete button modulate is `Color(1.0, 0.4, 0.4)` at rest and `Color(1.0, 0.2, 0.2)` on hover.
- [x] Cursor is a pointer on hover.
- [x] Tooltip "Delete this card" is visible on hover (no hotkey text).

## PR #76 fold
PR #76 (closed, superseded) touched the same delete button with a different red (`Color(1.0, 0.55, 0.55)`), a wider hit area (`48×34`), no tooltip, and no cursor. Per S17.3-003 spec this PR uses the stricter spec values and adds the missing tooltip + cursor. PR #76's hit-area widening and select-overlay non-overlap work are **out of scope** for S17.3-003 and are intentionally **not folded** here — if that polish is still wanted it should come as a separate task with its own spec.

## Tests added
- `godot/tests/test_s17_3_003_delete_redesign.gd` — 6 test functions / 16 assertions covering constants + live button state + hover/exit handler behavior. Hover state is driven by calling the handler directly since headless SceneTree can't simulate a real `mouse_entered` event.
- Registered in `godot/tests/test_runner.gd`.

## Deviations
None. Implemented the spec verbatim.

## Files touched
- `godot/ui/brottbrain_screen.gd` — constants, delete-button wiring, hover handlers.
- `godot/tests/test_s17_3_003_delete_redesign.gd` — new test file.
- `godot/tests/test_runner.gd` — registration.
