### PR TITLE
S17.4-003: test_runner dedupe (#211) + enum-ordinal cleanup (#212)

### DIFF
--- a/godot/tests/test_runner.gd
+++ b/godot/tests/test_runner.gd
@@ -54,7 +54,6 @@ const SPRINT_TEST_FILES := [
 	"res://tests/test_sprint17_1_first_run_crate.gd",
 	"res://tests/test_sprint17_2_wall_stuck.gd",
 	"res://tests/test_s17_2_scout_feel.gd",
-	"res://tests/test_s17_2_scout_feel.gd",
 	"res://tests/test_s17_3_002_drag_lie.gd",
 	"res://tests/test_s17_3_003_delete_redesign.gd",
 	"res://tests/test_s17_3_004_card_library.gd",

--- a/godot/tests/test_s17_4_002_tray_scroll_anchor.gd.uid
+++ b/godot/tests/test_s17_4_002_tray_scroll_anchor.gd.uid
@@ -1,0 +1,1 @@
+uid://bdmbokkqfd87i

--- a/godot/ui/brottbrain_screen.gd
+++ b/godot/ui/brottbrain_screen.gd
@@ -392,9 +392,10 @@ func _format_trigger_param(trigger: int, param: Variant) -> String:
 	var td: Array = TRIGGER_DISPLAY[trigger]
 	match td[2]:
 		"pct":
-			return "below %d%%" % int(float(param) * 100) if trigger in [0, 2, 4] else "above %d%%" % int(float(param) * 100)
+			var pct_below_triggers := [BrottBrain.Trigger.WHEN_IM_HURT, BrottBrain.Trigger.WHEN_LOW_ENERGY, BrottBrain.Trigger.WHEN_THEYRE_HURT]
+			return "below %d%%" % int(float(param) * 100) if trigger in pct_below_triggers else "above %d%%" % int(float(param) * 100)
 		"tiles":
-			return "within %s tiles" % str(param) if trigger == 5 else "beyond %s tiles" % str(param)
+			return "within %s tiles" % str(param) if trigger == BrottBrain.Trigger.WHEN_THEYRE_CLOSE else "beyond %s tiles" % str(param)
 		"tiles_per_sec":
 			return "at %s tiles/sec" % str(param)
 		"seconds":


### PR DESCRIPTION
## S17.4-003 (stretch) — Hygiene

Two tiny, orthogonal cleanups batched into one PR.

### #211 — test_runner dedupe (one-line)
`test_s17_2_scout_feel.gd` appeared twice on consecutive lines in `SPRINT_TEST_FILES`. Removed the duplicate. Suite now runs that file exactly once.

**AC1:** `test_s17_2_scout_feel.gd` appears in `test_runner.gd` exactly once ✅

### #212 — enum-ordinal cleanup (readability)
Replaced raw trigger ordinals in the `pct` / `tiles` branches of `_format_trigger_param` with named `BrottBrain.Trigger` enum references. Matches the convention already used in the `seconds` branch (`WHEN_I_JUST_HIT_THEM`).

- `[0, 2, 4]` → `[WHEN_IM_HURT, WHEN_LOW_ENERGY, WHEN_THEYRE_HURT]`
- `trigger == 5` → `trigger == WHEN_THEYRE_CLOSE`

Behavior-preserving. No phrasing-output string changes. No test assertion changes.

**AC2:** No raw integer ordinals in pct/tiles branches; named enum references used ✅

### Verification
Full headless suite: **38 sprint files pass, 0 fail** (+ all inline checks green).

### Scope
- `godot/ui/brottbrain_screen.gd`
- `godot/tests/test_runner.gd`
- `godot/tests/test_s17_4_002_tray_scroll_anchor.gd.uid` (auto-regenerated import companion for an existing test, mirrors the pattern of the other `.uid` files already tracked in that dir)

No touches to `godot/data/**`, `godot/arena/**`, `godot/combat/**`, or `docs/gdd.md`.

Closes #211
Closes #212