### PR TITLE
[S18.1-013] throwaway — Boltz cross-actor review test

### DIFF
--- a/docs/kb/per-agent-github-apps.md
+++ b/docs/kb/per-agent-github-apps.md
@@ -181,3 +181,4 @@ The S16.2 Specc App pattern generalizes to any pipeline agent that needs a disti
 - `~/bin/specc-gh-token` — reference helper implementation.
 - S16.2-002 PR — profile wiring first instance.
 - S16.2-003 redo PR #149 — cross-actor validation end-to-end test.
+


### PR DESCRIPTION
No-op doc touch. Will be approved by Boltz via App token and merged to validate AC-2 (cross-actor HTTP 200, reviewer identity `brott-studio-boltz[bot]`). Delete after merge.