### PR TITLE
[S18.1-012] throwaway — Optic check-run smoke (pre-008)

### DIFF
--- a/docs/kb/per-agent-github-apps.md
+++ b/docs/kb/per-agent-github-apps.md
@@ -182,3 +182,4 @@ The S16.2 Specc App pattern generalizes to any pipeline agent that needs a disti
 - S16.2-002 PR — profile wiring first instance.
 - S16.2-003 redo PR #149 — cross-actor validation end-to-end test.
 
+


### PR DESCRIPTION
No-op doc touch. Optic will post Optic Verified check-run against this PR's head SHA to validate S18.1-007. Branch-protection requirement (S18.1-008) is NOT yet active. Delete after smoke completes.