### PR TITLE
[S18.1-012] throwaway — AC-1 formal proof (post-008)

### DIFF
--- a/docs/kb/per-agent-github-apps.md
+++ b/docs/kb/per-agent-github-apps.md
@@ -182,3 +182,4 @@ The S16.2 Specc App pattern generalizes to any pipeline agent that needs a disti
 - S16.2-002 PR — profile wiring first instance.
 - S16.2-003 redo PR #149 — cross-actor validation end-to-end test.
 
+


### PR DESCRIPTION
No-op doc touch. Formal AC-1 proof: attempt merge pre-Optic (expect 405 — Optic Verified missing). Spawn Optic to post check. Attempt merge post-Optic (expect 200). Delete after.