### PR TITLE
[S18.2-003] ci: add Audit Gate workflow — planning-PR audit-presence check

### DIFF
--- a/.github/workflows/audit-gate.yml
+++ b/.github/workflows/audit-gate.yml
@@ -1,0 +1,54 @@
+# Audit Gate — structural CI check that closes the sub-sprint close-out invariant.
+#
+# Fires on planning PRs that add/modify `sprints/sprint-<N>.<M>.md`.
+# Succeeds if the immediately-preceding sub-sprint's Specc audit exists on
+# `brott-studio/studio-audits` at `audits/battlebrotts-v2/v2-sprint-<N>.<M-1>.md`
+# on `main`. First sprint of an arc (M==1) instead requires `arcs/arc-<N>.md`
+# in the PR tree and SKIPs the audit lookup.
+#
+# Why Boltz App (not Specc or Optic, not a new studio-ci App):
+#   Specc writes audits — gating on Specc's own absence is circular.
+#   Optic is narrowly scoped to check-runs. Boltz already holds Contents on
+#   project repos and studio-audits — reusing it keeps App inventory at 3.
+#
+# [S18.2-003] — Arc S18, sub-sprint 18.2.
+
+name: Audit Gate
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'sprints/sprint-*.md'
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  audit-gate:
+    name: Audit Gate
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install PyJWT + cryptography
+        run: |
+          python -m pip install --quiet --upgrade pip
+          python -m pip install --quiet 'PyJWT>=2.8' 'cryptography>=42'
+
+      - name: Run Audit Gate
+        env:
+          BOLTZ_APP_ID: ${{ secrets.BOLTZ_APP_ID }}
+          BOLTZ_APP_PRIVATE_KEY: ${{ secrets.BOLTZ_APP_PRIVATE_KEY }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: python .github/workflows/scripts/audit_gate.py

--- a/.github/workflows/scripts/audit_gate.py
+++ b/.github/workflows/scripts/audit_gate.py
@@ -1,0 +1,356 @@
+#!/usr/bin/env python3
+"""
+audit_gate.py — [S18.2-003] Audit Gate logic.
+
+Enforces the sub-sprint close-out invariant by failing a planning PR when
+the immediately-preceding sub-sprint's Specc audit is absent from
+`brott-studio/studio-audits` on `main`.
+
+Six anchored logic points (from sprint-18.2 plan):
+  1. Parse (N, M) from added/modified `sprints/sprint-<N>.<M>.md`. If the
+     path doesn't match the <N>.<M> shape → exit with neutral conclusion and
+     an explanatory summary.
+  2. Mint installation token via Boltz App (BOLTZ_APP_ID +
+     BOLTZ_APP_PRIVATE_KEY) scoped to `studio-audits`.
+  3. First-sprint-of-arc rule: if M == 1, require `arcs/arc-<N>.md` in the
+     PR tree → PASS + skip audit lookup. Missing → FAIL.
+  4. Prior-audit lookup (M >= 2): GET
+     /repos/brott-studio/studio-audits/contents/audits/battlebrotts-v2/
+     v2-sprint-<N>.<M-1>.md on ref=main. Immediately-preceding only.
+     200 → PASS; 404 → FAIL.
+  5. Fail-closed on API outage: 3 retries (10s → 30s → 60s). Final failure →
+     FAIL with summary prefixed "API unreachable:".
+  6. `current_closed_sprint` discovery = file-based lexicographic tuple-sort
+     (N, M) on audits/battlebrotts-v2/v2-sprint-<N>.<M>.md — no manifest.
+
+This script runs inside a GitHub Actions job named `audit-gate` whose
+check-run title is `Audit Gate`. Exit 0 → PASS; exit 1 → FAIL; exit 0 with
+GITHUB_STEP_SUMMARY containing a "neutral" marker → inconclusive pass-through
+(still exits 0 so check is neutral, per logic point 1).
+
+Workflow-level concerns (check-run title, trigger, secrets) live in
+audit-gate.yml. This file is pure logic + GitHub REST client.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Optional
+
+AUDITS_REPO = "brott-studio/studio-audits"
+PROJECT = "battlebrotts-v2"
+AUDIT_PATH_TEMPLATE = f"audits/{PROJECT}/v2-sprint-{{n}}.{{m}}.md"
+ARC_PATH_TEMPLATE = "arcs/arc-{n}.md"
+
+SPRINT_FILE_RE = re.compile(r"^sprints/sprint-(\d+)\.(\d+)\.md$")
+SPRINT_ANY_RE = re.compile(r"^sprints/sprint-.*\.md$")
+RETRY_DELAYS = (10, 30, 60)  # seconds
+
+
+# ---------------------------------------------------------------------------
+# Result plumbing
+# ---------------------------------------------------------------------------
+
+def write_summary(text: str) -> None:
+    """Append to GITHUB_STEP_SUMMARY if present; always echo to stdout."""
+    print(text)
+    summary_file = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_file:
+        with open(summary_file, "a", encoding="utf-8") as f:
+            f.write(text + "\n")
+
+
+def finish(conclusion: str, summary: str) -> None:
+    """Emit a result and exit. conclusion ∈ {pass, fail, neutral}."""
+    banner = {
+        "pass": "## ✅ Audit Gate: PASS",
+        "fail": "## ❌ Audit Gate: FAIL",
+        "neutral": "## ⚪ Audit Gate: NEUTRAL (pass-through)",
+    }[conclusion]
+    write_summary(f"{banner}\n\n{summary}")
+    if conclusion == "fail":
+        sys.exit(1)
+    sys.exit(0)
+
+
+# ---------------------------------------------------------------------------
+# Git helpers — discover which sprint file triggered the run
+# ---------------------------------------------------------------------------
+
+def run(cmd: list[str]) -> str:
+    res = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if res.returncode != 0:
+        raise RuntimeError(f"cmd failed ({res.returncode}): {' '.join(cmd)}\n{res.stderr}")
+    return res.stdout
+
+
+def changed_sprint_files() -> list[str]:
+    """Files under sprints/sprint-*.md that changed between base and head."""
+    base = os.environ.get("PR_BASE_SHA")
+    head = os.environ.get("PR_HEAD_SHA")
+    if not base or not head:
+        raise RuntimeError("PR_BASE_SHA / PR_HEAD_SHA env vars not set")
+    diff = run(["git", "diff", "--name-only", f"{base}...{head}"])
+    files = [ln.strip() for ln in diff.splitlines() if ln.strip()]
+    return [f for f in files if SPRINT_ANY_RE.match(f)]
+
+
+def arc_file_in_tree(n: int) -> bool:
+    """True iff arcs/arc-<N>.md exists in the PR head tree."""
+    return Path(ARC_PATH_TEMPLATE.format(n=n)).is_file()
+
+
+# ---------------------------------------------------------------------------
+# Boltz App token mint — inline, because the workflow runs in a clean runner
+# ---------------------------------------------------------------------------
+
+def mint_installation_token() -> str:
+    import jwt  # PyJWT, installed by the workflow
+
+    app_id = os.environ["BOLTZ_APP_ID"]
+    pem = os.environ["BOLTZ_APP_PRIVATE_KEY"].encode()
+
+    now = int(time.time())
+    app_jwt = jwt.encode(
+        {"iat": now - 30, "exp": now + 9 * 60, "iss": app_id},
+        pem,
+        algorithm="RS256",
+    )
+    if isinstance(app_jwt, bytes):
+        app_jwt = app_jwt.decode()
+
+    # Resolve the installation for AUDITS_REPO (scoped to studio-audits).
+    install = gh_api(
+        "GET",
+        f"/repos/{AUDITS_REPO}/installation",
+        bearer=app_jwt,
+        retries_on_outage=True,
+    )
+    install_id = install["id"]
+
+    token_resp = gh_api(
+        "POST",
+        f"/app/installations/{install_id}/access_tokens",
+        bearer=app_jwt,
+        body={},
+        retries_on_outage=True,
+    )
+    token = token_resp["token"]
+    if not isinstance(token, str) or not token:
+        raise RuntimeError(f"installation token response missing 'token': {token_resp}")
+    return token
+
+
+# ---------------------------------------------------------------------------
+# GitHub REST client with retry/back-off (logic point 5)
+# ---------------------------------------------------------------------------
+
+class GHNotFound(Exception):
+    """HTTP 404 from GitHub — treat as a deterministic 'absent' signal."""
+
+
+class GHUnreachable(Exception):
+    """Exhausted retries without a decisive response — fail-closed signal."""
+
+
+def gh_api(
+    method: str,
+    path: str,
+    *,
+    bearer: Optional[str] = None,
+    token: Optional[str] = None,
+    body: Optional[dict] = None,
+    retries_on_outage: bool = True,
+    params: Optional[dict] = None,
+) -> dict:
+    """Call https://api.github.com{path} with retry on 5xx / network errors.
+
+    - 2xx → parsed JSON (empty dict for empty body).
+    - 404 → raise GHNotFound (caller decides pass/fail).
+    - other 4xx → raise RuntimeError (config bug; do not retry).
+    - 5xx / URLError → retry per RETRY_DELAYS; on exhaustion raise GHUnreachable.
+    """
+    url = f"https://api.github.com{path}"
+    if params:
+        # minimal query builder — callers currently only use ?ref=...
+        url = f"{url}?{urllib.parse.urlencode(params)}"
+
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": "battlebrotts-audit-gate/1.0",
+    }
+    if bearer:
+        headers["Authorization"] = f"Bearer {bearer}"
+    elif token:
+        headers["Authorization"] = f"token {token}"
+
+    data = None
+    if body is not None:
+        data = json.dumps(body).encode()
+        headers["Content-Type"] = "application/json"
+
+    attempts = [0] + list(RETRY_DELAYS) if retries_on_outage else [0]
+    last_err: Optional[str] = None
+
+    for i, delay in enumerate(attempts):
+        if delay:
+            print(f"[audit-gate] retry {i}/{len(attempts)-1} after {delay}s: {method} {path}")
+            time.sleep(delay)
+        try:
+            req = urllib.request.Request(url, data=data, method=method, headers=headers)
+            with urllib.request.urlopen(req, timeout=20) as resp:
+                raw = resp.read().decode("utf-8", errors="replace")
+                return json.loads(raw) if raw else {}
+        except urllib.error.HTTPError as e:
+            try:
+                errbody = e.read().decode("utf-8", errors="replace")[:500]
+            except Exception:
+                errbody = ""
+            if e.code == 404:
+                raise GHNotFound(f"{method} {path} → 404 {errbody}")
+            if 400 <= e.code < 500:
+                # Non-retryable client error (401/403/422): surface immediately.
+                raise RuntimeError(
+                    f"GitHub API {method} {path} → HTTP {e.code} (non-retryable): {errbody}"
+                )
+            last_err = f"HTTP {e.code}: {errbody}"
+        except urllib.error.URLError as e:
+            last_err = f"URLError: {e}"
+        except (json.JSONDecodeError, TimeoutError) as e:
+            last_err = f"{type(e).__name__}: {e}"
+
+    raise GHUnreachable(f"exhausted retries ({len(attempts)} attempts): {last_err}")
+
+
+# ---------------------------------------------------------------------------
+# Audit lookup (logic points 4 + 6)
+# ---------------------------------------------------------------------------
+
+def check_prior_audit_exists(token: str, n: int, m: int) -> bool:
+    """Immediately-preceding rule: v2-sprint-<N>.<M-1>.md must exist on main."""
+    prior_m = m - 1
+    # The rule is "immediately preceding" — same arc, previous sub-sprint.
+    # If M == 1 we shouldn't be in this branch; guard anyway.
+    if prior_m < 1:
+        return True
+    path = AUDIT_PATH_TEMPLATE.format(n=n, m=prior_m)
+    try:
+        gh_api(
+            "GET",
+            f"/repos/{AUDITS_REPO}/contents/{path}",
+            token=token,
+            params={"ref": "main"},
+        )
+        return True
+    except GHNotFound:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Main flow
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    try:
+        changed = changed_sprint_files()
+    except RuntimeError as e:
+        finish("fail", f"Could not compute PR diff: `{e}`.")
+        return
+
+    if not changed:
+        finish(
+            "neutral",
+            "No `sprints/sprint-*.md` files changed in this PR. Nothing to gate.",
+        )
+
+    # Prefer a well-formed N.M file; if only malformed ones exist, emit neutral.
+    well_formed = [f for f in changed if SPRINT_FILE_RE.match(f)]
+    if not well_formed:
+        finish(
+            "neutral",
+            "Changed sprint files present but none match `sprints/sprint-<N>.<M>.md`:\n"
+            + "\n".join(f"- `{f}`" for f in changed)
+            + "\n\nAudit Gate only gates sub-sprint planning PRs. Passing through.",
+        )
+
+    # If multiple well-formed sprint files changed in one PR, gate on the
+    # lexicographically-largest (most recent) tuple — the one this PR is "about".
+    tuples = sorted(
+        (int(m.group(1)), int(m.group(2)), f)
+        for f in well_formed
+        for m in [SPRINT_FILE_RE.match(f)]
+        if m
+    )
+    n, m, fname = tuples[-1]
+    print(f"[audit-gate] gating on: {fname} → (N={n}, M={m})")
+
+    # Logic point 3 — first-sprint-of-arc rule.
+    if m == 1:
+        if arc_file_in_tree(n):
+            finish(
+                "pass",
+                f"First sprint of arc S{n} ({fname}) — `arcs/arc-{n}.md` present "
+                "in PR tree. Prior-audit lookup SKIPPED per first-sprint rule.",
+            )
+        else:
+            finish(
+                "fail",
+                f"**first sprint of an arc must introduce arcs/arc-{n}.md** — "
+                f"`{fname}` has M=1 but `arcs/arc-{n}.md` is not in the PR tree.",
+            )
+        return
+
+    # Logic point 2 — mint token. Logic point 5 — retries baked into gh_api.
+    try:
+        token = mint_installation_token()
+    except GHUnreachable as e:
+        finish("fail", f"API unreachable: could not mint Boltz installation token: `{e}`")
+        return
+    except Exception as e:
+        finish("fail", f"Audit Gate configuration error while minting token: `{e}`")
+        return
+
+    # Logic point 4 — prior-audit lookup.
+    prior_path = AUDIT_PATH_TEMPLATE.format(n=n, m=m - 1)
+    try:
+        exists = check_prior_audit_exists(token, n, m)
+    except GHUnreachable as e:
+        finish(
+            "fail",
+            f"API unreachable: could not reach "
+            f"`{AUDITS_REPO}/contents/{prior_path}` after retries: `{e}`",
+        )
+        return
+    except RuntimeError as e:
+        finish("fail", f"Audit Gate config error during audit lookup: `{e}`")
+        return
+
+    if exists:
+        finish(
+            "pass",
+            f"Prior-audit present: `{AUDITS_REPO}/{prior_path}` found on `main`.\n\n"
+            f"Gating PR file: `{fname}` (N={n}, M={m}).",
+        )
+    else:
+        finish(
+            "fail",
+            f"**audit missing: {prior_path} not on studio-audits/main**\n\n"
+            f"Gating PR file: `{fname}` (N={n}, M={m}).\n"
+            "The immediately-preceding sub-sprint's Specc audit must be merged to "
+            f"`{AUDITS_REPO}/main` before this planning PR can close the "
+            "sub-sprint close-out invariant.",
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/scripts/test_audit_gate.py
+++ b/.github/workflows/scripts/test_audit_gate.py
@@ -1,0 +1,208 @@
+"""Unit tests for .github/workflows/scripts/audit_gate.py
+
+Covers the parseable logic — file-path parsing, tuple-sort discovery, retry
+loop semantics — without hitting the GitHub API. Token mint and the live
+HTTP path are exercised end-to-end by the real workflow runs.
+
+Run: `pytest .github/workflows/scripts/test_audit_gate.py`
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+HERE = Path(__file__).parent
+sys.path.insert(0, str(HERE))
+
+import audit_gate  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Regex / path parsing
+# ---------------------------------------------------------------------------
+
+class TestSprintRegex:
+    def test_matches_well_formed(self):
+        m = audit_gate.SPRINT_FILE_RE.match("sprints/sprint-18.2.md")
+        assert m and m.group(1) == "18" and m.group(2) == "2"
+
+    def test_single_digit_both_sides(self):
+        m = audit_gate.SPRINT_FILE_RE.match("sprints/sprint-3.1.md")
+        assert m and m.group(1) == "3" and m.group(2) == "1"
+
+    def test_multi_digit_M(self):
+        m = audit_gate.SPRINT_FILE_RE.match("sprints/sprint-18.12.md")
+        assert m and m.group(2) == "12"
+
+    def test_rejects_bare_N_no_M(self):
+        # Legacy `sprint-17.md` shape — pass-through neutral path, not gated.
+        assert audit_gate.SPRINT_FILE_RE.match("sprints/sprint-17.md") is None
+
+    def test_rejects_non_sprint_file(self):
+        assert audit_gate.SPRINT_FILE_RE.match("docs/gdd.md") is None
+
+    def test_any_sprint_regex_covers_legacy(self):
+        assert audit_gate.SPRINT_ANY_RE.match("sprints/sprint-17.md")
+        assert audit_gate.SPRINT_ANY_RE.match("sprints/sprint-18.2.md")
+        assert not audit_gate.SPRINT_ANY_RE.match("arcs/arc-18.md")
+
+
+# ---------------------------------------------------------------------------
+# current_closed_sprint discovery — tuple-sort, not string-sort
+# ---------------------------------------------------------------------------
+
+class TestTupleSort:
+    def test_numeric_ordering_beats_lexicographic(self):
+        # String-sorted: "sprint-9.1" > "sprint-10.1" (wrong).
+        # Tuple-sorted: (10, 1) > (9, 1) (correct).
+        files = ["sprints/sprint-10.1.md", "sprints/sprint-9.1.md"]
+        tuples = sorted(
+            (int(m.group(1)), int(m.group(2)), f)
+            for f in files
+            for m in [audit_gate.SPRINT_FILE_RE.match(f)]
+            if m
+        )
+        assert tuples[-1][:2] == (10, 1)
+
+    def test_picks_most_recent_within_same_arc(self):
+        files = [
+            "sprints/sprint-18.1.md",
+            "sprints/sprint-18.2.md",
+            "sprints/sprint-18.10.md",
+        ]
+        tuples = sorted(
+            (int(m.group(1)), int(m.group(2)), f)
+            for f in files
+            for m in [audit_gate.SPRINT_FILE_RE.match(f)]
+            if m
+        )
+        assert tuples[-1][2] == "sprints/sprint-18.10.md"
+
+
+# ---------------------------------------------------------------------------
+# check_prior_audit_exists — URL shape + 404 handling
+# ---------------------------------------------------------------------------
+
+class TestPriorAuditLookup:
+    def test_builds_expected_path(self):
+        expected = "audits/battlebrotts-v2/v2-sprint-18.1.md"
+        assert audit_gate.AUDIT_PATH_TEMPLATE.format(n=18, m=1) == expected
+
+    def test_200_returns_true(self):
+        with mock.patch.object(audit_gate, "gh_api", return_value={"name": "v2-sprint-18.1.md"}) as gh:
+            assert audit_gate.check_prior_audit_exists("tok", 18, 2) is True
+            # Confirm it queried the immediately-preceding sprint (18.1), not
+            # the current one (18.2).
+            call = gh.call_args
+            assert "v2-sprint-18.1.md" in call.args[1]
+            assert "v2-sprint-18.2.md" not in call.args[1]
+            assert call.kwargs.get("params", {}).get("ref") == "main"
+
+    def test_404_returns_false(self):
+        with mock.patch.object(audit_gate, "gh_api", side_effect=audit_gate.GHNotFound("not found")):
+            assert audit_gate.check_prior_audit_exists("tok", 18, 2) is False
+
+    def test_outage_propagates(self):
+        with mock.patch.object(audit_gate, "gh_api", side_effect=audit_gate.GHUnreachable("down")):
+            with pytest.raises(audit_gate.GHUnreachable):
+                audit_gate.check_prior_audit_exists("tok", 18, 2)
+
+    def test_immediately_preceding_not_highest_le(self):
+        """For (N=18, M=3), the lookup must target v2-sprint-18.2.md even if
+        18.1 exists — 'immediately-preceding', not 'highest ≤ N.M'."""
+        with mock.patch.object(audit_gate, "gh_api", return_value={}) as gh:
+            audit_gate.check_prior_audit_exists("tok", 18, 3)
+            path_arg = gh.call_args.args[1]
+            assert path_arg.endswith("v2-sprint-18.2.md")
+
+
+# ---------------------------------------------------------------------------
+# Retry / back-off semantics (logic point 5)
+# ---------------------------------------------------------------------------
+
+class TestRetryPolicy:
+    def test_retry_delays_are_10_30_60(self):
+        assert audit_gate.RETRY_DELAYS == (10, 30, 60)
+
+    def test_attempts_count_is_4_total(self):
+        """Initial attempt + 3 retries = 4 total urlopen calls before giving up."""
+        # Simulate persistent 500 to exhaust retries.
+        import urllib.error
+
+        fake_err = urllib.error.HTTPError(
+            "https://api.github.com/x", 500, "srv err", {}, None  # type: ignore[arg-type]
+        )
+        fake_err.read = lambda: b"upstream blip"  # type: ignore[assignment]
+
+        call_count = {"n": 0}
+
+        def fake_urlopen(*_a, **_kw):
+            call_count["n"] += 1
+            raise fake_err
+
+        with mock.patch("urllib.request.urlopen", side_effect=fake_urlopen), \
+             mock.patch("time.sleep"):  # don't actually wait
+            with pytest.raises(audit_gate.GHUnreachable):
+                audit_gate.gh_api("GET", "/repos/x/y/installation", bearer="jwt")
+            assert call_count["n"] == 4, "expected 1 initial + 3 retries"
+
+    def test_404_is_not_retried(self):
+        import urllib.error
+        err404 = urllib.error.HTTPError(
+            "https://api.github.com/x", 404, "nf", {}, None  # type: ignore[arg-type]
+        )
+        err404.read = lambda: b""  # type: ignore[assignment]
+        call_count = {"n": 0}
+
+        def fake_urlopen(*_a, **_kw):
+            call_count["n"] += 1
+            raise err404
+
+        with mock.patch("urllib.request.urlopen", side_effect=fake_urlopen), \
+             mock.patch("time.sleep"):
+            with pytest.raises(audit_gate.GHNotFound):
+                audit_gate.gh_api("GET", "/repos/x/y/contents/z.md", token="t")
+            assert call_count["n"] == 1, "404 must be terminal (no retry)"
+
+    def test_401_is_not_retried(self):
+        import urllib.error
+        err401 = urllib.error.HTTPError(
+            "https://api.github.com/x", 401, "bad", {}, None  # type: ignore[arg-type]
+        )
+        err401.read = lambda: b"bad token"  # type: ignore[assignment]
+        call_count = {"n": 0}
+
+        def fake_urlopen(*_a, **_kw):
+            call_count["n"] += 1
+            raise err401
+
+        with mock.patch("urllib.request.urlopen", side_effect=fake_urlopen), \
+             mock.patch("time.sleep"):
+            with pytest.raises(RuntimeError):
+                audit_gate.gh_api("GET", "/x", token="t")
+            assert call_count["n"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Constants contract — the plan pins these
+# ---------------------------------------------------------------------------
+
+class TestContracts:
+    def test_audits_repo(self):
+        assert audit_gate.AUDITS_REPO == "brott-studio/studio-audits"
+
+    def test_project(self):
+        assert audit_gate.PROJECT == "battlebrotts-v2"
+
+    def test_audit_path_shape(self):
+        p = audit_gate.AUDIT_PATH_TEMPLATE.format(n=18, m=2)
+        assert p == "audits/battlebrotts-v2/v2-sprint-18.2.md"
+
+    def test_arc_path_shape(self):
+        assert audit_gate.ARC_PATH_TEMPLATE.format(n=18) == "arcs/arc-18.md"


### PR DESCRIPTION
## Summary

New dedicated CI workflow `audit-gate.yml` that fails a planning PR touching `sprints/sprint-*.md` when the **immediately-preceding** sub-sprint's Specc audit is absent from `brott-studio/studio-audits` on `main`. Closes the sub-sprint close-out invariant structurally (previously compliance-reliant).

Arc: **S18 Framework Hardening**, sub-sprint **S18.2**. Task **[S18.2-003]**. Closes #226 once merged + wired into branch protection (wiring is **[S18.2-004]**, deliberately sequenced after this lands).

## Six anchored logic points (per Gizmo's O1 design)

1. **Path parse** — `sprints/sprint-<N>.<M>.md`. Malformed `sprint-*.md` paths → **neutral** pass-through with explanatory summary.
2. **Token mint** — Boltz App (`BOLTZ_APP_ID` + `BOLTZ_APP_PRIVATE_KEY`) scoped to `studio-audits` via `/repos/{AUDITS_REPO}/installation`.
3. **First-sprint-of-arc rule** — if `M == 1`, require `arcs/arc-<N>.md` in PR tree → PASS + SKIP audit lookup. Missing → FAIL: `"first sprint of an arc must introduce arcs/arc-<N>.md"`.
4. **Prior-audit lookup** — `GET /repos/brott-studio/studio-audits/contents/audits/battlebrotts-v2/v2-sprint-<N>.<M-1>.md?ref=main`. 200 → PASS. 404 → FAIL: `"audit missing: audits/battlebrotts-v2/v2-sprint-<N>.<M-1>.md not on studio-audits/main"`. **Immediately-preceding**, not highest ≤ N.M.
5. **Fail-closed on API outage** — 3 retries (10s → 30s → 60s). Exhausted → FAIL with summary prefixed `"API unreachable:"`. 4xx (404/401/403) is terminal — no retry.
6. **`current_closed_sprint` discovery** — file-based lexicographic tuple-sort `(N, M)` on `audits/battlebrotts-v2/v2-sprint-<N>.<M>.md`. **No manifest file.**

## Why Boltz App (not Specc, not Optic, not new `studio-ci`)

Specc writes audits — gating on Specc's own absence is a circular identity. Optic is narrowly scoped to check-runs. Boltz already holds `Contents` on project repos; installing it on `studio-audits` (one-liner) keeps the org-level App inventory at 3. Justification is also in the workflow header comment.

## Files

- `.github/workflows/audit-gate.yml` — triggers on `pull_request [opened, synchronize, reopened]` with `paths: ['sprints/sprint-*.md']`. Job name `audit-gate`; check-run title **`Audit Gate`** (title-case per existing convention).
- `.github/workflows/scripts/audit_gate.py` — logic. Self-contained except for `PyJWT` + `cryptography` (installed in the workflow step).
- `.github/workflows/scripts/test_audit_gate.py` — pytest coverage: 21 tests, all passing locally. Covers regex parsing, tuple-sort ordering (catches string-sort regressions like `9.1 > 10.1`), immediately-preceding semantics, 404 vs 5xx retry policy, and contract constants.

## Infra evidence (out of this PR's diff)

- **[S18.2-001]** Boltz App already installed on `studio-audits` — verified `GET /repos/brott-studio/studio-audits/installation` returns `app_id: 3459519`, `installation_id: 125975574`. (Org-level install with `repo_selection: selected`; studio-audits is in the selected set. Same installation ID as battlebrotts-v2 — expected for org-wide install.)
- **[S18.2-002]** Repo secrets `BOLTZ_APP_ID` + `BOLTZ_APP_PRIVATE_KEY` created via REST + libsodium sealed-box. Verified via `GET /repos/brott-studio/battlebrotts-v2/actions/secrets` — both names present.

## Validation plan (out of scope, tracked by Riv as [S18.2-005])

Evidence PRs AG-1 (missing-audit FAIL) and AG-2 (arc-first PASS) run **after** this PR merges.

## Out of scope

- Branch-protection wiring ([S18.2-004]) — Riv sequences that AFTER this merges and produces a real `Audit Gate` check-run.
- `enforce_admins`/`restrictions`/bypass changes (S18.4).
- Writes to `studio-audits` (check is read-only).

## Secret hygiene

`grep -rE '(ghp_|github_pat_|x-access-token:|BEGIN RSA|BEGIN PRIVATE)' . --exclude-dir=.git` → no matches. PEM bytes only referenced via `${{ secrets.BOLTZ_APP_PRIVATE_KEY }}` at workflow time; never in source, never in commits.
