### PR TITLE
[S18.4-001] Optic Verified producer workflow

### DIFF
--- a/.github/workflows/optic-verified.yml
+++ b/.github/workflows/optic-verified.yml
@@ -1,0 +1,90 @@
+# Optic Verified — producer workflow for the "Optic Verified" check-run.
+#
+# [S18.4-001] Arc S18 "Framework Hardening", sub-sprint 18.4.
+# Resolves brott-studio/battlebrotts-v2#229.
+#
+# Purpose
+# -------
+# Posts the `Optic Verified` check-run (authored by the **Optic App**, not
+# `GITHUB_TOKEN` and not the shared PAT) on every PR to `main`, with a binary
+# PASS/FAIL conclusion derived from the existing `Verify` workflow's outcome.
+#
+# Why workflow_run (not a fresh job duplicating Verify logic)
+# -----------------------------------------------------------
+# Optic's role per `studio-framework/agents/optic.md` is to be the *identity*
+# posting the binary verdict. Re-implementing test criteria here would drift
+# from Verify over time. `workflow_run` lets us read Verify's conclusion +
+# PR head SHA directly from the triggering run's payload, mint the Optic App
+# token, and post exactly one check-run against the PR head — no extra test
+# infrastructure.
+#
+# `workflow_run` SHA semantics: when Verify was triggered by a `pull_request`
+# event, `github.event.workflow_run.head_sha` is the PR branch's head SHA
+# (same SHA Verify's own checks are attached to). We target that SHA so
+# `Optic Verified` shows up on the PR's check list alongside Verify.
+#
+# Bootstrap note: the first time this workflow lands on a PR, the PR itself
+# can't satisfy an "Optic Verified" required context because the producer
+# doesn't yet exist on main. S18.2 §11.2 Option A bootstrap-annotation
+# carve-out covers that case. Post-merge validation uses a trivial follow-up
+# PR to exercise the workflow end-to-end.
+
+name: Optic Verified
+
+on:
+  # Path-agnostic producer per the S18.4-001 brief: every PR to main should
+  # produce an `Optic Verified` check-run. Keep the `pull_request` trigger
+  # here so GitHub registers the workflow file against PR events (discovery
+  # + the "workflows on this repo" surface), even though the actual posting
+  # happens from the workflow_run branch below.
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+  # Primary trigger: Verify finished for a PR — now post the binary verdict
+  # under the Optic App identity.
+  workflow_run:
+    workflows: ["Verify"]
+    types: [completed]
+
+permissions:
+  contents: read
+  pull-requests: read
+  # NOTE: we do NOT need `checks: write` here because we post the check-run
+  # using an Optic App installation token, not `GITHUB_TOKEN`. Keeping the
+  # default token's scope minimal follows least-privilege.
+
+jobs:
+  post-optic-verified:
+    # Only run on the workflow_run branch AND only for PR-triggered Verify
+    # runs. On direct pushes to main (Verify's push trigger) there is no PR
+    # head to post against and the `Optic Verified` context doesn't apply.
+    if: >-
+      github.event_name == 'workflow_run' &&
+      github.event.workflow_run.event == 'pull_request'
+    name: Post Optic Verified check-run
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (for scripts/)
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install PyJWT + cryptography
+        run: |
+          python -m pip install --quiet --upgrade pip
+          python -m pip install --quiet 'PyJWT>=2.8' 'cryptography>=42'
+
+      - name: Post Optic Verified
+        env:
+          OPTIC_APP_ID: ${{ secrets.OPTIC_APP_ID }}
+          OPTIC_INSTALLATION_ID: ${{ secrets.OPTIC_INSTALLATION_ID }}
+          OPTIC_APP_PRIVATE_KEY: ${{ secrets.OPTIC_APP_PRIVATE_KEY }}
+          VERIFY_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          VERIFY_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          VERIFY_RUN_ID: ${{ github.event.workflow_run.id }}
+          VERIFY_HTML_URL: ${{ github.event.workflow_run.html_url }}
+          TARGET_REPO: ${{ github.repository }}
+        run: python .github/workflows/scripts/optic_verified.py

--- a/.github/workflows/scripts/optic_verified.py
+++ b/.github/workflows/scripts/optic_verified.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""
+optic_verified.py — [S18.4-001] Optic Verified producer.
+
+Runs from `.github/workflows/optic-verified.yml` on the `workflow_run`
+completion event from the `Verify` workflow. Mints an installation token
+for the **Optic App** (App ID 3459479, installation 125974902 on
+`brott-studio/battlebrotts-v2`) and posts the `Optic Verified` check-run
+against the PR's head SHA with a binary PASS/FAIL conclusion derived from
+Verify's conclusion.
+
+Rules per the S18.4-001 brief and optic.md:
+  - Identity: Optic App token (Authorization: Bearer <installation-token>).
+    NOT GITHUB_TOKEN, NOT the shared PAT.
+  - Name: exactly "Optic Verified".
+  - Status: "completed". Conclusion: "success" iff Verify.conclusion ==
+    "success", otherwise "failure". Do not invent new criteria.
+  - head_sha: github.event.workflow_run.head_sha (PR branch head).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+from typing import Any, Optional
+
+API_ROOT = "https://api.github.com"
+CHECK_NAME = "Optic Verified"
+# Verify → Optic mapping. Anything non-"success" becomes a failure.
+# GitHub workflow_run.conclusion values: success, failure, cancelled,
+# skipped, timed_out, action_required, neutral, stale, null.
+SUCCESS_SET = {"success"}
+
+
+def mint_installation_token() -> str:
+    """Mint an Optic App installation access token for the current repo.
+
+    Uses `OPTIC_INSTALLATION_ID` directly (no lookup) since the brief pins
+    the installation to 125974902 on battlebrotts-v2.
+    """
+    import jwt  # PyJWT, installed by the workflow
+
+    app_id = os.environ["OPTIC_APP_ID"]
+    pem = os.environ["OPTIC_APP_PRIVATE_KEY"].encode()
+    install_id = os.environ["OPTIC_INSTALLATION_ID"]
+
+    now = int(time.time())
+    app_jwt = jwt.encode(
+        {"iat": now - 30, "exp": now + 9 * 60, "iss": app_id},
+        pem,
+        algorithm="RS256",
+    )
+    if isinstance(app_jwt, bytes):
+        app_jwt = app_jwt.decode()
+
+    resp = gh_api(
+        "POST",
+        f"/app/installations/{install_id}/access_tokens",
+        bearer=app_jwt,
+        body={},
+    )
+    token = resp.get("token")
+    if not isinstance(token, str) or not token:
+        raise RuntimeError(f"installation token response missing 'token': {resp}")
+    return token
+
+
+def gh_api(
+    method: str,
+    path: str,
+    *,
+    bearer: Optional[str] = None,
+    token: Optional[str] = None,
+    body: Optional[dict] = None,
+) -> dict:
+    url = f"{API_ROOT}{path}"
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": "optic-verified/1.0",
+    }
+    if bearer:
+        headers["Authorization"] = f"Bearer {bearer}"
+    elif token:
+        headers["Authorization"] = f"token {token}"
+    data = None
+    if body is not None:
+        data = json.dumps(body).encode()
+        headers["Content-Type"] = "application/json"
+    req = urllib.request.Request(url, data=data, method=method, headers=headers)
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            raw = resp.read()
+            return json.loads(raw) if raw else {}
+    except urllib.error.HTTPError as e:
+        detail = ""
+        try:
+            detail = e.read().decode()
+        except Exception:
+            pass
+        raise RuntimeError(f"GitHub API {method} {path} -> {e.code}: {detail}") from e
+
+
+def build_check_run_body(head_sha: str, verify_conclusion: str,
+                          verify_html_url: str = "") -> dict[str, Any]:
+    """Construct the POST /repos/.../check-runs JSON body.
+
+    Public for unit tests. Pure function — no I/O, no env reads beyond args.
+    """
+    is_success = verify_conclusion in SUCCESS_SET
+    conclusion = "success" if is_success else "failure"
+    if is_success:
+        summary = "PASS — Verify workflow succeeded."
+    else:
+        summary = (
+            f"FAIL — Verify workflow concluded '{verify_conclusion}'."
+        )
+    if verify_html_url:
+        summary += f" (Verify run: {verify_html_url})"
+    return {
+        "name": CHECK_NAME,
+        "head_sha": head_sha,
+        "status": "completed",
+        "conclusion": conclusion,
+        "output": {
+            "title": "Optic verification",
+            "summary": summary,
+        },
+    }
+
+
+def main() -> int:
+    head_sha = os.environ.get("VERIFY_HEAD_SHA", "").strip()
+    conclusion = os.environ.get("VERIFY_CONCLUSION", "").strip()
+    html_url = os.environ.get("VERIFY_HTML_URL", "").strip()
+    repo = os.environ.get("TARGET_REPO", "").strip()
+    if not head_sha:
+        print("ERROR: VERIFY_HEAD_SHA not set", file=sys.stderr)
+        return 2
+    if not conclusion:
+        print("ERROR: VERIFY_CONCLUSION not set", file=sys.stderr)
+        return 2
+    if not repo:
+        print("ERROR: TARGET_REPO not set", file=sys.stderr)
+        return 2
+
+    body = build_check_run_body(head_sha, conclusion, html_url)
+    print(f"[optic-verified] posting check-run: {json.dumps(body)}")
+
+    token = mint_installation_token()
+    resp = gh_api(
+        "POST",
+        f"/repos/{repo}/check-runs",
+        bearer=token,
+        body=body,
+    )
+    check_id = resp.get("id")
+    check_url = resp.get("html_url", "")
+    print(f"[optic-verified] posted check-run id={check_id} url={check_url}")
+
+    step_summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if step_summary:
+        with open(step_summary, "a", encoding="utf-8") as f:
+            f.write(
+                f"## Optic Verified — {body['conclusion'].upper()}\n\n"
+                f"- head_sha: `{head_sha}`\n"
+                f"- Verify conclusion: `{conclusion}`\n"
+                f"- Check-run: {check_url}\n"
+            )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/scripts/test_optic_verified.py
+++ b/.github/workflows/scripts/test_optic_verified.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Unit tests for optic_verified.build_check_run_body — pure-function checks
+for the JWT mint + POST-body construction contract in the S18.4-001 brief.
+
+The JWT mint itself is exercised implicitly by the live workflow; here we
+assert the body contract (name/status/conclusion mapping, output shape)
+deterministically without network I/O.
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+# Import sibling module.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import optic_verified as ov  # noqa: E402
+
+
+class BuildCheckRunBodyTests(unittest.TestCase):
+    SHA = "a" * 40
+
+    def _assert_common(self, body: dict) -> None:
+        self.assertEqual(body["name"], "Optic Verified")
+        self.assertEqual(body["status"], "completed")
+        self.assertEqual(body["head_sha"], self.SHA)
+        self.assertIn("output", body)
+        self.assertEqual(body["output"]["title"], "Optic verification")
+        self.assertIsInstance(body["output"]["summary"], str)
+        self.assertTrue(body["output"]["summary"])
+
+    def test_success_maps_to_success(self) -> None:
+        body = ov.build_check_run_body(self.SHA, "success")
+        self._assert_common(body)
+        self.assertEqual(body["conclusion"], "success")
+        self.assertIn("PASS", body["output"]["summary"])
+
+    def test_failure_maps_to_failure(self) -> None:
+        body = ov.build_check_run_body(self.SHA, "failure")
+        self._assert_common(body)
+        self.assertEqual(body["conclusion"], "failure")
+        self.assertIn("FAIL", body["output"]["summary"])
+
+    def test_cancelled_maps_to_failure(self) -> None:
+        body = ov.build_check_run_body(self.SHA, "cancelled")
+        self.assertEqual(body["conclusion"], "failure")
+
+    def test_timed_out_maps_to_failure(self) -> None:
+        body = ov.build_check_run_body(self.SHA, "timed_out")
+        self.assertEqual(body["conclusion"], "failure")
+
+    def test_neutral_maps_to_failure(self) -> None:
+        # Binary PASS/FAIL per optic.md — only "success" is success.
+        body = ov.build_check_run_body(self.SHA, "neutral")
+        self.assertEqual(body["conclusion"], "failure")
+
+    def test_empty_conclusion_maps_to_failure(self) -> None:
+        body = ov.build_check_run_body(self.SHA, "")
+        self.assertEqual(body["conclusion"], "failure")
+
+    def test_html_url_included_in_summary(self) -> None:
+        url = "https://github.com/brott-studio/battlebrotts-v2/actions/runs/123"
+        body = ov.build_check_run_body(self.SHA, "failure", url)
+        self.assertIn(url, body["output"]["summary"])
+
+    def test_exact_name_string(self) -> None:
+        # Acceptance criterion #3: name: "Optic Verified" (exact).
+        body = ov.build_check_run_body(self.SHA, "success")
+        self.assertEqual(body["name"], "Optic Verified")
+
+    def test_body_json_serialisable(self) -> None:
+        import json
+        body = ov.build_check_run_body(self.SHA, "success")
+        json.dumps(body)  # must not raise
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## [S18.4-001] Optic Verified producer workflow

This is **[S18.4-001]** of S18 arc **"Framework Hardening"**.

Resolves #229.

---

### Scope-gate assertion

> Scope-gate: this PR touches only `.github/workflows/` and `.github/scripts/` (if used). No diffs under `godot/**` or `docs/gdd.md`. Framework/CI-only per S18.4 constraint.

Files changed:
- `.github/workflows/optic-verified.yml` (new)
- `.github/workflows/scripts/optic_verified.py` (new)
- `.github/workflows/scripts/test_optic_verified.py` (new)

---

### What changed

Adds a producer workflow that posts the `Optic Verified` check-run (authored by the **Optic App**, App ID `3459479`, installation `125974902`) against every PR to `main`, with a binary PASS/FAIL conclusion derived from the existing `Verify` workflow's outcome.

The script mints an Optic App installation access token (PyJWT + cryptography, same pattern as `.github/workflows/audit-gate.yml`) and POSTs to `/repos/brott-studio/battlebrotts-v2/check-runs` with:

```json
{
  "name": "Optic Verified",
  "head_sha": "<PR head SHA>",
  "status": "completed",
  "conclusion": "success" | "failure",
  "output": { "title": "Optic verification", "summary": "<one-line PASS/FAIL>" }
}
```

**Auth:** `Authorization: Bearer <installation-token>` (Optic App). Not `GITHUB_TOKEN`, not the shared PAT.

---

### Mechanism chosen: `workflow_run` on `Verify` completion

**Rationale (one line):** Optic's role per `studio-framework/agents/optic.md` and the S18.4-001 brief is to be the *identity* that posts the binary verdict Verify already produces — duplicating Verify's test logic in a parallel workflow would drift from Verify over time, so we listen for `workflow_run` and republish the conclusion under the Optic App identity.

**SHA semantics:** when Verify was triggered by a `pull_request` event, `github.event.workflow_run.head_sha` is the PR branch's head SHA (the same SHA Verify's own checks are attached to). We target that SHA so `Optic Verified` shows up on the PR's check list alongside Verify's own checks.

**Scope guard:** the `post-optic-verified` job is gated by `github.event.workflow_run.event == 'pull_request'` so direct pushes to `main` don't post an `Optic Verified` check-run against a commit with no PR.

**Verification mapping:** `Verify.conclusion == "success"` → `success`, anything else (`failure`, `cancelled`, `timed_out`, `neutral`, etc.) → `failure`. Binary PASS/FAIL per `optic.md`. No new test criteria invented.

**Note on `pull_request` trigger in the workflow:** the workflow file also declares a `pull_request` trigger block. It is intentionally there for repo-surface discovery only — no job runs on that event (the only job is guarded by `github.event_name == 'workflow_run'`). This keeps the file registered as "this workflow applies to PRs" in the Actions UI while the actual posting continues to happen from `workflow_run`.

---

### Test evidence

**Unit tests** (`.github/workflows/scripts/test_optic_verified.py`) — 9/9 pass locally on Python 3.12:

```
test_body_json_serialisable ... ok
test_cancelled_maps_to_failure ... ok
test_empty_conclusion_maps_to_failure ... ok
test_exact_name_string ... ok
test_failure_maps_to_failure ... ok
test_html_url_included_in_summary ... ok
test_neutral_maps_to_failure ... ok
test_success_maps_to_success ... ok
test_timed_out_maps_to_failure ... ok
----------------------------------------------------------------------
Ran 9 tests in 0.000s
OK
```

Coverage: `build_check_run_body` — exact name string (`"Optic Verified"`), `status=completed`, binary success→success / everything-else→failure mapping, `output` shape (title + summary), JSON-serialisability, `html_url` propagation into summary.

**actionlint 1.7.1** on `.github/workflows/optic-verified.yml`:

```
$ actionlint .github/workflows/optic-verified.yml
$ echo $?
0
```

Clean. (YAML safe_load also verified.)

---

### Prerequisite secrets — seeded on `brott-studio/battlebrotts-v2`

Verified present via GitHub API (`GET /repos/brott-studio/battlebrotts-v2/actions/secrets`):

- `OPTIC_APP_ID` = `3459479`
- `OPTIC_INSTALLATION_ID` = `125974902`
- `OPTIC_APP_PRIVATE_KEY` = Optic App PEM

Encrypted via libsodium SealedBox + repo public-key. Not surfaced in any workflow log — the workflow reads them as `${{ secrets.* }}` only.

---

### ⚠️ Expected bootstrap failure on THIS PR

The `Optic Verified` required-context check **cannot be produced for THIS PR** because the producing workflow does not yet exist on `main`. Once this PR merges, future PRs will get the check-run automatically; but for this PR itself there is no upstream producer.

**Merge will require the S18.2 §11.2 Option A bootstrap-annotation carve-out by Boltz / Riv / Bott.** This is the canonical bootstrap-PR pattern for a new required status context.

Reporting check state as-is — no remediation attempt on this PR.

---

### Post-merge validation plan

After this PR merges to `main`, Nutts will open a trivial follow-up PR (README typo or similar no-op) to exercise the workflow end-to-end:

1. Observe `Verify` fires on the no-op PR → completes with `success`.
2. Observe `Optic Verified` workflow fires via `workflow_run` on Verify completion.
3. Observe `Optic Verified` check-run posted on the PR's head SHA, authored by the **Optic App** identity (not `github-actions[bot]`, not a PAT-authored commit).
4. Confirm `conclusion: success` and the summary text.

---

### Deviations from Ett's plan

- **`pull_request` trigger block kept for repo-surface discovery only** — no job runs on it. This is a minor documentation/UX choice, not a functional deviation; the actual producer logic is pure `workflow_run`.
- No other deviations.

---

### Handoff

Do NOT merge. Boltz reviews next.
