### PR TITLE
[S18.4-002] Admin-bypass closure — enforce_admins=true on main

### DIFF
--- a/.github/branch-protection/README.md
+++ b/.github/branch-protection/README.md
@@ -1,0 +1,38 @@
+# Branch protection as code
+
+Declarative snapshots of GitHub branch-protection rules for this repo.
+Changes are committed here first, reviewed in PR, then applied **on demand**
+(not from CI) by a human/agent with an org-admin PAT.
+
+## Files
+
+- `main.json` — desired state for the `main` branch. Shape matches the body
+  expected by `PUT /repos/{owner}/{repo}/branches/{branch}/protection`
+  (see [GitHub docs](https://docs.github.com/en/rest/branches/branch-protection#update-branch-protection)).
+
+## Apply
+
+Use `.github/scripts/apply-branch-protection.sh`. Dry-run first:
+
+```bash
+BROTT_PAT=$(cat ~/.config/gh/brott-studio-token) \
+  .github/scripts/apply-branch-protection.sh --dry-run main
+```
+
+Then apply:
+
+```bash
+BROTT_PAT=$(cat ~/.config/gh/brott-studio-token) \
+  .github/scripts/apply-branch-protection.sh main
+```
+
+## Rollback
+
+Revert the change to `main.json` via a PR, then re-run the apply script.
+The apply script is idempotent: it always sends the full desired state.
+
+## Why not a GitHub Action?
+
+Running this from CI means the repo's own pipeline can mutate its branch
+protection, which defeats the point. Apply is manual and uses an org-admin
+PAT held by a human (or The Bott). See S18.4 design notes.

--- a/.github/branch-protection/main.json
+++ b/.github/branch-protection/main.json
@@ -1,0 +1,28 @@
+{
+  "required_status_checks": {
+    "strict": true,
+    "contexts": [
+      "Godot Unit Tests",
+      "Playwright Smoke Tests",
+      "Optic Verified",
+      "Audit Gate"
+    ]
+  },
+  "enforce_admins": true,
+  "required_pull_request_reviews": {
+    "dismiss_stale_reviews": false,
+    "require_code_owner_reviews": false,
+    "require_last_push_approval": false,
+    "required_approving_review_count": 1,
+    "bypass_pull_request_allowances": {
+      "users": [],
+      "teams": [],
+      "apps": ["brott-studio-specc"]
+    }
+  },
+  "restrictions": null,
+  "required_linear_history": false,
+  "allow_force_pushes": false,
+  "allow_deletions": false,
+  "required_conversation_resolution": false
+}

--- a/.github/branch-protection/test_main_config.py
+++ b/.github/branch-protection/test_main_config.py
@@ -1,0 +1,56 @@
+"""Unit test: main.json snapshot matches the S18.4-002 desired state.
+
+This asserts every field so that any drift surfaces as a diff in PR review.
+"""
+
+import json
+import pathlib
+
+CONFIG = pathlib.Path(__file__).parent / "main.json"
+
+EXPECTED = {
+    "required_status_checks": {
+        "strict": True,
+        "contexts": [
+            "Godot Unit Tests",
+            "Playwright Smoke Tests",
+            "Optic Verified",
+            "Audit Gate",
+        ],
+    },
+    "enforce_admins": True,
+    "required_pull_request_reviews": {
+        "dismiss_stale_reviews": False,
+        "require_code_owner_reviews": False,
+        "require_last_push_approval": False,
+        "required_approving_review_count": 1,
+        "bypass_pull_request_allowances": {
+            "users": [],
+            "teams": [],
+            "apps": ["brott-studio-specc"],
+        },
+    },
+    "restrictions": None,
+    "required_linear_history": False,
+    "allow_force_pushes": False,
+    "allow_deletions": False,
+    "required_conversation_resolution": False,
+}
+
+
+def test_main_config_matches_expected():
+    with CONFIG.open() as fh:
+        actual = json.load(fh)
+    assert actual == EXPECTED, f"main.json drifted from expected S18.4-002 state"
+
+
+def test_enforce_admins_true():
+    with CONFIG.open() as fh:
+        actual = json.load(fh)
+    assert actual["enforce_admins"] is True, "enforce_admins must be True (S18.4-002)"
+
+
+if __name__ == "__main__":
+    test_main_config_matches_expected()
+    test_enforce_admins_true()
+    print("OK")

--- a/.github/scripts/apply-branch-protection.sh
+++ b/.github/scripts/apply-branch-protection.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Apply a branch-protection snapshot from .github/branch-protection/<branch>.json
+# to the GitHub API. Runs on demand; never from CI.
+#
+# Usage:
+#   BROTT_PAT=... apply-branch-protection.sh [--dry-run] <branch>
+#
+# Requires: curl, jq. Reads PAT from $BROTT_PAT (required).
+# Repo is inferred from the git origin remote.
+
+set -euo pipefail
+
+DRY_RUN=0
+if [[ "${1:-}" == "--dry-run" ]]; then
+  DRY_RUN=1
+  shift
+fi
+
+BRANCH="${1:-}"
+if [[ -z "${BRANCH}" ]]; then
+  echo "usage: $0 [--dry-run] <branch>" >&2
+  exit 2
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+CONFIG="${REPO_ROOT}/.github/branch-protection/${BRANCH}.json"
+
+if [[ ! -f "${CONFIG}" ]]; then
+  echo "error: no config at ${CONFIG}" >&2
+  exit 2
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "error: jq required" >&2
+  exit 2
+fi
+
+# Validate JSON shape minimally.
+if ! jq -e '.required_status_checks.contexts and (.enforce_admins == true or .enforce_admins == false)' \
+     "${CONFIG}" >/dev/null; then
+  echo "error: ${CONFIG} missing required fields" >&2
+  exit 2
+fi
+
+# Infer owner/repo from git origin.
+ORIGIN="$(git -C "${REPO_ROOT}" config --get remote.origin.url)"
+# Strip any embedded credentials (https://x-access-token:...@github.com/owner/repo.git)
+CLEAN_ORIGIN="${ORIGIN##*@}"
+# Handle git@github.com:owner/repo.git
+CLEAN_ORIGIN="${CLEAN_ORIGIN#github.com/}"
+CLEAN_ORIGIN="${CLEAN_ORIGIN#github.com:}"
+CLEAN_ORIGIN="${CLEAN_ORIGIN#https://github.com/}"
+CLEAN_ORIGIN="${CLEAN_ORIGIN%.git}"
+OWNER="${CLEAN_ORIGIN%%/*}"
+REPO="${CLEAN_ORIGIN##*/}"
+
+if [[ -z "${OWNER}" || -z "${REPO}" || "${OWNER}" == "${REPO}" ]]; then
+  echo "error: could not infer owner/repo from origin: ${ORIGIN}" >&2
+  exit 2
+fi
+
+URL="https://api.github.com/repos/${OWNER}/${REPO}/branches/${BRANCH}/protection"
+BODY="$(cat "${CONFIG}")"
+
+if [[ "${DRY_RUN}" -eq 1 ]]; then
+  echo "DRY RUN"
+  echo "PUT ${URL}"
+  echo "Body:"
+  echo "${BODY}" | jq .
+  exit 0
+fi
+
+if [[ -z "${BROTT_PAT:-}" ]]; then
+  echo "error: BROTT_PAT not set" >&2
+  exit 2
+fi
+
+TMP="$(mktemp)"
+trap 'rm -f "${TMP}"' EXIT
+
+HTTP_CODE="$(curl -sS -o "${TMP}" -w '%{http_code}' \
+  -X PUT "${URL}" \
+  -H "Authorization: Bearer ${BROTT_PAT}" \
+  -H "Accept: application/vnd.github+json" \
+  -H "X-GitHub-Api-Version: 2022-11-28" \
+  -d "${BODY}")"
+
+if [[ "${HTTP_CODE}" -ge 200 && "${HTTP_CODE}" -lt 300 ]]; then
+  echo "OK ${HTTP_CODE}"
+  jq -c '{enforce_admins: .enforce_admins.enabled, contexts: .required_status_checks.contexts}' "${TMP}"
+  exit 0
+else
+  echo "FAIL ${HTTP_CODE}" >&2
+  cat "${TMP}" >&2
+  exit 1
+fi


### PR DESCRIPTION
## [S18.4-002] Admin-bypass closure — `enforce_admins: true` on `main`

Part of S18 arc **Framework Hardening**. Second of three PRs in S18.4.

Closes the admin-PAT bypass on `brott-studio/battlebrotts-v2:main` by flipping `enforce_admins` from `false` to `true`, and establishes a declarative **branch-protection-as-code** pattern so the change is auditable, diff-reviewable, and trivially revertable.

Depends on **[S18.4-001]** (Optic Verified check-run producer workflow, ref #229 — already merged at `7e16b95`). `restrictions` hardening is deferred to S18.5 (ref #225).

Scope-gate: this PR touches only `.github/branch-protection/` and `.github/scripts/`. No diffs under `godot/**` or `docs/gdd.md`. Framework/CI-only per S18.4 constraint.

### What changed

| File | Purpose |
|---|---|
| `.github/branch-protection/main.json` | Declarative desired state for the `main` branch. Every field from the pre-S18.4 snapshot preserved verbatim; only `enforce_admins` flipped `false → true`. |
| `.github/branch-protection/README.md` | Apply/rollback docs; explains why this is on-demand and NOT a CI job. |
| `.github/branch-protection/test_main_config.py` | Unit test asserting `main.json` matches the expected S18.4-002 state. Any drift surfaces as a failing test in review. |
| `.github/scripts/apply-branch-protection.sh` | Reads `main.json`, PUTs to the GitHub branch-protection API. Supports `--dry-run`. Runs on demand with an org-admin PAT; **not** wired into any workflow. |

### Why branch-protection-as-code

1. **Audit trail.** The current state lives in the repo; changes are reviewed via PR diff rather than invisibly clicked through the GitHub UI.
2. **Reversible.** Rollback = revert `main.json` in a PR + re-run the apply script. Idempotent (full-state PUT every time).
3. **No self-mutation.** Apply is deliberately NOT wired into CI. The repo's own pipeline cannot change its branch-protection rules; a human (or The Bott) with an org-admin PAT runs the script on demand post-merge.

### Post-merge plan

1. **Boltz** (or The Bott) runs `apply-branch-protection.sh main` with `BROTT_PAT` set, then re-fetches branch protection and confirms `enforce_admins.enabled: true`.
2. **[S18.4-003]** (next PR in this sprint) is a trivial README-typo PR that validates end-to-end: (a) cannot merge without all four required checks green, (b) an admin cannot override via PAT.

### Rollback procedure

Revert `main.json` in a follow-up PR → merge → re-run `apply-branch-protection.sh main`. The script sends the full desired state every time, so revert is guaranteed-idempotent.

### Tests / validation evidence

- ✅ `python3 .github/branch-protection/test_main_config.py` → `OK` (asserts every field matches the expected desired state; `enforce_admins == True`).
- ✅ `bash .github/scripts/apply-branch-protection.sh --dry-run main` prints the exact `PUT` URL + JSON body it would send, no secrets.
- ✅ `bash -n .github/scripts/apply-branch-protection.sh` → syntax OK. (Note: `shellcheck` is not available in the Nutts runtime; will be caught by any CI lint job that has it installed. The script is small and exercises standard `set -euo pipefail` / `curl` / `jq` patterns.)

### Squash-merge body (for Boltz to use on merge)

> Close admin-PAT bypass on `main` via `enforce_admins: true`.
>
> Part of S18.4 "Optic automation + admin-bypass closure". Depends on Optic producer workflow from [S18.4-001] (ref #229, resolved in prior PR). `restrictions` hardening deferred to S18.5 (ref #225).
>
> Resolves #224.

### Merge handling

**Do not admin-override.** This PR must merge via the normal pipeline: Boltz-App approval + all four required checks green (Godot Unit Tests, Playwright Smoke Tests, Optic Verified, Audit Gate). That's the proof the gate works end-to-end before we turn on `enforce_admins` post-merge.

Audit Gate should short-circuit (no `sprints/sprint-*.md` changes in this PR). Optic Verified should fire via the new producer workflow from [S18.4-001].
