### PR TITLE
[S18.4-002a] fix(ci): remove Audit Gate path-filter, guard short-circuit instead

### DIFF
--- a/.github/workflows/audit-gate.yml
+++ b/.github/workflows/audit-gate.yml
@@ -12,14 +12,35 @@
 #   project repos and studio-audits — reusing it keeps App inventory at 3.
 #
 # [S18.2-003] — Arc S18, sub-sprint 18.2.
+#
+# [S18.4-002a] Amendment — Path-filter regression fix.
+#
+# Problem: the original `on.pull_request.paths: ['sprints/sprint-*.md']`
+# filter meant PRs that didn't touch sprint files never triggered this
+# workflow. Because `Audit Gate` is a *required* status check on main,
+# that turned into a permanent block — GitHub sees "Audit Gate" as a
+# missing required context and blocks merge forever (not "pending").
+#
+# Fix: remove the path filter so the workflow runs on every PR to main.
+# A guard step computes `has_sprint_changes` via `git diff` against the
+# merge-base. Sprint-path PRs run the full audit-gate validation logic
+# (unchanged). Non-sprint PRs short-circuit: the guard step writes the
+# success summary and all validation steps skip via `if:` conditions.
+# The job name stays `Audit Gate` in both cases, so branch protection's
+# required context is satisfied identically either way.
+#
+# Mirrors the pattern already used by `.github/workflows/verify.yml`
+# (S16.3-001): one job that always starts, with a guard computing a
+# boolean output and downstream steps `if:`-gated. Same reasoning — a
+# required check cannot use `paths:` at the workflow level without
+# deadlocking PRs that don't touch those paths.
 
 name: Audit Gate
 
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-    paths:
-      - 'sprints/sprint-*.md'
+    branches: [main]
 
 permissions:
   contents: read
@@ -35,17 +56,73 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Guard: decide whether this PR touches any `sprints/sprint-*.md`
+      # files and therefore needs full Audit Gate validation. We compare
+      # against `origin/${{ github.base_ref }}` (the PR's merge base proxy),
+      # NOT `github.sha` or `HEAD~1` — those can diverge from the actual
+      # base when PRs are multi-commit or when force-pushes shift the tip.
+      #
+      # Glob intentionally matches the original workflow-level path-filter
+      # exactly: `sprints/sprint-*.md` → regex `^sprints/sprint-.*\.md$`.
+      # If the PR added/modified even one such file, we fall through to
+      # full validation. Otherwise we short-circuit with success.
+      - name: Guard — detect sprint-file changes
+        id: guard
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+          # Ensure we actually have the base branch locally (shallow clones
+          # only fetch the PR ref by default). fetch-depth:0 above should
+          # give us everything, but this is belt-and-suspenders.
+          git fetch --no-tags --depth=0 origin "$BASE_REF" 2>/dev/null || \
+            git fetch --no-tags origin "$BASE_REF" || true
+
+          # `origin/<base>...HEAD` is symmetric-three-dot: diff between
+          # merge-base and HEAD. This matches what GitHub's PR view shows.
+          changed=$(git diff --name-only "origin/${BASE_REF}...HEAD" || true)
+          echo "Changed files:"
+          echo "$changed" | sed 's/^/  /'
+
+          # Exact glob parity with the original path-filter:
+          # on.pull_request.paths: ['sprints/sprint-*.md']
+          if echo "$changed" | grep -qE '^sprints/sprint-.*\.md$'; then
+            echo "has_sprint_changes=true" >> "$GITHUB_OUTPUT"
+            echo "Sprint files changed — running full Audit Gate validation."
+          else
+            echo "has_sprint_changes=false" >> "$GITHUB_OUTPUT"
+            echo "No sprint files changed — audit gate short-circuited."
+          fi
+
+      # Short-circuit branch: non-sprint PR. Write the exact success summary
+      # and let the job finish successfully. The `Audit Gate` check-run
+      # (named after this job) posts with conclusion=success, satisfying
+      # branch protection.
+      - name: Short-circuit — no sprint files changed
+        if: steps.guard.outputs.has_sprint_changes != 'true'
+        run: |
+          echo "## ✅ Audit Gate: SHORT-CIRCUIT" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "No sprint files changed — audit gate short-circuited." >> "$GITHUB_STEP_SUMMARY"
+          echo "No sprint files changed — audit gate short-circuited."
+
+      # Full-validation branch: PR touches a sprint file. All steps below
+      # are gated on has_sprint_changes == 'true' so the no-sprint-change
+      # path is a true skip — no partial validation, no side effects.
       - name: Set up Python
+        if: steps.guard.outputs.has_sprint_changes == 'true'
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
 
       - name: Install PyJWT + cryptography
+        if: steps.guard.outputs.has_sprint_changes == 'true'
         run: |
           python -m pip install --quiet --upgrade pip
           python -m pip install --quiet 'PyJWT>=2.8' 'cryptography>=42'
 
       - name: Run Audit Gate
+        if: steps.guard.outputs.has_sprint_changes == 'true'
         env:
           BOLTZ_APP_ID: ${{ secrets.BOLTZ_APP_ID }}
           BOLTZ_APP_PRIVATE_KEY: ${{ secrets.BOLTZ_APP_PRIVATE_KEY }}

--- a/.github/workflows/scripts/test_audit_gate_guard.sh
+++ b/.github/workflows/scripts/test_audit_gate_guard.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# test_audit_gate_guard.sh — dry-run test of the Audit Gate guard logic.
+#
+# [S18.4-002a] The guard step in `.github/workflows/audit-gate.yml` decides
+# whether to short-circuit (non-sprint PR) or fall through to full validation
+# (sprint PR). This script exercises the guard *shell logic in isolation*
+# against both branches, without needing GitHub Actions, secrets, or the
+# Boltz App. It verifies:
+#
+#   a. When the simulated diff contains `sprints/sprint-*.md`: the guard
+#      emits `has_sprint_changes=true` and downstream full-validation steps
+#      would run.
+#   b. When the diff contains only non-sprint paths: the guard emits
+#      `has_sprint_changes=false` and the short-circuit summary text is
+#      exactly `No sprint files changed — audit gate short-circuited.`
+#
+# Run: bash .github/workflows/scripts/test_audit_gate_guard.sh
+#
+# This is a regression test for the silent-success failure mode flagged
+# in the S18.4-002a brief: if the guard conditional is inverted or the
+# glob drifts from the original path-filter (`sprints/sprint-*.md`), the
+# required check could post green on sprint PRs that skipped full
+# validation — worse than a missing check. These cases pin the glob and
+# both output paths.
+
+set -euo pipefail
+
+FAILED=0
+
+# Extracted guard logic: takes a newline-separated list of changed files
+# on stdin, writes `has_sprint_changes=true|false` to $GITHUB_OUTPUT, and
+# writes the short-circuit summary on the false branch. Identical grep
+# pattern to the workflow.
+run_guard() {
+    local changed
+    changed=$(cat)
+    if echo "$changed" | grep -qE '^sprints/sprint-.*\.md$'; then
+        echo "has_sprint_changes=true" >> "$GITHUB_OUTPUT"
+    else
+        echo "has_sprint_changes=false" >> "$GITHUB_OUTPUT"
+        echo "No sprint files changed — audit gate short-circuited." > "$SUMMARY_OUT"
+    fi
+}
+
+assert_eq() {
+    local label="$1" expected="$2" actual="$3"
+    if [[ "$expected" == "$actual" ]]; then
+        echo "  ✓ $label"
+    else
+        echo "  ✗ $label"
+        echo "    expected: $expected"
+        echo "    actual:   $actual"
+        FAILED=1
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Case A: sprint file in diff → full validation branch
+# ---------------------------------------------------------------------------
+echo "Case A — sprint PR (sprints/sprint-18.4.md changed):"
+GITHUB_OUTPUT=$(mktemp)
+SUMMARY_OUT=$(mktemp)
+printf 'sprints/sprint-18.4.md\ndocs/gdd.md\n' | run_guard
+assert_eq "has_sprint_changes output" "has_sprint_changes=true" "$(cat "$GITHUB_OUTPUT")"
+assert_eq "short-circuit summary NOT written" "" "$(cat "$SUMMARY_OUT")"
+rm -f "$GITHUB_OUTPUT" "$SUMMARY_OUT"
+
+# ---------------------------------------------------------------------------
+# Case B: no sprint file in diff → short-circuit branch
+# ---------------------------------------------------------------------------
+echo "Case B — non-sprint PR (framework/CI changes only):"
+GITHUB_OUTPUT=$(mktemp)
+SUMMARY_OUT=$(mktemp)
+printf '.github/workflows/audit-gate.yml\nREADME.md\n' | run_guard
+assert_eq "has_sprint_changes output" "has_sprint_changes=false" "$(cat "$GITHUB_OUTPUT")"
+assert_eq "short-circuit summary text" \
+    "No sprint files changed — audit gate short-circuited." \
+    "$(cat "$SUMMARY_OUT")"
+rm -f "$GITHUB_OUTPUT" "$SUMMARY_OUT"
+
+# ---------------------------------------------------------------------------
+# Case C: empty diff (edge case — should short-circuit, not crash)
+# ---------------------------------------------------------------------------
+echo "Case C — empty diff:"
+GITHUB_OUTPUT=$(mktemp)
+SUMMARY_OUT=$(mktemp)
+printf '' | run_guard
+assert_eq "has_sprint_changes output" "has_sprint_changes=false" "$(cat "$GITHUB_OUTPUT")"
+rm -f "$GITHUB_OUTPUT" "$SUMMARY_OUT"
+
+# ---------------------------------------------------------------------------
+# Case D: glob parity — legacy `sprints/sprint-17.md` (no .M) must NOT match
+# the original path-filter `sprints/sprint-*.md` required `*` to be present,
+# but glob `sprint-*.md` does match `sprint-17.md` (single-level). Verify
+# our regex matches what the original `on.pull_request.paths:` glob would.
+# The original glob `sprints/sprint-*.md` matches `sprint-17.md` AND
+# `sprint-18.4.md`. Our regex `^sprints/sprint-.*\.md$` matches both too.
+# ---------------------------------------------------------------------------
+echo "Case D — legacy sprint-N.md (no sub-sprint) triggers full validation:"
+GITHUB_OUTPUT=$(mktemp)
+SUMMARY_OUT=$(mktemp)
+printf 'sprints/sprint-17.md\n' | run_guard
+assert_eq "legacy sprint file triggers validation" \
+    "has_sprint_changes=true" "$(cat "$GITHUB_OUTPUT")"
+rm -f "$GITHUB_OUTPUT" "$SUMMARY_OUT"
+
+# ---------------------------------------------------------------------------
+# Case E: false-positive guard — file named `sprints/sprint-X.md` in a
+# subdirectory must NOT match (anchored ^). Protects against silent-success.
+# ---------------------------------------------------------------------------
+echo "Case E — nested path must NOT match (anchor integrity):"
+GITHUB_OUTPUT=$(mktemp)
+SUMMARY_OUT=$(mktemp)
+printf 'archive/sprints/sprint-18.4.md\ndocs/sprints/sprint-18.4.md\n' | run_guard
+assert_eq "nested sprint-ish paths do NOT trigger validation" \
+    "has_sprint_changes=false" "$(cat "$GITHUB_OUTPUT")"
+rm -f "$GITHUB_OUTPUT" "$SUMMARY_OUT"
+
+if (( FAILED )); then
+    echo ""
+    echo "FAIL — one or more guard assertions did not hold."
+    exit 1
+fi
+
+echo ""
+echo "OK — all guard-logic assertions passed."


### PR DESCRIPTION
## [S18.4-002a] Audit Gate path-filter fix — blocker-forced amendment

**Sprint:** S18.4 (Framework Hardening). **Amendment:** Ett Amendment 001 to S18.4 sprint plan — inserted *before* [S18.4-002] (PR #234) can merge.

Closes #235. ref #229 (closed predecessor — Optic Verified producer, different root cause, same class of bug: required check-context unreachable on otherwise-valid PRs).

### Problem

`.github/workflows/audit-gate.yml` declared:

```yaml
on:
  pull_request:
    paths: ['sprints/sprint-*.md']
```

`Audit Gate` is also a **required status check** on `main` (branch protection). Classification of the bug: *required check-context unreachable on non-sprint PRs due to workflow-level path-filter*.

Consequence: any PR that doesn't touch `sprints/sprint-*.md` (i.e. most framework/CI/infrastructure PRs — including #234) never triggers the workflow → the `Audit Gate` check-run never posts → branch protection sees the required context as unmet → the PR is blocked **permanently**, not in `pending` state. PR #234 is the triggering case.

### Fix

Remove the workflow-level `paths:` filter. Use an always-run + guard-step short-circuit pattern:

1. **`on.pull_request` / `branches: [main]`** — runs on every PR to main, no `paths:` filter.
2. **Guard step** computes `has_sprint_changes` via `git diff --name-only origin/${{ github.base_ref }}...HEAD | grep -E '^sprints/sprint-.*\.md$'`.
3. **Sprint-path PRs** (`has_sprint_changes == 'true'`): fall through to the existing validation steps — `actions/setup-python@v5` → install PyJWT/cryptography → `python .github/workflows/scripts/audit_gate.py`. **Behavior unchanged.**
4. **Non-sprint PRs** (`has_sprint_changes != 'true'`): guard writes the exact summary `No sprint files changed — audit gate short-circuited.`, downstream validation steps skip via `if:` conditions.
5. **Job name stays `Audit Gate`** in both branches — branch protection matches required contexts by name, case-sensitive. Both branches produce the same check-run context with `conclusion: success` (on short-circuit) or whatever the real validation logic decides (on sprint PRs).

### Precedent

This is the same pattern `.github/workflows/verify.yml` already uses (S16.3-001), which solved the identical deadlock for the `Verify` required check:

> `paths-ignore removed intentionally. These jobs are required status checks on main. If they don't run on doc-only PRs, auto-merge for those PRs will block forever. Instead we always start the jobs, but short-circuit with success for PRs that only touch docs/sprints/markdown.`

Same reasoning applies here: a required check cannot use a workflow-level `paths:` filter without re-introducing the deadlock.

### Scope-gate

> Scope-gate: this PR touches only `.github/workflows/audit-gate.yml` + existing `.github/scripts/` or `.github/audit-gate/` helpers. No diffs under `godot/**`, `docs/gdd.md`, `sprints/**`, or `.github/branch-protection/`. Framework/CI-only per S18.4 Amendment 001.

(Actual paths touched: `.github/workflows/audit-gate.yml` + new `.github/workflows/scripts/test_audit_gate_guard.sh`. No helpers existed under `.github/scripts/` or `.github/audit-gate/` — the existing helpers live at `.github/workflows/scripts/`, which is within scope.)

### Tests

- **`test_audit_gate_guard.sh`** (new) — dry-run shell test covering 5 cases:
  - **A.** Sprint PR → `has_sprint_changes=true`, no short-circuit summary written.
  - **B.** Non-sprint PR → `has_sprint_changes=false`, short-circuit summary text is *exactly* `No sprint files changed — audit gate short-circuited.`
  - **C.** Empty diff → short-circuit (no crash).
  - **D.** Legacy `sprints/sprint-17.md` (no sub-sprint) → triggers full validation (glob parity with the original path-filter preserved).
  - **E.** Nested paths (`archive/sprints/sprint-18.4.md`, `docs/sprints/sprint-18.4.md`) → do NOT match (anchor integrity — protects against the silent-success failure mode where a loose glob claims a green `Audit Gate` while skipping real validation).
- **`test_audit_gate.py`** — 21 existing unit tests still pass (`audit_gate.py` logic is unchanged).
- **`actionlint` v1.7.1** — clean on the modified workflow *and* all other workflows in the repo (no drift).
- **`shellcheck`** — not available in this runtime; the guard shell is short, uses `set -euo pipefail`, and is exercised by `test_audit_gate_guard.sh`.

### Acceptance criteria

- **a.** Non-sprint PR → `Audit Gate` posts `conclusion: success` with summary containing `short-circuited`. ✅ (this PR is itself a non-sprint PR — watch this PR's check-run.)
- **b.** Sprint PR → `Audit Gate` continues full validation. ✅ (validation steps are identical; only wrapped in `if:` gates.)
- **c.** This fix PR itself merges cleanly through all 4 required contexts (Godot Unit Tests, Playwright Smoke Tests, Optic Verified, Audit Gate). **The merge is the regression test.** — pending CI.
- **d.** No bootstrap carve-out. No admin override. No Option A. If this PR can't merge, the fix is wrong.

### Reviewer focus (Boltz)

The highest-risk failure mode is **silent-success regression**: if the guard conditional is inverted or the diff base is wrong, `Audit Gate` could post green on sprint PRs that skipped full validation — worse than a missing check. Please verify:

- **Diff base:** `origin/${{ github.base_ref }}...HEAD` (three-dot / merge-base proxy). Specifically **NOT** `github.sha` or `HEAD~1`.
- **Glob parity:** guard regex is `^sprints/sprint-.*\.md$`, exactly matching the original workflow's `sprints/sprint-*.md` path-filter glob. Pinned by `test_audit_gate_guard.sh` cases D + E.
- **Name parity:** check-run name `Audit Gate` is emitted in both branches. It comes from the single job's `name: Audit Gate`, case-sensitive, unchanged. Both branches run inside the same job — there is no way for the name to diverge.
- **True skip on short-circuit:** all three validation steps (`setup-python`, `pip install`, `run audit_gate.py`) carry `if: steps.guard.outputs.has_sprint_changes == 'true'`. The short-circuit branch runs only the guard + a summary-writing step — **no partial validation** that could coincidentally succeed.

### Merge handling

**DO NOT self-merge.** Boltz reviews; auto-merge via pipeline normal path. No Option A. No admin override.

---

Head SHA will be `309187f` (plus any review-requested amendments).
