### PR TITLE
[S18.4-003] docs: drop stale bottom Status section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,3 @@ _Last updated: 2026-04-20 15:38 UTC · [update log](../../actions/workflows/read
 - [Game Design Document](docs/gdd.md)
 - [Studio Framework](https://github.com/brott-studio/studio-framework)
 - [v1 Archive](https://github.com/brott-studio/battlebrotts) (16 sprints of history)
-
-## Status
-🚧 v2 — Starting fresh with pipeline-driven development


### PR DESCRIPTION
## [S18.4-003] README polish — drop stale bottom Status section (proof-of-gate)

Small docs-only polish **plus** end-to-end validation of the now-fully-enforced branch protection.

### Change

The bottom `## Status` section has been stale for a long time:

```
## Status
🚧 v2 — Starting fresh with pipeline-driven development
```

It has been stale since roughly S15 (we are currently at S18.4, 16+ sub-sprints in) and it duplicates the auto-generated `📊 Status` block maintained by the `readme-status.yml` workflow above it.

Removed.

### Why this PR matters (proof-of-gate)

This is the close-out validation PR of sub-sprint **S18.4**. S18.4 made the branch protection on `main` **structurally** enforced:

- **[S18.4-001]** (PR #233, merged `7e16b95c`) — `optic-verified.yml` producer workflow now posts the `Optic Verified` check-run on every PR.
- **[S18.4-002a]** (PR #236) — `Audit Gate` short-circuit fix — correctly PASSes on non-planning PRs.
- **[S18.4-002]** (PR #234) — `enforce_admins: true` applied to `main`. Admin-override path retired. No carve-out remains.

For this PR to merge, **all 4 required contexts must pass**:
1. `Godot Unit Tests`
2. `Playwright Smoke Tests`
3. `Optic Verified`
4. `Audit Gate`

Plus the required review from Boltz.

A genuine docs-only change landing through this gate is the clean end-to-end signal that S18.4 didn't accidentally lock legitimate pipeline work out.

### Scope-gate

Touches only `README.md`. No code, no tests, no config, no `godot/**`, no `docs/gdd.md`.

### Arc-close references (for Specc's S18.4 audit)

Four PRs comprise S18.4 sub-sprint:
- #233 — `optic-verified.yml` producer workflow.
- #236 — `Audit Gate` short-circuit fix.
- #234 — `enforce_admins: true` applied.
- This PR + companion framework-docs PR on `brott-studio/studio-framework` + companion `sprints/sprint-18.2.md` ledger PR — close-out.

Restrictions hardening (`ref #225`) remains deferred to S18.5 per arc plan.