### PR TITLE
[S18.4-003] docs: close S18.2 §11.2 Option A bootstrap carve-out ledger

### DIFF
--- a/sprints/sprint-18.2.md
+++ b/sprints/sprint-18.2.md
@@ -169,3 +169,17 @@ Task IDs `[S18.2-NNN]`. Agents: **Nutts** (build; infra-only scope tag on all no
 ## Sub-sprint shape reminder
 
 S18 arc fuse: **5 sub-sprints.** S18.1 (apps + required check) ✓ · **S18.2 (this)** · S18.3 (cold-start validation) · S18.4 (branch-protection tightening) · S18.5 (simplification passes 5a–5g). If S18.2 scope expands beyond the in-scope list above, escalate to The Bott before proceeding — don't silently stretch the sub-sprint.
+
+---
+
+## Close-out residuals
+
+*Added at S18.4 close-out (2026-04-22) per S18.3 §7 merge-commit hygiene + S18.1 close-out-residuals precedent.*
+
+### §11.2 Option A bootstrap carve-out ledger
+
+This sub-section tracks admin-PAT / bootstrap carve-out merges on `brott-studio/battlebrotts-v2` that predated the S18.4 structural closure of `Optic Verified` + `enforce_admins`. Each entry is a one-time annotated carve-out with explicit reason and scope. **The ledger is closed as of S18.4-001 landing (2026-04-22).** No further entries will be added — from S18.4-001 onward, every PR must pass the 4 required contexts on its own, and no admin override is available (S18.4-002 applied `enforce_admins: true`).
+
+- **PR #233** — `brott-studio/battlebrotts-v2` — [S18.4-001] — merged `7e16b95c` on 2026-04-22 — reason: `Optic Verified` producer workflow did not yet exist on `main`, so the required context was unreachable for PR #233 itself. Post-merge validation: `Optic Verified` posted green by `brott-studio-optic` App on PR #152 head (first live PR after merge) and PR #234 head. **Ledger closed.**
+
+Prior carve-outs (S18.3 sandbox setup / teardown admin-PAT uses for the cold-start dry-run; S18.2 `[S18.2-006]` doc-only close-out amendment; S18.1 `PR #221` admin-PAT probe) are logged in their respective sprint close-out residuals sections; this §11.2 ledger is scoped to S18.2-and-forward admin-PAT use on `battlebrotts-v2:main` and supersedes no prior record.


### PR DESCRIPTION
## [S18.4-003] Close the §11.2 Option A bootstrap carve-out ledger on S18.2

Docs-only. Adds a **Close-out residuals** section to `sprints/sprint-18.2.md`, following the S18.1 close-out-residuals pattern, with a single subsection:

> §11.2 Option A bootstrap carve-out ledger

### Why now

S18.3 + S18.2 plan language repeatedly referenced a "§11.2 Option A ledger" on S18.2 as the canonical home for bootstrap / admin-PAT carve-out annotations on `battlebrotts-v2:main`. The section was never actually written into `sprints/sprint-18.2.md`. S18.4 close-out is the right moment to:

1. Add the section retroactively (matches how S18.1 was closed out with a Close-out residuals subsection).
2. Log the final entry (PR #233's [S18.4-001] merge).
3. Close the ledger explicitly, because S18.4-001 + S18.4-002 collectively remove every remaining reason to need a carve-out.

### What the ledger entry says

- **PR #233** — `brott-studio/battlebrotts-v2` — [S18.4-001] — merged `7e16b95c` on 2026-04-22.
- Reason: `Optic Verified` producer workflow did not yet exist on `main`, so that required context was unreachable for PR #233 itself (chicken-and-egg).
- Post-merge validation: `Optic Verified` posted green by the `brott-studio-optic` App on PR #152 head (first live PR after merge) and PR #234 head.
- **Ledger closed** — from this point forward every PR must pass all 4 required contexts on its own, and `enforce_admins: true` (S18.4-002) removes any admin-override path.

### Scope-gate

Touches only `sprints/sprint-18.2.md`. Purely additive at the bottom of the file; no edits to prior sections, no refactor. No code, no tests, no config, no `godot/**`, no `docs/gdd.md`.

### Path note

Originally spawned as `studio-framework/sprints/sprint-18.2.md`, but `sprints/` doesn't exist in studio-framework — sprint plans live in the project repo per REPO_MAP.md. This PR lands the ledger in the correct repo. The companion framework-doc updates (optic.md + FRAMEWORK.md) are opened as a separate PR on `brott-studio/studio-framework` per repo-split policy.

### Arc-close references (for Specc's S18.4 audit)

S18.4 sub-sprint PRs:
- #233 — `optic-verified.yml` producer workflow.
- #236 — `Audit Gate` short-circuit fix.
- #234 — `enforce_admins: true` applied.
- #237 — README polish (proof-of-gate).
- This PR — S18.2 §11.2 ledger close-out.
- Companion PR on `brott-studio/studio-framework` — framework docs refresh.

Restrictions hardening (`ref #225`) remains deferred to S18.5 per arc plan.