### PR TITLE
[S21.1] Bronze content drop — 6 opponent templates + unlock_league schema

### DIFF
--- a/docs/gdd.md
+++ b/docs/gdd.md
@@ -367,7 +367,7 @@ chassis, weapons, armor, modules, and stance.
 | `skirmish_scrapper` | Scrapper | SKIRMISHER | 2 | Bronze | Scout + Shotgun + Reactive + Overclock |
 | `bruiser_clanker` | Clanker | BRUISER | 2 | Bronze | Brawler + Arc Emitter + Minigun + Plating + Overclock |
 | `control_static` | Static | CONTROLLER | 3 | Bronze | Brawler + Arc Emitter + Shotgun + Reactive + Repair Nanites |
-| `control_prowler` | Prowler | CONTROLLER | 3 | Bronze | Scout + Arc Emitter + Reactive + Repair Nanites |
+| `control_prowler` | Prowler | CONTROLLER | 3 | Bronze | Scout + Arc Emitter + Reactive + Overclock |
 
 **Difficulty tier mapping** (`OpponentLoadouts.difficulty_for(league, index)`):
 

--- a/docs/gdd.md
+++ b/docs/gdd.md
@@ -365,9 +365,9 @@ chassis, weapons, armor, modules, and stance.
 | `tank_rustwall` | Rustwall | TANK | 2 | Bronze | Brawler + Shotgun + Minigun + Reactive + Repair Nanites |
 | `glass_zap` | Zap | GLASS_CANNON | 2 | Bronze | Scout + Arc Emitter + Reactive + Overclock |
 | `skirmish_scrapper` | Scrapper | SKIRMISHER | 2 | Bronze | Scout + Shotgun + Reactive + Overclock |
-| `bruiser_clanker` | Clanker | BRUISER | 2 | Bronze | Brawler + Arc Emitter + Minigun + Plating + Overclock |
+| `bruiser_clanker` | Clanker | BRUISER | 2 | Bronze | Brawler + Arc Emitter + Shotgun + Plating + Overclock |
 | `control_static` | Static | CONTROLLER | 3 | Bronze | Brawler + Arc Emitter + Shotgun + Reactive + Repair Nanites |
-| `control_prowler` | Prowler | CONTROLLER | 3 | Bronze | Scout + Arc Emitter + Reactive + Overclock |
+| `control_prowler` | Prowler | CONTROLLER | 3 | Bronze | Scout + Arc Emitter + Reactive + Repair Nanites |
 
 **Difficulty tier mapping** (`OpponentLoadouts.difficulty_for(league, index)`):
 

--- a/docs/gdd.md
+++ b/docs/gdd.md
@@ -352,21 +352,27 @@ chassis, weapons, armor, modules, and stance.
 - **BRUISER** — Medium armor, dual weapons, aggressive stance. Midrange pressure; rewards TCR-window commitment.
 - **CONTROLLER** — Disruption (jammer / EMP / arc emitter), defensive stance. Punishes module-reliant player builds.
 
-**Starter templates** (6):
+**Template pool** (12 total; 7 Bronze-legal, 5 Silver+):
 
-| ID | Name | Archetype | Tier | Composition |
-|---|---|---|---|---|
-| `tank_ironclad` | Ironclad | TANK | 2 | Fortress + Shotgun/Flak + Ablative + Repair Nanites |
-| `glass_sniper` | Pinprick | GLASS_CANNON | 2 | Scout + Railgun/Plasma + None + Overclock/Sensor/Afterburner |
-| `skirmish_wasp` | Wasp | SKIRMISHER | 1 | Scout + Flak/Plasma + Plating + Afterburner/Sensor/Overclock |
-| `bruiser_crusher` | Crusher-II | BRUISER | 2 | Brawler + Shotgun/Minigun + Reactive + Overclock/Repair |
-| `controller_jammer` | Jammer | CONTROLLER | 3 | Brawler + Arc/Missile + Reactive + EMP/Shield Projector |
-| `tank_tincan` | Tincan | TANK | 1 | Scout + Plasma + Plating |
+| ID | Name | Archetype | Tier | Unlock | Composition |
+|---|---|---|---|---|---|
+| `tank_tincan` | Tincan | TANK | 1 | Scrapyard | Scout + Plasma + Plating |
+| `skirmish_wasp` | Wasp | SKIRMISHER | 1 | Silver | Scout + Flak/Plasma + Plating + Afterburner/Sensor/Overclock |
+| `tank_ironclad` | Ironclad | TANK | 2 | Silver | Fortress + Shotgun/Flak + Ablative + Repair Nanites |
+| `glass_sniper` | Pinprick | GLASS_CANNON | 2 | Silver | Scout + Railgun/Plasma + None + Overclock/Sensor/Afterburner |
+| `bruiser_crusher` | Crusher-II | BRUISER | 2 | Bronze | Brawler + Shotgun/Minigun + Reactive + Overclock/Repair |
+| `controller_jammer` | Jammer | CONTROLLER | 3 | Gold | Brawler + Arc/Missile + Reactive + EMP/Shield Projector |
+| `tank_rustwall` | Rustwall | TANK | 2 | Bronze | Brawler + Shotgun + Minigun + Reactive + Repair Nanites |
+| `glass_zap` | Zap | GLASS_CANNON | 2 | Bronze | Scout + Arc Emitter + Reactive + Overclock |
+| `skirmish_scrapper` | Scrapper | SKIRMISHER | 2 | Bronze | Scout + Shotgun + Reactive + Overclock |
+| `bruiser_clanker` | Clanker | BRUISER | 2 | Bronze | Brawler + Arc Emitter + Minigun + Plating + Overclock |
+| `control_static` | Static | CONTROLLER | 3 | Bronze | Brawler + Arc Emitter + Shotgun + Reactive + Repair Nanites |
+| `control_prowler` | Prowler | CONTROLLER | 3 | Bronze | Scout + Arc Emitter + Reactive + Repair Nanites |
 
 **Difficulty tier mapping** (`OpponentLoadouts.difficulty_for(league, index)`):
 
 - **Scrapyard** indices 0, 1, 2 → tiers **1, 1, 2**
-- **Bronze** indices 0, 1, 2 → tiers **2, 2, 3** (hooks only; league unpopulated)
+- **Bronze** indices 0, 1, 2, 3, 4 → tiers **2, 2, 2, 3, 3** (populated at S21.1 — 5-opponent curve, tier-2 openers → tier-3 closers)
 
 Picker fallback: when a tier's pool has fewer than 2 entries, tier-1-lower
 templates are added. The variety strip (`last_archetype != pick.archetype`)
@@ -384,6 +390,14 @@ naturally cleared by `GameFlow.new_game()` (fresh GameState per run).
 - Counter-play hook reserved for **Sprint 13.10**: picker signature
   accepts `_player_archetype_hint` (currently unused) so tier/variety
   logic can later be composed with matchup-aware filtering.
+- **League-gating (S21.1):** templates carry an `unlock_league` field
+  (`scrapyard` | `bronze` | `silver` | `gold` | `platinum`). The picker
+  accepts a `current_league` arg and filters out templates whose unlock
+  exceeds the current league's rank, so Bronze players never face Silver+
+  gear. Empty-string (backward-compat default) skips the filter, which
+  is how the Scrapyard path continues to draw from the grandfathered
+  tier-2 pool. Opponent templates also carry a `behavior_cards` field
+  (data-only at S21.1; engine wiring tracked as carry-forward).
 
 ---
 

--- a/godot/data/opponent_loadouts.gd
+++ b/godot/data/opponent_loadouts.gd
@@ -185,15 +185,15 @@ const TEMPLATES: Array[Dictionary] = [
 		"archetype": Archetype.BRUISER,
 		"tier": 2,
 		"chassis": ChassisData.ChassisType.BRAWLER,
-		"weapons": [WeaponData.WeaponType.ARC_EMITTER, WeaponData.WeaponType.MINIGUN],
+		"weapons": [WeaponData.WeaponType.ARC_EMITTER, WeaponData.WeaponType.SHOTGUN],
 		"armor": ArmorData.ArmorType.PLATING,
 		"modules": [ModuleData.ModuleType.OVERCLOCK],
 		"stance": 0,
 		"unlock_league": "bronze",
 		"behavior_cards": [
 			{
-				"trigger": {"kind": "enemy_within_tiles", "value": 4},
-				"action": {"kind": "use_gadget", "value": ModuleData.ModuleType.OVERCLOCK},
+				"trigger": {"kind": "enemy_within_tiles", "value": 2},
+				"action": {"kind": "weapons_all_fire"},
 			},
 			{
 				"trigger": {"kind": "enemy_hp_below_pct", "value": 40},
@@ -231,7 +231,7 @@ const TEMPLATES: Array[Dictionary] = [
 		"chassis": ChassisData.ChassisType.SCOUT,
 		"weapons": [WeaponData.WeaponType.ARC_EMITTER],
 		"armor": ArmorData.ArmorType.REACTIVE_MESH,
-		"modules": [ModuleData.ModuleType.OVERCLOCK],
+		"modules": [ModuleData.ModuleType.REPAIR_NANITES],
 		"stance": 3,
 		"unlock_league": "bronze",
 		"behavior_cards": [

--- a/godot/data/opponent_loadouts.gd
+++ b/godot/data/opponent_loadouts.gd
@@ -1,11 +1,38 @@
-## Sprint 13.9 — Opponent loadout templates + variety-preserving picker.
-## See docs/design/sprint13.9-fortress-loadout-pass.md §3, §4.
+## Opponent loadout templates + variety-preserving picker.
+##
+## S13.9 — initial 6 templates + picker + tier hooks (Scrapyard populated; Bronze hooks only).
+## S21.1 — Bronze league populated (5-opponent curve, tier-2 openers → tier-3 closers)
+##          • 6 new Bronze-legal templates (4 tier-2 + 2 tier-3); existing `bruiser_crusher`
+##            remains Bronze-legal → active Bronze pool = 7 templates.
+##          • Tier mapping `difficulty_for("bronze", i)` = [2,2,2,3,3].
+##          • Schema adds `unlock_league` (scrapyard | bronze | silver | gold | platinum)
+##            + `behavior_cards` (data-only; engine wiring tracked as carry-forward).
+##          • Picker takes optional `current_league`; when non-empty, filters out
+##            templates whose `unlock_league` exceeds the league rank, so Bronze
+##            players never face Silver+ gear.
+##
+## Spec refs: docs/design/sprint13.9-fortress-loadout-pass.md §3, §4;
+##            memory/2026-04-23-s21.1-gizmo-bronze-loadout-spec.md §1–§5;
+##            memory/2026-04-23-s21.1-ett-sprint-plan.md §1.1–§1.3.
 class_name OpponentLoadouts
 extends RefCounted
 
 enum Archetype { TANK, GLASS_CANNON, SKIRMISHER, BRUISER, CONTROLLER }
 
-# Template schema (§3.1): id, name, archetype, tier, chassis, weapons, armor, modules, stance.
+## League rank for unlock_league gating (S21.1). Higher rank = later league.
+## Unknown league strings passed via current_league → skip the league filter
+## (treated as "no cap") by the picker for backward compatibility.
+const LEAGUE_RANK: Dictionary = {
+	"scrapyard": 0,
+	"bronze": 1,
+	"silver": 2,
+	"gold": 3,
+	"platinum": 4,
+}
+
+# Template schema (§3.1 + S21.1 additions):
+#   id, name, archetype, tier, chassis, weapons, armor, modules, stance,
+#   unlock_league (S21.1), behavior_cards (S21.1; data-only, engine-ignored).
 const TEMPLATES: Array[Dictionary] = [
 	{
 		"id": "tank_ironclad",
@@ -17,6 +44,8 @@ const TEMPLATES: Array[Dictionary] = [
 		"armor": ArmorData.ArmorType.ABLATIVE_SHELL,
 		"modules": [ModuleData.ModuleType.REPAIR_NANITES],
 		"stance": 1,
+		"unlock_league": "silver",
+		"behavior_cards": [],
 	},
 	{
 		"id": "glass_sniper",
@@ -28,6 +57,8 @@ const TEMPLATES: Array[Dictionary] = [
 		"armor": ArmorData.ArmorType.NONE,
 		"modules": [ModuleData.ModuleType.OVERCLOCK, ModuleData.ModuleType.SENSOR_ARRAY, ModuleData.ModuleType.AFTERBURNER],
 		"stance": 2,
+		"unlock_league": "silver",
+		"behavior_cards": [],
 	},
 	{
 		"id": "skirmish_wasp",
@@ -39,6 +70,8 @@ const TEMPLATES: Array[Dictionary] = [
 		"armor": ArmorData.ArmorType.PLATING,
 		"modules": [ModuleData.ModuleType.AFTERBURNER, ModuleData.ModuleType.SENSOR_ARRAY, ModuleData.ModuleType.OVERCLOCK],
 		"stance": 2,
+		"unlock_league": "silver",
+		"behavior_cards": [],
 	},
 	{
 		"id": "bruiser_crusher",
@@ -50,6 +83,8 @@ const TEMPLATES: Array[Dictionary] = [
 		"armor": ArmorData.ArmorType.REACTIVE_MESH,
 		"modules": [ModuleData.ModuleType.OVERCLOCK, ModuleData.ModuleType.REPAIR_NANITES],
 		"stance": 0,
+		"unlock_league": "bronze",
+		"behavior_cards": [],
 	},
 	{
 		"id": "controller_jammer",
@@ -61,6 +96,8 @@ const TEMPLATES: Array[Dictionary] = [
 		"armor": ArmorData.ArmorType.REACTIVE_MESH,
 		"modules": [ModuleData.ModuleType.EMP_CHARGE, ModuleData.ModuleType.SHIELD_PROJECTOR],
 		"stance": 1,
+		"unlock_league": "gold",
+		"behavior_cards": [],
 	},
 	{
 		"id": "tank_tincan",
@@ -72,30 +109,190 @@ const TEMPLATES: Array[Dictionary] = [
 		"armor": ArmorData.ArmorType.PLATING,
 		"modules": [],
 		"stance": 1,
+		"unlock_league": "scrapyard",
+		"behavior_cards": [],
+	},
+	# ── S21.1 Bronze content drop (Gizmo spec §4) ───────────────────────────────
+	{
+		"id": "tank_rustwall",
+		"name": "Rustwall",
+		"archetype": Archetype.TANK,
+		"tier": 2,
+		"chassis": ChassisData.ChassisType.BRAWLER,
+		"weapons": [WeaponData.WeaponType.SHOTGUN, WeaponData.WeaponType.MINIGUN],
+		"armor": ArmorData.ArmorType.REACTIVE_MESH,
+		"modules": [ModuleData.ModuleType.REPAIR_NANITES],
+		"stance": 0,
+		"unlock_league": "bronze",
+		"behavior_cards": [
+			{
+				"trigger": {"kind": "enemy_within_tiles", "value": 3},
+				"action": {"kind": "weapons_all_fire"},
+			},
+			{
+				"trigger": {"kind": "self_hp_below_pct", "value": 30},
+				"action": {"kind": "switch_stance", "value": 1},
+			},
+		],
+	},
+	{
+		"id": "glass_zap",
+		"name": "Zap",
+		"archetype": Archetype.GLASS_CANNON,
+		"tier": 2,
+		"chassis": ChassisData.ChassisType.SCOUT,
+		"weapons": [WeaponData.WeaponType.ARC_EMITTER],
+		"armor": ArmorData.ArmorType.REACTIVE_MESH,
+		"modules": [ModuleData.ModuleType.OVERCLOCK],
+		"stance": 2,
+		"unlock_league": "bronze",
+		"behavior_cards": [
+			{
+				"trigger": {"kind": "enemy_beyond_tiles", "value": 5},
+				"action": {"kind": "switch_stance", "value": 0},
+			},
+			{
+				"trigger": {"kind": "self_energy_above_pct", "value": 70},
+				"action": {"kind": "use_gadget", "value": ModuleData.ModuleType.OVERCLOCK},
+			},
+		],
+	},
+	{
+		"id": "skirmish_scrapper",
+		"name": "Scrapper",
+		"archetype": Archetype.SKIRMISHER,
+		"tier": 2,
+		"chassis": ChassisData.ChassisType.SCOUT,
+		"weapons": [WeaponData.WeaponType.SHOTGUN],
+		"armor": ArmorData.ArmorType.REACTIVE_MESH,
+		"modules": [ModuleData.ModuleType.OVERCLOCK],
+		"stance": 2,
+		"unlock_league": "bronze",
+		"behavior_cards": [
+			{
+				"trigger": {"kind": "enemy_within_tiles", "value": 3},
+				"action": {"kind": "weapons_all_fire"},
+			},
+			{
+				"trigger": {"kind": "enemy_beyond_tiles", "value": 5},
+				"action": {"kind": "switch_stance", "value": 0},
+			},
+		],
+	},
+	{
+		"id": "bruiser_clanker",
+		"name": "Clanker",
+		"archetype": Archetype.BRUISER,
+		"tier": 2,
+		"chassis": ChassisData.ChassisType.BRAWLER,
+		"weapons": [WeaponData.WeaponType.ARC_EMITTER, WeaponData.WeaponType.MINIGUN],
+		"armor": ArmorData.ArmorType.PLATING,
+		"modules": [ModuleData.ModuleType.OVERCLOCK],
+		"stance": 0,
+		"unlock_league": "bronze",
+		"behavior_cards": [
+			{
+				"trigger": {"kind": "enemy_within_tiles", "value": 4},
+				"action": {"kind": "use_gadget", "value": ModuleData.ModuleType.OVERCLOCK},
+			},
+			{
+				"trigger": {"kind": "enemy_hp_below_pct", "value": 40},
+				"action": {"kind": "pick_target", "value": "weakest"},
+			},
+		],
+	},
+	{
+		"id": "control_static",
+		"name": "Static",
+		"archetype": Archetype.CONTROLLER,
+		"tier": 3,
+		"chassis": ChassisData.ChassisType.BRAWLER,
+		"weapons": [WeaponData.WeaponType.ARC_EMITTER, WeaponData.WeaponType.SHOTGUN],
+		"armor": ArmorData.ArmorType.REACTIVE_MESH,
+		"modules": [ModuleData.ModuleType.REPAIR_NANITES],
+		"stance": 1,
+		"unlock_league": "bronze",
+		"behavior_cards": [
+			{
+				"trigger": {"kind": "enemy_within_tiles", "value": 3},
+				"action": {"kind": "weapons_all_fire"},
+			},
+			{
+				"trigger": {"kind": "self_hp_below_pct", "value": 50},
+				"action": {"kind": "switch_stance", "value": 3},
+			},
+		],
+	},
+	{
+		"id": "control_prowler",
+		"name": "Prowler",
+		"archetype": Archetype.CONTROLLER,
+		"tier": 3,
+		"chassis": ChassisData.ChassisType.SCOUT,
+		"weapons": [WeaponData.WeaponType.ARC_EMITTER],
+		"armor": ArmorData.ArmorType.REACTIVE_MESH,
+		"modules": [ModuleData.ModuleType.REPAIR_NANITES],
+		"stance": 3,
+		"unlock_league": "bronze",
+		"behavior_cards": [
+			{
+				"trigger": {"kind": "enemy_within_tiles", "value": 2},
+				"action": {"kind": "switch_stance", "value": 2},
+			},
+			{
+				"trigger": {"kind": "self_hp_below_pct", "value": 40},
+				"action": {"kind": "switch_stance", "value": 1},
+			},
+		],
 	},
 ]
 
 ## §4.1 — maps (league, index) to a difficulty tier.
+## S21.1: Bronze expanded to 5-slot curve [2,2,2,3,3] — tier-2 openers, tier-3 closers.
 static func difficulty_for(league: String, index: int) -> int:
 	match league:
 		"scrapyard":
 			var tiers := [1, 1, 2]
 			return tiers[index] if index >= 0 and index < tiers.size() else 1
 		"bronze":
-			var tiers := [2, 2, 3]
+			var tiers := [2, 2, 2, 3, 3]
 			return tiers[index] if index >= 0 and index < tiers.size() else 2
 		_:
 			return 1
 
-## §4 — tier filter + weaker-tier fallback + variety strip.
+## §4 — tier filter + weaker-tier fallback + variety strip + (S21.1) league gating.
+##
+## current_league (S21.1): when non-empty and a recognized league string, filter
+## out templates whose `unlock_league` exceeds the current league's rank. The
+## league filter runs *after* the tier fallback but *before* the variety strip,
+## so Silver+ templates cannot leak in via either pool slot. Unknown league
+## strings (or "") skip the filter entirely for backward compatibility with any
+## call-site that hasn't been updated to thread league context.
+##
 ## player_archetype_hint unused; reserved for Sprint 13.10 counter-play.
-static func pick_opponent_loadout(difficulty_tier: int, last_archetype: int = -1, _player_archetype_hint: int = -1) -> Dictionary:
+static func pick_opponent_loadout(difficulty_tier: int, current_league: String = "", last_archetype: int = -1, _player_archetype_hint: int = -1) -> Dictionary:
 	var pool: Array = TEMPLATES.filter(func(t): return t.tier == difficulty_tier)
 	if pool.size() < 2:
 		pool += TEMPLATES.filter(func(t): return t.tier == difficulty_tier - 1)
+	if current_league != "" and LEAGUE_RANK.has(current_league):
+		var league_cap: int = LEAGUE_RANK[current_league]
+		pool = pool.filter(func(t): return LEAGUE_RANK.get(t.get("unlock_league", "scrapyard"), 0) <= league_cap)
 	if last_archetype != -1:
 		var varied: Array = pool.filter(func(t): return t.archetype != last_archetype)
-		if not varied.is_empty():
+		if varied.is_empty():
+			# S21.1: when variety would empty the pool (e.g. Bronze tier-3
+			# is all-CONTROLLER), widen to tier-(N-1) templates respecting
+			# the league cap, so the variety invariant holds without needing
+			# ≥2 archetypes per tier band. Falls through to the original
+			# "keep pool intact" only when no wider tier yields a different
+			# archetype either.
+			var wider: Array = TEMPLATES.filter(func(t): return t.tier == difficulty_tier - 1 and t.archetype != last_archetype)
+			if current_league != "" and LEAGUE_RANK.has(current_league):
+				var league_cap2: int = LEAGUE_RANK[current_league]
+				wider = wider.filter(func(t): return LEAGUE_RANK.get(t.get("unlock_league", "scrapyard"), 0) <= league_cap2)
+			if not wider.is_empty():
+				pool = wider
+		else:
 			pool = varied
 	if pool.is_empty():
 		return {}

--- a/godot/data/opponent_loadouts.gd
+++ b/godot/data/opponent_loadouts.gd
@@ -231,7 +231,7 @@ const TEMPLATES: Array[Dictionary] = [
 		"chassis": ChassisData.ChassisType.SCOUT,
 		"weapons": [WeaponData.WeaponType.ARC_EMITTER],
 		"armor": ArmorData.ArmorType.REACTIVE_MESH,
-		"modules": [ModuleData.ModuleType.REPAIR_NANITES],
+		"modules": [ModuleData.ModuleType.OVERCLOCK],
 		"stance": 3,
 		"unlock_league": "bronze",
 		"behavior_cards": [

--- a/godot/game/opponent_data.gd
+++ b/godot/game/opponent_data.gd
@@ -56,13 +56,18 @@ static func build_opponent_brott(league: String, index: int, game_state: GameSta
 	var last_arch: int = -1
 	if game_state != null:
 		last_arch = game_state._last_opponent_archetype
-	var template: Dictionary = OpponentLoadouts.pick_opponent_loadout(tier, last_arch)
+	# S21.1: league filter active at bronze+ only; scrapyard continues to pull
+	# from the full tier pool (incl. grandfathered tier-2 templates that carry
+	# Silver+ gear) to preserve the pre-S21.1 scrapyard behavior documented in
+	# test_sprint13_9.gd (T12b build_opponent_brott_variety at index 2).
+	var filter_league: String = league if league != "scrapyard" else ""
+	var template: Dictionary = OpponentLoadouts.pick_opponent_loadout(tier, filter_league, last_arch)
 	if template.is_empty():
 		push_warning("OpponentLoadouts: empty pool for tier=%d league=%s index=%d; retrying without variety" % [tier, league, index])
-		template = OpponentLoadouts.pick_opponent_loadout(tier, -1)
+		template = OpponentLoadouts.pick_opponent_loadout(tier, filter_league, -1)
 	if template.is_empty():
 		push_warning("OpponentLoadouts: still empty after variety skip for tier=%d; falling back to tier 1" % tier)
-		template = OpponentLoadouts.pick_opponent_loadout(1, -1)
+		template = OpponentLoadouts.pick_opponent_loadout(1, filter_league, -1)
 	if template.is_empty():
 		return null
 

--- a/godot/game/opponent_data.gd
+++ b/godot/game/opponent_data.gd
@@ -56,11 +56,13 @@ static func build_opponent_brott(league: String, index: int, game_state: GameSta
 	var last_arch: int = -1
 	if game_state != null:
 		last_arch = game_state._last_opponent_archetype
-	# S21.1: league filter active at bronze+ only; scrapyard continues to pull
-	# from the full tier pool (incl. grandfathered tier-2 templates that carry
-	# Silver+ gear) to preserve the pre-S21.1 scrapyard behavior documented in
-	# test_sprint13_9.gd (T12b build_opponent_brott_variety at index 2).
-	var filter_league: String = league if league != "scrapyard" else ""
+	# S21.1 remediation (Gizmo §6.2b / Optic D4): league filter now applies to
+	# scrapyard as well as bronze+. This correctly excludes Silver+ templates
+	# (tank_ironclad, glass_sniper) from scrapyard pools, aligning runtime
+	# behavior with the `unlock_league` schema. Scrapyard's effective pool is
+	# now tank_tincan only; the build chain falls back to tier-1 via the
+	# existing empty-pool guard when scrapyard tier-2 resolves empty.
+	var filter_league: String = league
 	var template: Dictionary = OpponentLoadouts.pick_opponent_loadout(tier, filter_league, last_arch)
 	if template.is_empty():
 		push_warning("OpponentLoadouts: empty pool for tier=%d league=%s index=%d; retrying without variety" % [tier, league, index])

--- a/godot/tests/test_runner.gd
+++ b/godot/tests/test_runner.gd
@@ -59,6 +59,7 @@ const SPRINT_TEST_FILES := [
 	"res://tests/test_s17_3_004_card_library.gd",
 	"res://tests/test_s17_4_001_selected_row_pixels.gd",
 	"res://tests/test_s17_4_002_tray_scroll_anchor.gd",
+	"res://tests/test_sprint21_1.gd",
 ]
 
 var file_pass_count := 0

--- a/godot/tests/test_sprint13_10.gd
+++ b/godot/tests/test_sprint13_10.gd
@@ -38,12 +38,12 @@ func _test_template_count_within_cap() -> void:
 ## last_archetype != -1 and doesn't empty pool). With tier=99, pool=tier-(99-1)=tier-98=[].
 ## So pool stays empty through all branches → picker must return {}.
 func _test_picker_empty_pool_returns_empty_dict() -> void:
-	var pick: Dictionary = OpponentLoadouts.pick_opponent_loadout(99, -1)
+	var pick: Dictionary = OpponentLoadouts.pick_opponent_loadout(99, "", -1)
 	assert_true(pick.is_empty(), "T2 picker returns {} for tier=99 (no matches, no tier-98 fallback)")
 
 ## T3 — Same with a hint/variety arg; still {} rather than crash.
 func _test_picker_empty_pool_preserves_signature() -> void:
-	var pick: Dictionary = OpponentLoadouts.pick_opponent_loadout(99, OpponentLoadouts.Archetype.TANK)
+	var pick: Dictionary = OpponentLoadouts.pick_opponent_loadout(99, "", OpponentLoadouts.Archetype.TANK)
 	assert_true(pick.is_empty(), "T3 picker returns {} even with last_archetype hint")
 
 ## T4 — Builder with no game_state still survives empty-pool via tier-1 fallback chain.

--- a/godot/tests/test_sprint13_9.gd
+++ b/godot/tests/test_sprint13_9.gd
@@ -64,7 +64,7 @@ func _t2_templates_use_valid_enums() -> void:
 			if not WeaponData.WEAPONS.has(w): ok = false
 		for m in t["modules"]:
 			if not ModuleData.MODULES.has(m): ok = false
-		if t["stance"] < 0 or t["stance"] > 2: ok = false
+		if t["stance"] < 0 or t["stance"] > 3: ok = false
 	assert_true(ok, "T2 templates_use_valid_enums")
 
 func _t3_templates_respect_slot_limits() -> void:
@@ -99,7 +99,7 @@ func _t8_picker_variety_10_picks() -> void:
 	var last := -1
 	var no_repeat := true
 	for i in 10:
-		var pick := OpponentLoadouts.pick_opponent_loadout(2, last)
+		var pick := OpponentLoadouts.pick_opponent_loadout(2, "", last)
 		if last != -1 and pick["archetype"] == last:
 			no_repeat = false
 		last = pick["archetype"]
@@ -112,7 +112,7 @@ func _t9_picker_variety_fallback_when_pool_size_1() -> void:
 	# should not crash and should return a valid template (either the controller itself via
 	# "keep pool when strip empties" OR a tier-2 fallback).
 	for i in 20:
-		var pick := OpponentLoadouts.pick_opponent_loadout(3, OpponentLoadouts.Archetype.CONTROLLER)
+		var pick := OpponentLoadouts.pick_opponent_loadout(3, "", OpponentLoadouts.Archetype.CONTROLLER)
 		if not _is_valid_template(pick):
 			assert_true(false, "T9 picker returned invalid template on iter %d" % i)
 			return
@@ -180,5 +180,5 @@ func _t13_build_opponent_brott_null_game_state() -> void:
 
 func _t14_picker_accepts_player_archetype_hint() -> void:
 	# Signature stability: third param (player_archetype_hint) accepted without error.
-	var pick: Dictionary = OpponentLoadouts.pick_opponent_loadout(2, -1, OpponentLoadouts.Archetype.TANK)
+	var pick: Dictionary = OpponentLoadouts.pick_opponent_loadout(2, "", -1, OpponentLoadouts.Archetype.TANK)
 	assert_true(_is_valid_template(pick), "T14 picker_accepts_player_archetype_hint — valid template with hint param")

--- a/godot/tests/test_sprint13_9.gd
+++ b/godot/tests/test_sprint13_9.gd
@@ -154,14 +154,18 @@ func _t11_build_opponent_brott_uses_picker() -> void:
 	assert_true(all_ok, "T11 build_opponent_brott_uses_picker — brott fields match a template")
 
 func _t12_build_opponent_brott_variety() -> void:
-	# scrapyard[2] tier 2. Pool at tier 2 has 3 templates across ≥2 archetypes.
-	# 5 consecutive builds with the same GameState: never back-to-back same archetype.
+	# S21.1 remediation (Gizmo §6.2b / Optic D4): scrapyard now filters Silver+
+	# templates via `unlock_league`, leaving only `tank_tincan` (TANK) in the
+	# effective scrapyard pool. Variety is therefore not achievable under
+	# scrapyard anymore — the variety invariant now lives on bronze+ pools,
+	# which have ≥3 distinct archetypes at tier 2. Re-target this test to
+	# bronze[2] (tier 2) to preserve the "no back-to-back archetype" intent.
 	var gs := GameState.new()
 	var last_arch: int = -1
 	var no_repeat := true
 	var any_brott := true
 	for i in 5:
-		var b: BrottState = OpponentData.build_opponent_brott("scrapyard", 2, gs)
+		var b: BrottState = OpponentData.build_opponent_brott("bronze", 2, gs)
 		if b == null:
 			any_brott = false
 			break

--- a/godot/tests/test_sprint21_1.gd
+++ b/godot/tests/test_sprint21_1.gd
@@ -1,0 +1,287 @@
+## Sprint 21.1 — Bronze content drop tests.
+## Usage: godot --headless --script tests/test_sprint21_1.gd
+## Spec: memory/2026-04-23-s21.1-gizmo-bronze-loadout-spec.md §6.1 (unit);
+##       memory/2026-04-23-s21.1-ett-sprint-plan.md §3.1.
+##
+## Tests map to Gizmo §6.1 / Ett §3.1 table:
+##   t1 bronze_pool_nonempty       — 100 calls each at tier 2 + 3 return non-empty dict
+##   t2 bronze_tier_mapping        — difficulty_for("bronze", i) = [2,2,2,3,3], default 2
+##   t3 bronze_legality            — Bronze-legal items only (chassis/weapons/armor/modules,
+##                                   len(modules)==1 except scrapyard tank_tincan)
+##   t4 bronze_archetype_coverage  — Bronze-legal (tier ≥ 2) has ≥3 distinct archetypes
+##                                   (target: all 5)
+##   t5 bronze_variety_holds       — 1000 random 5-fight Bronze runs: no consecutive same arch
+##   t6 bronze_league_filter       — 100 picks at tier 2 w/ current_league="bronze" never
+##                                   return Silver+/Gold+/Plat templates
+##   t7 scrapyard_no_regression    — difficulty_for("scrapyard", i) unchanged [1,1,2];
+##                                   100 scrapyard picks include ≥2 distinct archetypes
+##   t8 weight_budget              — every template's total weight ≤ chassis cap
+##   (bonus) behavior_cards_persist — data-only round-trip for new Bronze templates
+extends SceneTree
+
+var pass_count := 0
+var fail_count := 0
+var test_count := 0
+
+const BRONZE_CHASSIS := [ChassisData.ChassisType.SCOUT, ChassisData.ChassisType.BRAWLER]
+const BRONZE_WEAPONS := [
+	WeaponData.WeaponType.PLASMA_CUTTER,
+	WeaponData.WeaponType.MINIGUN,
+	WeaponData.WeaponType.SHOTGUN,
+	WeaponData.WeaponType.ARC_EMITTER,
+]
+const BRONZE_ARMOR := [
+	ArmorData.ArmorType.NONE,
+	ArmorData.ArmorType.PLATING,
+	ArmorData.ArmorType.REACTIVE_MESH,
+]
+const BRONZE_MODULES := [
+	ModuleData.ModuleType.OVERCLOCK,
+	ModuleData.ModuleType.REPAIR_NANITES,
+]
+
+func _initialize() -> void:
+	print("=== Sprint 21.1 Bronze content drop tests ===\n")
+	_run_all()
+	print("\n=== Results: %d passed, %d failed, %d total ===" % [pass_count, fail_count, test_count])
+	quit(1 if fail_count > 0 else 0)
+
+func assert_true(cond: bool, msg: String) -> void:
+	test_count += 1
+	if cond:
+		pass_count += 1
+	else:
+		fail_count += 1
+		print("  FAIL: %s" % msg)
+
+func assert_eq(a, b, msg: String) -> void:
+	test_count += 1
+	if a == b:
+		pass_count += 1
+	else:
+		fail_count += 1
+		print("  FAIL: %s (got %s, expected %s)" % [msg, str(a), str(b)])
+
+func _run_all() -> void:
+	_t1_bronze_pool_nonempty()
+	_t2_bronze_tier_mapping()
+	_t3_bronze_legality()
+	_t4_bronze_archetype_coverage()
+	_t5_bronze_variety_holds()
+	_t6_bronze_league_filter()
+	_t7_scrapyard_no_regression()
+	_t8_weight_budget()
+	_t9_behavior_cards_persist()
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+func _league_rank(name: String) -> int:
+	return OpponentLoadouts.LEAGUE_RANK.get(name, 99)
+
+func _bronze_legal_templates() -> Array:
+	# unlock_league ≤ bronze (rank ≤ 1).
+	var out: Array = []
+	for t in OpponentLoadouts.TEMPLATES:
+		if _league_rank(t.get("unlock_league", "scrapyard")) <= _league_rank("bronze"):
+			out.append(t)
+	return out
+
+func _chassis_cap(chassis_type: int) -> float:
+	var c: Dictionary = ChassisData.CHASSIS[chassis_type]
+	# Chassis dict uses "weight_cap" or similar — fall back to a few common keys.
+	for k in ["weight_cap", "weight_capacity", "max_weight", "weight"]:
+		if c.has(k):
+			return float(c[k])
+	return 0.0
+
+func _item_weight(table: Dictionary, key: int) -> float:
+	var item: Dictionary = table.get(key, {})
+	for k in ["weight", "weight_kg", "mass"]:
+		if item.has(k):
+			return float(item[k])
+	return 0.0
+
+# ── Tests ────────────────────────────────────────────────────────────────────
+
+func _t1_bronze_pool_nonempty() -> void:
+	var all_ok := true
+	for i in 100:
+		var p2: Dictionary = OpponentLoadouts.pick_opponent_loadout(2, "bronze")
+		var p3: Dictionary = OpponentLoadouts.pick_opponent_loadout(3, "bronze")
+		if p2.is_empty() or p3.is_empty():
+			all_ok = false
+			break
+	assert_true(all_ok, "T1 bronze_pool_nonempty — 100 picks each at tier 2 + 3 non-empty")
+
+func _t2_bronze_tier_mapping() -> void:
+	var expected := [2, 2, 2, 3, 3]
+	var ok := true
+	for i in expected.size():
+		if OpponentLoadouts.difficulty_for("bronze", i) != expected[i]:
+			ok = false
+	# Out-of-range default.
+	if OpponentLoadouts.difficulty_for("bronze", 5) != 2:
+		ok = false
+	if OpponentLoadouts.difficulty_for("bronze", -1) != 2:
+		ok = false
+	assert_true(ok, "T2 bronze_tier_mapping = [2,2,2,3,3] with default 2")
+
+func _t3_bronze_legality() -> void:
+	var all_ok := true
+	var first_fail := ""
+	for t in _bronze_legal_templates():
+		var chassis_ok: bool = BRONZE_CHASSIS.has(t["chassis"])
+		var weapons_ok := true
+		for w in t["weapons"]:
+			if not BRONZE_WEAPONS.has(w):
+				weapons_ok = false
+		var armor_ok: bool = BRONZE_ARMOR.has(t["armor"])
+		var modules_ok := true
+		for m in t["modules"]:
+			if not BRONZE_MODULES.has(m):
+				modules_ok = false
+		# Module count rule (GDD §6.2): Bronze uses exactly 1 module; scrapyard
+		# `tank_tincan` is allowed 0 (scrapyard-baseline); the grandfathered
+		# `bruiser_crusher` (S13.9) carries 2 modules and is kept-as-is per
+		# Gizmo S21.1 spec §1.
+		var module_count_ok: bool
+		var tid: String = t.get("id", "")
+		if t.get("unlock_league", "scrapyard") == "scrapyard":
+			module_count_ok = t["modules"].size() <= 1
+		elif tid == "bruiser_crusher":
+			module_count_ok = t["modules"].size() <= 2
+		else:
+			module_count_ok = t["modules"].size() == 1
+		if not (chassis_ok and weapons_ok and armor_ok and modules_ok and module_count_ok):
+			all_ok = false
+			if first_fail == "":
+				first_fail = "%s chassis=%s weapons_ok=%s armor_ok=%s modules_ok=%s mcount_ok=%s" % [
+					t.get("id", "?"), str(chassis_ok), str(weapons_ok), str(armor_ok),
+					str(modules_ok), str(module_count_ok)
+				]
+	assert_true(all_ok, "T3 bronze_legality (first failing: %s)" % first_fail)
+
+func _t4_bronze_archetype_coverage() -> void:
+	# Bronze-legal set filtered to tier >= 2 (actually-Bronze-playable).
+	var seen := {}
+	for t in _bronze_legal_templates():
+		if t["tier"] >= 2:
+			seen[t["archetype"]] = true
+	# Floor = 3; target = all 5.
+	assert_true(seen.size() >= 3, "T4 bronze_archetype_coverage ≥3 (got %d)" % seen.size())
+	# Soft-check all 5 (info only — does not affect test_count beyond the line above).
+	if seen.size() != 5:
+		print("  INFO: bronze archetype coverage = %d (target 5)" % seen.size())
+
+func _t5_bronze_variety_holds() -> void:
+	var all_ok := true
+	var failed_run := -1
+	for run in 1000:
+		var last := -1
+		for i in 5:
+			var tier: int = OpponentLoadouts.difficulty_for("bronze", i)
+			var pick: Dictionary = OpponentLoadouts.pick_opponent_loadout(tier, "bronze", last)
+			if pick.is_empty():
+				all_ok = false
+				failed_run = run
+				break
+			if last != -1 and pick["archetype"] == last:
+				all_ok = false
+				failed_run = run
+				break
+			last = pick["archetype"]
+		if not all_ok:
+			break
+	assert_true(all_ok, "T5 bronze_variety_holds 1000× no back-to-back (failed run %d)" % failed_run)
+
+func _t6_bronze_league_filter() -> void:
+	var forbidden_ranks := {
+		_league_rank("silver"): true,
+		_league_rank("gold"): true,
+		_league_rank("platinum"): true,
+	}
+	var all_ok := true
+	var leaked_id := ""
+	for i in 100:
+		var pick: Dictionary = OpponentLoadouts.pick_opponent_loadout(2, "bronze")
+		if pick.is_empty():
+			all_ok = false
+			leaked_id = "<empty>"
+			break
+		var rank: int = _league_rank(pick.get("unlock_league", "scrapyard"))
+		if forbidden_ranks.has(rank):
+			all_ok = false
+			leaked_id = pick.get("id", "?")
+			break
+	assert_true(all_ok, "T6 bronze_league_filter — no silver+ leak (leaked: %s)" % leaked_id)
+
+func _t7_scrapyard_no_regression() -> void:
+	var s_tiers := [OpponentLoadouts.difficulty_for("scrapyard", 0),
+					OpponentLoadouts.difficulty_for("scrapyard", 1),
+					OpponentLoadouts.difficulty_for("scrapyard", 2)]
+	var mapping_ok := s_tiers == [1, 1, 2]
+	# Pick 100 times across all 3 scrapyard indices without passing league — mirrors
+	# pre-S21.1 call convention (back-compat path: current_league="").
+	var seen := {}
+	for i in 100:
+		var idx := i % 3
+		var tier: int = OpponentLoadouts.difficulty_for("scrapyard", idx)
+		var pick: Dictionary = OpponentLoadouts.pick_opponent_loadout(tier)
+		if pick.is_empty():
+			mapping_ok = false
+			break
+		seen[pick["archetype"]] = true
+	assert_true(mapping_ok and seen.size() >= 2,
+		"T7 scrapyard_no_regression — tiers [1,1,2], ≥2 archetypes (got %d)" % seen.size())
+
+func _t8_weight_budget() -> void:
+	# Scope: S21.1 new templates + existing Bronze-legal (`bruiser_crusher`,
+	# `tank_tincan`). Silver+ grandfathered templates are out of S21.1 scope
+	# (`glass_sniper` is intentionally weight-overweight per its S13.9 design
+	# and not an S21.1 regression).
+	var s21_scope := [
+		"tank_rustwall", "glass_zap", "skirmish_scrapper",
+		"bruiser_clanker", "control_static", "control_prowler",
+		"bruiser_crusher", "tank_tincan",
+	]
+	var all_ok := true
+	var first_fail := ""
+	for t in OpponentLoadouts.TEMPLATES:
+		if not s21_scope.has(t.get("id", "")):
+			continue
+		var cap: float = _chassis_cap(t["chassis"])
+		if cap <= 0.0:
+			continue
+		var total: float = 0.0
+		for w in t["weapons"]:
+			total += _item_weight(WeaponData.WEAPONS, w)
+		total += _item_weight(ArmorData.ARMORS, t["armor"])
+		for m in t["modules"]:
+			total += _item_weight(ModuleData.MODULES, m)
+		if total > cap:
+			all_ok = false
+			if first_fail == "":
+				first_fail = "%s total=%.1f cap=%.1f" % [t.get("id", "?"), total, cap]
+	assert_true(all_ok, "T8 weight_budget — Bronze-scope templates ≤ chassis cap (first fail: %s)" % first_fail)
+
+func _t9_behavior_cards_persist() -> void:
+	# Data-only round-trip: every S21.1 new Bronze template has a populated
+	# `behavior_cards` Array. Engine ignores the field this sprint; this test
+	# guards the authored-data integrity so the carry-forward BC engine-wiring
+	# sprint finds non-empty intent already in place.
+	var s21_1_ids := ["tank_rustwall", "glass_zap", "skirmish_scrapper",
+					  "bruiser_clanker", "control_static", "control_prowler"]
+	var ok := true
+	var missing := []
+	for t in OpponentLoadouts.TEMPLATES:
+		if s21_1_ids.has(t["id"]):
+			var bc = t.get("behavior_cards", null)
+			if bc == null or not (bc is Array) or bc.is_empty():
+				ok = false
+				missing.append(t["id"])
+			else:
+				for card in bc:
+					if not (card is Dictionary and card.has("trigger") and card.has("action")):
+						ok = false
+						missing.append(t["id"] + ":malformed")
+	assert_true(ok, "T9 behavior_cards_persist on S21.1 new templates (missing/malformed: %s)" % str(missing))

--- a/godot/tests/test_sprint21_1.gd.uid
+++ b/godot/tests/test_sprint21_1.gd.uid
@@ -1,0 +1,1 @@
+uid://bj26a05ugx5aa


### PR DESCRIPTION
## S21.1 — Bronze content drop (closes #112)

First sub-sprint of **Arc B — Content & Feel**. Populates the Bronze league opponent pool with 6 new templates, adds `unlock_league` schema for league gating, and adds `behavior_cards` data schema (engine wiring carry-forward).

### What changed
- **6 new Bronze-legal templates** per Gizmo §4: `tank_rustwall`, `glass_zap`, `skirmish_scrapper`, `bruiser_clanker`, `control_static`, `control_prowler`. All 5 archetypes covered; active Bronze pool = 7 (6 new + grandfathered `bruiser_crusher`).
- **Tier mapping** `difficulty_for("bronze", i)` expanded from `[2,2,3]` to `[2,2,2,3,3]` (5-opponent curve per GDD §6.1).
- **Schema**: `unlock_league` (scrapyard | bronze | silver | gold | platinum) + `behavior_cards` array. `LEAGUE_RANK` const + picker filter (default empty-string = backward-compat skip).
- **Picker signature**: `pick_opponent_loadout(tier, current_league="", last_archetype=-1, _player_archetype_hint=-1)`. Existing call-sites updated.
- **Variety-strip widening**: when variety would empty the pool (e.g. Bronze tier-3 all-CONTROLLER), pool widens to tier-(N-1) respecting league cap. Fixes Gizmo §1 implicit assumption.
- **`opponent_data.build_opponent_brott`** bypasses league filter on `"scrapyard"` to preserve pre-S21.1 grandfathered tier-2 behavior.
- **GDD §6.3** updated: expanded template table, tier-mapping bullet, new league-gating design note.
- **Unit tests** (`test_sprint21_1.gd`): 9 tests (Gizmo §6.1 t1–t8 + bonus behavior-card persist round-trip). Registered in `test_runner.gd`.

### How to verify
```
cd godot
godot --headless --path . --script res://tests/test_sprint21_1.gd
godot --headless --path . --script res://tests/test_runner.gd
```
All 9 S21.1 tests pass. Full runner: 39 sprint test files PASS, 0 FAIL, inline PASS.

### Scope
**In:** 6 Bronze templates + `unlock_league` + `behavior_cards` data + picker filter + tier mapping + GDD + tests.
**Out:** Opponent behavior-card engine wiring (tracked as carry-forward issue). Silver/Gold/Platinum content. UX/audio arcs (S21.2/S21.3 scope).

### Drift from spec (flagged)
1. Picker variety-strip widens to tier-(N-1) when strip would empty pool — narrow additive fix to preserve Gizmo §6.1 t5 invariant given Bronze tier-3 is all CONTROLLER.
2. `bruiser_crusher` exempted from t3 `len(modules)==1` Bronze rule (2 modules) because Gizmo §1 says "keep as-is." Reconciliation deferred.
3. t8 weight-budget scoped to S21.1-new + existing Bronze-legal templates. `glass_sniper` (38 kg vs 30 kg cap) is a pre-existing Silver+ issue, not S21.1 regression.
4. `build_opponent_brott` skips league filter for `"scrapyard"` to preserve pre-S21.1 behavior.

Full rationale: `memory/2026-04-23-s21.1-nutts-impl-notes.md`.

### Links
- Gizmo design spec: `memory/2026-04-23-s21.1-gizmo-bronze-loadout-spec.md`
- Ett sprint plan: `memory/2026-04-23-s21.1-ett-sprint-plan.md`
- Arc brief: `memory/2026-04-23-arc-brief-arc-b-content-and-feel.md`

Closes #112.

### Hand-off
- **Optic**: combat-sim batch (sim1–sim4 per Gizmo §6.2) against this branch.
- **Boltz**: PR review per Ett §2.3.
- **Specc**: audit to `studio-audits/main` at `audits/battlebrotts-v2/v2-sprint-21.1.md` after Optic + Boltz pass.
- **Do not merge** until all three gates pass.
