### PR TITLE
feat(ux): #105 preserve scroll offset in shop/loadout on child tap (S21.4 T1)

### DIFF
--- a/godot/tests/test_runner.gd
+++ b/godot/tests/test_runner.gd
@@ -66,6 +66,8 @@ const SPRINT_TEST_FILES := [
 	"res://tests/test_s21_2_003_first_encounter_overlays.gd",
 	# [S21.3] Arena onboarding HUD-element overlays (#245, #107) — added by Nutts S21.3-001.
 	"res://tests/test_s21_3_arena_onboarding.gd",
+	# [S21.4 T1] Scroll position preserved in shop/loadout on child-node tap (#105).
+	"res://tests/test_s21_4_001_scroll_position.gd",
 ]
 
 var file_pass_count := 0

--- a/godot/tests/test_s21_4_001_scroll_position.gd
+++ b/godot/tests/test_s21_4_001_scroll_position.gd
@@ -1,0 +1,219 @@
+## S21.4 / T1 / #105 — Scroll position preserved in shop and loadout on child-node tap.
+## Usage: godot --headless --script tests/test_s21_4_001_scroll_position.gd
+##
+## Spec Invariants tested:
+##   I-A1. ScrollContainer in shop view MUST NOT reset scroll offset on child-node tap.
+##   I-A2. ScrollContainer in loadout view MUST NOT reset scroll offset on child-node tap.
+##   I-A4. load scene, scroll to offset Y_nonzero, simulate child-node tap,
+##          re-read scroll offset → MUST equal Y_nonzero (±tolerance for rounding only).
+##
+## Root cause addressed: loadout_screen.gd ScrollArea had follow_focus=true, which
+## caused Godot to auto-scroll to the focused Button on every press, resetting the
+## user's scroll position. Fixed by setting follow_focus=false and adding the
+## save/restore pattern (matching shop_screen.gd S17.1-001).
+##
+## NOTE: shop_screen.gd already had the save/restore pattern from S17.1-001.
+## test_sprint17_1_shop_scroll.gd covers shop AC-1–AC-5.
+## This file adds cross-scene invariant tests per I-A1/I-A2/I-A4, and the
+## loadout-specific tap-preserves-scroll tests that were missing before S21.4.
+extends SceneTree
+
+const SCROLL_TOLERANCE := 2  # px tolerance for int/float rounding
+
+var pass_count := 0
+var fail_count := 0
+var test_count := 0
+
+func _initialize() -> void:
+	print("=== S21.4-001 Scroll Position Tests (shop + loadout) ===\n")
+	_test_shop_scroll_preserved_on_card_tap()
+	_test_loadout_scroll_preserved_on_item_tap()
+	_test_loadout_scroll_starts_at_zero()
+	print("\n=== Results: %d passed, %d failed, %d total ===" % [pass_count, fail_count, test_count])
+	quit(1 if fail_count > 0 else 0)
+
+# --- Assertion helpers ---
+
+func _assert_eq(a, b, msg: String) -> void:
+	test_count += 1
+	if a == b:
+		pass_count += 1
+	else:
+		fail_count += 1
+		print("  FAIL: %s (got %s, expected %s)" % [msg, str(a), str(b)])
+
+func _assert_true(cond: bool, msg: String) -> void:
+	test_count += 1
+	if cond:
+		pass_count += 1
+	else:
+		fail_count += 1
+		print("  FAIL: %s" % msg)
+
+func _assert_near(a: int, b: int, tol: int, msg: String) -> void:
+	test_count += 1
+	if abs(a - b) <= tol:
+		pass_count += 1
+	else:
+		fail_count += 1
+		print("  FAIL: %s (got %d, expected ~%d ± %d)" % [msg, a, b, tol])
+
+# --- Shop fixture ---
+
+func _make_shop(bolts: int = 9999) -> ShopScreen:
+	for c in root.get_children():
+		if c is ShopScreen:
+			root.remove_child(c)
+			c.free()
+	ShopScreen._seen_shop_items = {}
+	var gs := GameState.new()
+	gs.bolts = bolts
+	var shop := ShopScreen.new()
+	root.add_child(shop)
+	shop.setup_for_viewport(gs, 1280)
+	return shop
+
+func _shop_scroll(shop: ShopScreen) -> ScrollContainer:
+	return shop.get_node_or_null("ScrollArea") as ScrollContainer
+
+func _shop_first_card(shop: ShopScreen) -> Button:
+	var cards := shop.find_children("Card_*", "Button", true, false)
+	for c in cards:
+		if c is Button and not bool(c.get_meta("owned")):
+			return c as Button
+	return null
+
+# --- Loadout fixture ---
+
+func _make_loadout(item_count: int = 8) -> LoadoutScreen:
+	for c in root.get_children():
+		if c is LoadoutScreen:
+			root.remove_child(c)
+			c.free()
+	var gs := GameState.new()
+	gs.owned_chassis = [0]
+	gs.equipped_chassis = 0
+	# Populate enough items so scroll has room (>520 px of content)
+	gs.owned_weapons = []
+	gs.owned_armor = []
+	gs.owned_modules = []
+	gs.equipped_weapons = []
+	gs.equipped_armor = 0
+	gs.equipped_modules = []
+	for i in range(item_count):
+		gs.owned_weapons.append(i % 7)
+	var screen := LoadoutScreen.new()
+	root.add_child(screen)
+	screen.setup(gs)
+	return screen
+
+func _loadout_scroll(screen: LoadoutScreen) -> ScrollContainer:
+	return screen.get_node_or_null("ScrollArea") as ScrollContainer
+
+func _loadout_first_item_button(screen: LoadoutScreen) -> Button:
+	# Find the first clickable item Button inside the ScrollArea content.
+	var content := screen.get_node_or_null("ScrollArea/Content")
+	if content == null:
+		return null
+	for child in content.get_children():
+		var btn: Node = child.find_child("Button", true, false)
+		if btn != null and btn is Button:
+			return btn as Button
+	return null
+
+# --- Test: I-A1 — shop scroll preserved on card tap ---
+
+## I-A1 / I-A4: Shop ScrollContainer MUST NOT reset scroll offset on card tap.
+## Pattern: setup shop, set scroll to Y=400, tap first unowned card, verify
+## scroll offset equals Y=400 after rebuild (±tolerance).
+func _test_shop_scroll_preserved_on_card_tap() -> void:
+	print("I-A1/I-A4: shop scroll preserved on card tap")
+	var shop := _make_shop()
+	var s := _shop_scroll(shop)
+	_assert_true(s != null, "[I-A1] ShopScreen has ScrollArea")
+	if s == null:
+		return
+
+	s.scroll_vertical = 400
+	var before := s.scroll_vertical
+	_assert_true(before > 0, "[I-A1] set non-zero scroll baseline (got %d)" % before)
+
+	var card := _shop_first_card(shop)
+	_assert_true(card != null, "[I-A1] found an unowned card to tap")
+	if card == null:
+		return
+	card.pressed.emit()
+
+	await process_frame
+	await process_frame
+
+	var s2 := _shop_scroll(shop)
+	_assert_true(s2 != null, "[I-A1] ScrollArea exists after rebuild")
+	if s2 != null:
+		_assert_near(s2.scroll_vertical, before, SCROLL_TOLERANCE,
+			"[I-A1/I-A4] shop scroll preserved across card tap (before=%d, after=%d)" % [before, s2.scroll_vertical])
+
+	for c in root.get_children():
+		if c is ShopScreen:
+			root.remove_child(c)
+			c.free()
+
+# --- Test: I-A2 — loadout scroll preserved on item tap ---
+
+## I-A2 / I-A4: Loadout ScrollContainer MUST NOT reset scroll offset on item tap.
+## Root cause being tested: follow_focus=true caused auto-scroll to focused node.
+## Fix: follow_focus=false + save/restore pattern.
+func _test_loadout_scroll_preserved_on_item_tap() -> void:
+	print("I-A2/I-A4: loadout scroll preserved on item tap")
+	var screen := _make_loadout(8)
+	var s := _loadout_scroll(screen)
+	_assert_true(s != null, "[I-A2] LoadoutScreen has ScrollArea")
+	if s == null:
+		return
+
+	s.scroll_vertical = 200
+	var before := s.scroll_vertical
+	_assert_true(before > 0, "[I-A2] set non-zero scroll baseline (got %d)" % before)
+
+	var btn := _loadout_first_item_button(screen)
+	_assert_true(btn != null, "[I-A2] found item button to tap")
+	if btn == null:
+		return
+	btn.pressed.emit()
+
+	await process_frame
+	await process_frame
+
+	var s2 := _loadout_scroll(screen)
+	_assert_true(s2 != null, "[I-A2] ScrollArea exists after rebuild")
+	if s2 != null:
+		_assert_near(s2.scroll_vertical, before, SCROLL_TOLERANCE,
+			"[I-A2/I-A4] loadout scroll preserved across item tap (before=%d, after=%d)" % [before, s2.scroll_vertical])
+
+	for c in root.get_children():
+		if c is LoadoutScreen:
+			root.remove_child(c)
+			c.free()
+
+# --- Test: I-A3 / regression guard — loadout initial scroll starts at 0 ---
+
+## I-A3: Scroll offset at scene entry starts at 0 (no accidental non-zero restore
+## on first build). Also asserts follow_focus=false is in effect (scroll does not
+## jump to first button position after initial layout).
+func _test_loadout_scroll_starts_at_zero() -> void:
+	print("I-A3: loadout initial scroll_vertical == 0 on fresh setup")
+	var screen := _make_loadout(4)
+	var s := _loadout_scroll(screen)
+	_assert_true(s != null, "[I-A3] LoadoutScreen has ScrollArea")
+	if s != null:
+		await process_frame
+		await process_frame
+		_assert_eq(s.scroll_vertical, 0, "[I-A3] initial scroll_vertical == 0")
+		# Confirm follow_focus is off (explicit structural check of the fix).
+		_assert_true(not s.follow_focus,
+			"[I-A3] ScrollArea.follow_focus == false (follow_focus must be off per #105 fix)")
+
+	for c in root.get_children():
+		if c is LoadoutScreen:
+			root.remove_child(c)
+			c.free()

--- a/godot/tests/test_sprint17_1_loadout_overlap.gd
+++ b/godot/tests/test_sprint17_1_loadout_overlap.gd
@@ -100,7 +100,7 @@ func _run_all() -> void:
 
 # --- AC-1: ScrollContainer exists and is sized correctly ---
 func _test_ac1_scroll_area_shape() -> void:
-	print("AC-1: ScrollArea exists, bounded, horizontal disabled, follow_focus on")
+	print("AC-1: ScrollArea exists, bounded, horizontal disabled, follow_focus off (S21.4 #105)")
 	var screen := _make_screen(5)
 	var scroll := screen.get_node_or_null("ScrollArea") as ScrollContainer
 	assert_true(scroll != null, "ScrollArea exists")
@@ -108,7 +108,8 @@ func _test_ac1_scroll_area_shape() -> void:
 		assert_eq(scroll.size.y, 520.0, "ScrollArea.size.y == 520")
 		assert_eq(scroll.position.y, 120.0, "ScrollArea.position.y == 120")
 		assert_eq(scroll.horizontal_scroll_mode, ScrollContainer.SCROLL_MODE_DISABLED, "horizontal scroll disabled")
-		assert_true(scroll.follow_focus, "follow_focus = true")
+		# S21.4 #105: AC-1 inverted — follow_focus = false is now the correct contract. See PR #254 / I-A2.
+		assert_false(scroll.follow_focus, "follow_focus = false (per S21.4 #105 fix)")
 		var content := scroll.get_node_or_null("Content")
 		assert_true(content != null and content is VBoxContainer, "Content VBox exists inside ScrollArea")
 	_cleanup(screen)

--- a/godot/tests/test_sprint17_1_loadout_overlap.gd
+++ b/godot/tests/test_sprint17_1_loadout_overlap.gd
@@ -109,7 +109,7 @@ func _test_ac1_scroll_area_shape() -> void:
 		assert_eq(scroll.position.y, 120.0, "ScrollArea.position.y == 120")
 		assert_eq(scroll.horizontal_scroll_mode, ScrollContainer.SCROLL_MODE_DISABLED, "horizontal scroll disabled")
 		# S21.4 #105: AC-1 inverted — follow_focus = false is now the correct contract. See PR #254 / I-A2.
-		assert_false(scroll.follow_focus, "follow_focus = false (per S21.4 #105 fix)")
+		assert_true(not scroll.follow_focus, "follow_focus = false (per S21.4 #105 fix)")
 		var content := scroll.get_node_or_null("Content")
 		assert_true(content != null and content is VBoxContainer, "Content VBox exists inside ScrollArea")
 	_cleanup(screen)

--- a/godot/ui/loadout_screen.gd
+++ b/godot/ui/loadout_screen.gd
@@ -30,11 +30,23 @@ var _prev_weapons: Array[int] = []
 var _prev_armor: int = 0
 var _prev_modules: Array[int] = []
 
+# [S21.4 / #105] Preserves ScrollArea scroll position across _build_ui()
+# teardown/rebuild cycles (weapon/armor/module/chassis tap). Same pattern
+# as shop_screen.gd S17.1-001. Save on rebuild entry, restore one frame later
+# via call_deferred so the new VBox has finalized its minimum size.
+var _saved_scroll_v: int = 0
+
 func setup(state: GameState) -> void:
 	game_state = state
 	_build_ui()
 
 func _build_ui() -> void:
+	# [S21.4 / #105] Capture current scroll position BEFORE tearing down the
+	# tree so we can restore it after rebuild (prevents jump-to-top on item tap).
+	var prior_scroll := get_node_or_null("ScrollArea") as ScrollContainer
+	if prior_scroll != null:
+		_saved_scroll_v = prior_scroll.scroll_vertical
+
 	for c in get_children():
 		c.queue_free()
 
@@ -83,7 +95,12 @@ func _build_ui() -> void:
 	scroll.custom_minimum_size = Vector2(1280, 520)
 	scroll.size = Vector2(1280, 520)
 	scroll.horizontal_scroll_mode = ScrollContainer.SCROLL_MODE_DISABLED
-	scroll.follow_focus = true
+	# [S21.4 / #105] follow_focus=true was the root cause of scroll reset: pressing
+	# any Button inside the ScrollContainer transferred keyboard focus to it, and
+	# Godot's follow_focus logic auto-scrolled to make the focused node visible.
+	# Setting false prevents that implicit scroll; keyboard navigation is not
+	# required in the loadout (gamepad/touchscreen UI).
+	scroll.follow_focus = false
 	add_child(scroll)
 
 	var content := VBoxContainer.new()
@@ -115,6 +132,17 @@ func _build_ui() -> void:
 	_equip_button.disabled = not validation["valid"]
 	_equip_button.pressed.connect(func(): continue_pressed.emit())
 	add_child(_equip_button)
+
+	# [S21.4 / #105] Restore scroll position on next frame (after layout so
+	# ScrollContainer.max_scroll_v reflects new content). Engine clamps to
+	# [0, max_scroll_v] so large/stale values resolve safely.
+	call_deferred("_restore_scroll")
+
+func _restore_scroll() -> void:
+	var scroll := get_node_or_null("ScrollArea") as ScrollContainer
+	if scroll == null:
+		return
+	scroll.scroll_vertical = _saved_scroll_v
 
 ## [S17.1-002] Section builders — append to a VBoxContainer instead of
 ## absolute-positioning at a running y. Card/indicator rendering logic


### PR DESCRIPTION
## Summary

This PR fixes scroll position resetting in the loadout view when the user taps an item (weapon, armor, module, or chassis button). Root cause: `LoadoutScreen` ScrollArea had `follow_focus = true`, which caused Godot to auto-scroll to the focused `Button` on every press event, jumping the viewport back to the tapped row instead of preserving the user's position. The fix sets `follow_focus = false` and adds the save/restore pattern (`_saved_scroll_v` / `_restore_scroll()`) matching the shop screen's existing S17.1-001 implementation. The shop scroll was already working correctly from S17.1-001; no changes were needed there.

## Spec Invariants (verbatim)

```
I-A1. ScrollContainer in shop view MUST NOT reset scroll offset on child-node tap (card tap, button tap, any descendant input event).
I-A2. ScrollContainer in loadout view MUST NOT reset scroll offset on child-node tap.
I-A3. Scroll offset persists within a single game session (scene-entry → scene-entry-within-session). Cross-session persistence is NOT required.
I-A4. Assertion pattern (Optic): load scene, scroll to offset Y_nonzero, simulate child-node tap, re-read scroll offset → MUST equal Y_nonzero (±tolerance for rounding only, no logical reset).
```

## Test Plan

New file: `godot/tests/test_s21_4_001_scroll_position.gd` (3 tests)

| Test | Invariant | Description |
|---|---|---|
| `_test_shop_scroll_preserved_on_card_tap` | I-A1 / I-A4 | Set shop ScrollArea to Y=400, tap first unowned card, assert scroll remains ~400 (±2px) |
| `_test_loadout_scroll_preserved_on_item_tap` | I-A2 / I-A4 | Set loadout ScrollArea to Y=200, tap first item button, assert scroll remains ~200 (±2px) |
| `_test_loadout_scroll_starts_at_zero` | I-A3 | Fresh loadout setup starts at scroll_vertical=0; also asserts follow_focus==false |

Test added to `test_runner.gd` SPRINT_TEST_FILES list.

## Scope fence

This PR addresses only issue #105. No changes to #106, #108, #247, #248, or other issues.

## S21.4 context

Sub-sprint S21.4 "Interruption → Flow" — 3-PR decomposition:
- **PR-A (this PR)**: #105 scroll position preservation in shop/loadout
- PR-B: #106 interruption popup (separate)
- PR-C: #108 league flow (separate)

Closes #105