### PR TITLE
fix(ux): #106 hot-patch — Engine.get_ticks_msec → Time.get_ticks_msec (S21.4 PR-B.1)

### DIFF
--- a/godot/game_main.gd
+++ b/godot/game_main.gd
@@ -87,7 +87,7 @@ var _concede_confirm: AcceptDialog = null
 
 # [S21.4 / #106] Random-event popup controller state.
 # _re_popup: active popup node (null when none visible).
-# _re_last_shown_time: Engine.get_ticks_msec() / 1000.0 at last popup show; -inf on reset.
+# _re_last_shown_time: Time.get_ticks_msec() / 1000.0 at last popup show; -inf on reset.
 # Used for dampening: a second trigger within RANDOM_EVENT_MIN_INTERVAL_SEC is suppressed.
 var _re_popup: Control = null
 var _re_last_shown_time: float = -INF
@@ -775,7 +775,7 @@ func _find_concede_button() -> Control:
 ## If a popup is already visible, or the interval has not elapsed, call is a no-op.
 func show_random_event(event_data: Dictionary = {}) -> void:
 	# Dampening check (I-B6): suppress if within RANDOM_EVENT_MIN_INTERVAL_SEC.
-	var now := Engine.get_ticks_msec() / 1000.0
+	var now := Time.get_ticks_msec() / 1000.0
 	if now - _re_last_shown_time < RANDOM_EVENT_MIN_INTERVAL_SEC:
 		return
 	# Guard: only one popup at a time.

--- a/godot/tests/test_s21_4_002_event_popup.gd
+++ b/godot/tests/test_s21_4_002_event_popup.gd
@@ -192,11 +192,12 @@ func _test_dampening_suppresses_second_trigger() -> void:
 	_assert(gm.get("_re_popup") == null, "Popup dismissed between triggers")
 
 	# Second trigger within RANDOM_EVENT_MIN_INTERVAL_SEC / 2 (dampening window).
-	# _re_last_shown_time was set during first show; Engine.get_ticks_msec() /
+	# _re_last_shown_time was set during first show; Time.get_ticks_msec() /
 	# 1000.0 is still within the interval (same ms frame in headless test).
+	# NOTE: check _re_popup (null = suppressed) not get_node_or_null("RandomEventPopup")
+	# because queue_free() defers removal; the dismissed node is still in tree.
 	gm.show_random_event({"title": "Event B"})
-	var popup_second: Node = gm.get_node_or_null("RandomEventPopup")
-	_assert(popup_second == null,
+	_assert(gm.get("_re_popup") == null,
 		"Second trigger within RANDOM_EVENT_MIN_INTERVAL_SEC is suppressed (I-B6)")
 
 	gm.free()


### PR DESCRIPTION
## Summary

Optic-caught bug in PR #255 (S21.4 PR-B). `Engine.get_ticks_msec()` is not a valid static method in Godot 4.4; replaced with `Time.get_ticks_msec()`.

## Root Cause

Nutts used the wrong singleton in PR-B. `Engine` does not expose `get_ticks_msec()` as a static method in Godot 4.4 — that API belongs to the `Time` singleton.

## Impact

Popup dampening invariant **I-B6** was non-functional in production until this fix. The parse error in `game_main.gd` prevented `GameMain` instantiation in the test environment, causing all 4 popup tests in `test_s21_4_002_event_popup.gd` to silently produce **0/0 assertions** (CI exit code 0 masked the failure).

## CI Gap (carry-forward — Specc to file issue during audit)

When a parse error in a dependency causes a test script to fail instantiation, the test runner still exits 0. The exit-code check is insufficient to detect silent-0-assertion failures. This is a framework-level concern that should be addressed as a separate carry-forward issue.

## Files Changed

- `godot/game_main.gd` (line 778, line 90 comment): `Engine.get_ticks_msec()` → `Time.get_ticks_msec()`
- `godot/tests/test_s21_4_002_event_popup.gd` (Test 3): Fixed assertion to use `_re_popup == null` instead of `get_node_or_null("RandomEventPopup")` — `queue_free()` defers removal so the dismissed node is still in tree at assertion time; `_re_popup` is the correct dampening-state indicator.

## Tests Affected

`test_s21_4_002_event_popup.gd` now produces real assertions. Count goes from **0/0 → 13/13 pass** (all 4 popup tests + 9 others confirmed passing).

## Verification

- Local parse: no parse errors on project load (Godot 4.4.1)
- Popup test suite: **13/13 pass** (was 0/0 silently)
- Full suite: **46/46 files pass** (no regressions)
- Diff: 6 insertions, 5 deletions (minimal scope)

## Scope Fence

Single-site API correction (`Engine` → `Time` singleton) + one test assertion fix. No functional changes beyond the API correction. No PR-A or PR-C scope touched.

## Closes

n/a — this is a regression fix from PR-B, not an open issue.

## References

- #255 (original PR — S21.4 PR-B, random-event popup redesign)
- S21.4 sub-sprint
- Optic verification report (Optic-caught bug)