### PR TITLE
[S22.2c] feat: Silver unlock narrative + modal ceremony

### DIFF
--- a/godot/game/game_flow.gd
+++ b/godot/game/game_flow.gd
@@ -48,7 +48,10 @@ func select_opponent(index: int) -> void:
 
 func finish_match(won: bool) -> void:
 	last_match_won = won
-	var opp_id: String = "scrapyard_%d" % selected_opponent_index
+	## S22.2c: narrow fix for battlebrotts-v2#260 — construct opp_id using the
+	## current league prefix instead of hardcoding "scrapyard_". Full generalization
+	## of league helpers deferred to Arc F per Ett plan.
+	var opp_id: String = "%s_%d" % [game_state.current_league, selected_opponent_index]
 	last_bolts_earned = game_state.apply_match_result(won, opp_id)
 	current_screen = Screen.RESULT
 

--- a/godot/game/game_state.gd
+++ b/godot/game/game_state.gd
@@ -31,6 +31,7 @@ var _last_opponent_archetype: int = -1
 var opponents_beaten: Array[String] = []  # "scrapyard_0", "scrapyard_1", etc.
 var first_wins: Array[String] = []  # Tracks first-win bonus
 var bronze_unlocked: bool = false
+var silver_unlocked: bool = false  ## S22.2c: edge-detect flag for silver ceremony.
 var brottbrain_unlocked: bool = false
 
 ## S13.6: BrottBrain Trick Choice (Scrapyard)
@@ -164,13 +165,28 @@ func _check_progression() -> void:
 			brottbrain_unlocked = true
 			if not was_unlocked:
 				emit_signal("league_unlocked", "bronze")
+	## S22.2c: silver unlock — fires once when all 7 Bronze opponents are beaten.
+	if current_league == "bronze":
+		var was_silver_unlocked := silver_unlocked
+		var all_bronze_beaten := true
+		for i in 7:  # 7 Silver templates from S22.1
+			if ("bronze_%d" % i) not in opponents_beaten:
+				all_bronze_beaten = false
+				break
+		if all_bronze_beaten:
+			silver_unlocked = true
+			if not was_silver_unlocked:
+				emit_signal("league_unlocked", "silver")
 
 ## S14.1: transition current_league past scrapyard once the bronze moment
 ## ceremony has been shown. Caller (game_main) also clears its pending-
 ## ceremony flag; we no-op if already advanced.
+## S22.2c: extended to advance bronze → silver once silver_unlocked is true.
 func advance_league() -> void:
 	if current_league == "scrapyard" and bronze_unlocked:
 		current_league = "bronze"
+	elif current_league == "bronze" and silver_unlocked:
+		current_league = "silver"
 
 ## S13.6: Apply a resolved trick choice (data-driven). Caller owns the modal
 ## lifecycle; GameState only mutates session state.

--- a/godot/game_main.gd
+++ b/godot/game_main.gd
@@ -2,6 +2,10 @@
 ## Flow: Menu → Shop → Loadout → BrottBrain → Opponent → Arena → Result → loop
 extends Node2D
 
+## S22.2c: emitted after a league-ceremony modal is dismissed. Lets analytics
+## and tutorial hooks listen without coupling to the modal lifecycle.
+signal ceremony_complete(league_id: String)
+
 const ARENA_OFFSET := Vector2(384, 60)
 const TICKS_PER_SEC := 10
 
@@ -210,14 +214,24 @@ func _show_shop() -> void:
 	# S14.1: if a league just unlocked, the ceremony modal gates shop reveal.
 	# On Continue, modal calls GameState.advance_league() then emits
 	# modal_dismissed; we then proceed into the shop normally.
+	#
+	# S22.2c: for silver (and any future league), fire-once guard checked via
+	# FirstRunState before showing modal. ceremony_complete signal emitted on dismiss.
 	if _pending_league_ceremony != "":
 		var ceremony := _pending_league_ceremony
 		_pending_league_ceremony = ""
+		# S22.2c: fire-once guard for silver ceremony.
+		if ceremony == "silver":
+			var frs: Node = get_node_or_null("/root/FirstRunState")
+			if frs != null and frs.call("has_seen", "silver_unlocked_modal_seen"):
+				# Already seen — skip ceremony, go straight to shop.
+				_show_shop()
+				return
 		var modal_scene: PackedScene = load("res://ui/league_complete_modal.tscn")
 		var modal := modal_scene.instantiate()
-		modal.setup(game_flow.game_state)
+		modal.setup(game_flow.game_state, ceremony)
 		add_child(modal)
-		modal.modal_dismissed.connect(_show_shop)
+		modal.modal_dismissed.connect(_on_ceremony_dismissed.bind(ceremony))
 		return
 	_clear_screen()
 	var shop := ShopScreen.new()
@@ -226,6 +240,18 @@ func _show_shop() -> void:
 	shop.setup(game_flow.game_state)
 	shop.continue_pressed.connect(_show_loadout)
 	_maybe_spawn_first_encounter(FE_KEY_SHOP)
+
+## S22.2c: called when a league ceremony modal is dismissed (via modal_dismissed
+## signal). Marks silver ceremony seen (fire-once guard), emits ceremony_complete
+## signal, then proceeds to shop.
+func _on_ceremony_dismissed(league_id: String) -> void:
+	if league_id == "silver":
+		var frs: Node = get_node_or_null("/root/FirstRunState")
+		if frs != null:
+			frs.call("mark_seen", "silver_unlocked_modal_seen")
+	# Mirror Bronze: emit ceremony_complete so any listener (analytics, tutorial) can hook.
+	emit_signal("ceremony_complete", league_id)
+	_show_shop()
 
 func _show_loadout() -> void:
 	_clear_screen()

--- a/godot/ui/league_complete_modal.gd
+++ b/godot/ui/league_complete_modal.gd
@@ -1,22 +1,50 @@
 ## S14.1 — League complete modal (bronze moment).
-## Fires on the ResultScreen \u2192 Shop transition when the player has just
+## Fires on the ResultScreen → Shop transition when the player has just
 ## cleared all three Scrapyard opponents. Fade-in, placeholder badge pulse,
 ## single "Continue" CTA. On Continue: tells GameState to advance league,
-## emits modal_dismissed, frees self. No audio this sprint (S14.1 plan \u00a73).
+## emits modal_dismissed, frees self. No audio this sprint (S14.1 plan §3).
+##
+## S22.2c: extended with LEAGUE_COPY dict, setup(state, league_id) overload,
+## and _apply_badge_color VFX beat (MESH_FAIL flash → SILVER settle for silver).
 class_name LeagueCompleteModal
 extends CanvasLayer
 
 signal modal_dismissed
 
-const BRONZE := Color(0.804, 0.498, 0.196)  ## #CD7F32-ish, muted bronze
-const FADE_MS := 400
+const BRONZE    := Color(0.804, 0.498, 0.196)  ## #CD7F32-ish, muted bronze
+const SILVER    := Color(0.72, 0.76, 0.80)     ## cold chrome
+const MESH_FAIL := Color(0.90, 0.25, 0.20)     ## hot red — "mesh burning out"
+const FLASH_DUR := 0.10
+const FADE_MS   := 400
+
+## S22.2c: extensible league copy dict. Fallback key is "bronze" on unknown league.
+const LEAGUE_COPY: Dictionary = {
+	"scrapyard": {
+		"header": "SCRAPYARD CLEARED",
+		"copy":   "Your brott earned it. Welcome to Bronze.",
+	},
+	"bronze": {
+		"header": "SCRAPYARD CLEARED",
+		"copy":   "Your brott earned it. Welcome to Bronze.",
+	},
+	"silver": {
+		"header": "BRONZE CLEARED",
+		"copy":   "Reactive mesh loses its teeth up here. Silver runs hotter.",
+	},
+}
 
 var _state: GameState
 var _overlay: ColorRect
 var _badge: ColorRect
+var _header_label: Label
+var _copy_label: Label
+var _league_id: String = "bronze"
 
-func setup(state: GameState) -> void:
+## S22.2c: accepts league_id to drive copy + VFX. Default "bronze" preserves
+## existing call-sites that pass only state (e.g. scrapyard ceremony).
+func setup(state: GameState, league_id: String = "bronze") -> void:
 	_state = state
+	_league_id = league_id
 
 func _ready() -> void:
 	layer = 110  # above any other modals/screens
@@ -41,13 +69,15 @@ func _ready() -> void:
 	vbox.add_theme_constant_override("separation", 18)
 	_overlay.add_child(vbox)
 
+	## S22.2c: header text is set after _ready via LEAGUE_COPY lookup.
 	var header := Label.new()
-	header.text = "SCRAPYARD CLEARED"
+	header.text = ""
 	header.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
 	header.add_theme_font_size_override("font_size", 28)
 	vbox.add_child(header)
+	_header_label = header
 
-	# Placeholder bronze badge \u2014 a ColorRect we pulse with a tween.
+	# Badge — a ColorRect; color driven by _apply_badge_color().
 	var badge_wrap := CenterContainer.new()
 	vbox.add_child(badge_wrap)
 	_badge = ColorRect.new()
@@ -55,12 +85,14 @@ func _ready() -> void:
 	_badge.color = BRONZE
 	badge_wrap.add_child(_badge)
 
+	## S22.2c: copy text is set after _ready via LEAGUE_COPY lookup.
 	var copy := Label.new()
-	copy.text = "Your brott earned it. Welcome to Bronze."
+	copy.text = ""
 	copy.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
 	copy.autowrap_mode = TextServer.AUTOWRAP_WORD
 	copy.custom_minimum_size = Vector2(380, 0)
 	vbox.add_child(copy)
+	_copy_label = copy
 
 	var btn := Button.new()
 	btn.text = "Continue"
@@ -70,7 +102,23 @@ func _ready() -> void:
 	btn_row.add_child(btn)
 	vbox.add_child(btn_row)
 
+	## S22.2c: apply copy + VFX BEFORE fade-in animation.
+	var entry: Dictionary = LEAGUE_COPY.get(_league_id, LEAGUE_COPY["bronze"])
+	_header_label.text = entry["header"]
+	_copy_label.text   = entry["copy"]
+	_apply_badge_color(_league_id)
 	_animate_in()
+
+## S22.2c: Set badge color/VFX for the given league.
+## For silver: 0-dur snap to MESH_FAIL ("mesh burning out") then FLASH_DUR
+## settle to SILVER chrome. Called BEFORE _animate_in() in _ready().
+func _apply_badge_color(league_id: String) -> void:
+	if league_id != "silver":
+		_badge.modulate = BRONZE
+		return
+	var tw := create_tween()
+	tw.tween_property(_badge, "modulate", MESH_FAIL, 0.0)    # snap to red
+	tw.tween_property(_badge, "modulate", SILVER, FLASH_DUR)  # settle to chrome
 
 func _animate_in() -> void:
 	# Fade overlay to dim; pulse the badge subtly.


### PR DESCRIPTION
## Context

HCD ruling 2026-04-24 12:14Z: Option A requires a narrative beat in the Silver-unlock flow. Mechanical lever shipped in PR #272 (merged @ 08004e6c); this PR is the narrative surface.

## What

Silver unlock ceremony. On Bronze-clear: modal fires ("BRONZE CLEARED" / "Reactive mesh loses its teeth up here. Silver runs hotter.") with a badge VFX beat (mesh-fail flash → silver settle). Tap to dismiss → shop loads. Fire-once guard via FirstRunState.

## Files

- `godot/game/game_state.gd` — silver_unlocked state, _check_progression, advance_league
- `godot/game/game_flow.gd` — finish_match league-prefix (narrow fix for #260)
- `godot/game_main.gd` — ceremony_complete signal, _show_shop guard, _on_ceremony_dismissed
- `godot/ui/league_complete_modal.gd` — LEAGUE_COPY dict, setup(state, league_id), _apply_badge_color, SILVER/MESH_FAIL consts

No new tests (Playwright smoke covers narrative flow). No new assets.

## Dependencies / carry-forwards

- Depends on PR #272 merge (mechanical lever + BrottState.current_league plumbing). Main HEAD verified @ 08004e6c before branching.
- Narrow fix for battlebrotts-v2#260 hardcoded "Bronze" in league helpers (full generalization deferred to Arc F per Ett).
- FirstRunState API reconciled: actual API is `mark_seen(key)` / `has_seen(key)` — matches spec. No deviations.

## Playwright smoke plan (Optic post-merge)

1. Bronze-clear all 7 opponents via iterated finish_match
2. Assert league_unlocked("silver") fires exactly once
3. Assert modal header "BRONZE CLEARED" + body contains "Reactive mesh loses its teeth"
4. Assert _badge.modulate settles to Color(0.72, 0.76, 0.80) at t = FLASH_DUR + 0.05
5. Tap-to-dismiss → _show_shop() called
6. Fire-once guard: 2nd trigger path → modal must NOT appear
7. Screenshot modal-visible frame (per S21.4 T3 pattern)

Refs: HCD ruling 2026-04-24 12:14Z, Gizmo spec `memory/s22.2c-gizmo-part3.md`, PR #272 merge (main @ 08004e6c), Ett plan Piece 3.