### PR TITLE
[S24.1] Foundation cleanup: shop_screen SFX bus fix + sfxr review request (closes #262)

### DIFF
--- a/godot/tests/test_sprint24_1_001_shop_screen_sfx_bus.gd
+++ b/godot/tests/test_sprint24_1_001_shop_screen_sfx_bus.gd
@@ -1,0 +1,27 @@
+## S24.1-001 ShopScreen SFX bus routing — invariant: _shop_audio.bus == "SFX" after _ready().
+## Usage: godot --headless --path godot/ --script res://tests/test_sprint24_1_001_shop_screen_sfx_bus.gd
+extends SceneTree
+var pass_count := 0
+var fail_count := 0
+var test_count := 0
+const ShopScreenScript := preload("res://ui/shop_screen.gd")
+
+func _initialize() -> void:
+	print("=== S24.1-001 ShopScreen SFX bus routing ===\n")
+	_test_shop_audio_routes_to_sfx()
+	print("\n=== Results: %d passed, %d failed, %d total ===" % [pass_count, fail_count, test_count])
+	quit(1 if fail_count > 0 else 0)
+
+func _assert_eq(a: Variant, b: Variant, msg: String) -> void:
+	test_count += 1
+	if a == b:
+		pass_count += 1
+	else:
+		fail_count += 1
+		print("  FAIL: %s (got %s, expected %s)" % [msg, str(a), str(b)])
+
+func _test_shop_audio_routes_to_sfx() -> void:
+	var shop: Control = ShopScreenScript.new()
+	get_root().add_child(shop)
+	_assert_eq(shop._shop_audio.bus, &"SFX", "I3c: _shop_audio.bus == SFX")
+	shop.queue_free()

--- a/godot/ui/shop_screen.gd
+++ b/godot/ui/shop_screen.gd
@@ -71,6 +71,7 @@ var _skip_trick: bool = false  # test hook: bypass modal in unit tests
 
 func _ready() -> void:
 	_shop_audio = AudioStreamPlayer.new()
+	_shop_audio.bus = "SFX"  # S24.1 / closes #262 — route through SFX bus per 3-bus architecture (S21.5)
 	add_child(_shop_audio)
 
 func _play_sfx(path: String) -> void:


### PR DESCRIPTION
## Summary

Two bundled deliverables for Arc E Pillar 1 Foundation Cleanup.

### File changes

- **`godot/ui/shop_screen.gd`** — 1 line added in `_ready()` between lines 73–74:
  ```gdscript
  _shop_audio.bus = "SFX"  # S24.1 / closes #262 — route through SFX bus per 3-bus architecture (S21.5)
  ```
- **`godot/tests/test_sprint24_1_001_shop_screen_sfx_bus.gd`** — new test file, 27 LOC, 1 assertion
- **`memory/ops/s24-1-sfxr-review-request.md`** — HCD listening guide for #263 keep/replace decision (workspace-only, not in this repo)

### Test delta

1347 → 1348 total assertions. One net-new assertion: `_shop_audio.bus == "SFX"`.

### Notes

- `ATTRIBUTION.md` is unchanged — no assets replaced in S24.1.
- [#263] stays open pending HCD review — see `memory/ops/s24-1-sfxr-review-request.md` for the listening guide.
- S24.2 (Mixer UI) gates on this PR merging to `main` — HCD keep/replace call on #263 is decoupled and can land async.

Fixes #262