### PR TITLE
[S24.2] docs: KB entries — FirstRunState additive schema + EVE UI primer

### DIFF
--- a/docs/kb/additive-firstrunstate-schema-extension.md
+++ b/docs/kb/additive-firstrunstate-schema-extension.md
@@ -1,0 +1,58 @@
+# KB: Additive FirstRunState Schema Extension Pattern
+
+**Source:** S24.2 (Arc E — Audio Depth)
+**Owner:** battlebrotts-v2
+
+---
+
+## Pattern
+
+When extending `FirstRunState` with new persistent settings, follow the **additive-only** schema extension pattern:
+
+1. **Add new keys to `[settings]` section only.** Never add keys to `[seen]`, never rename or remove existing keys.
+2. **Use `_cfg.get_value(SETTINGS_SECTION, "key", <safe_default>)` for reads.** The safe default is silently applied when the key is absent (old saves load the default — no migration required).
+3. **Provide both `get_` and `set_` helpers** following the existing `get_audio_muted()` / `set_audio_muted()` naming pattern.
+4. **Save on every write.** Each `set_*` method calls `_cfg.save(STORE_PATH)` immediately.
+5. **Log save errors with `push_warning`, do not assert or crash.**
+
+## Example — S24.2 Volume Helpers
+
+```gdscript
+func get_master_db() -> float:
+    _ensure_loaded()
+    return float(_cfg.get_value(SETTINGS_SECTION, "master_db", 0.0))
+
+func set_master_db(value: float) -> void:
+    _ensure_loaded()
+    _cfg.set_value(SETTINGS_SECTION, "master_db", value)
+    var err := _cfg.save(STORE_PATH)
+    if err != OK:
+        push_warning("[FirstRunState] save error %s for master_db" % err)
+```
+
+## Schema after S24.2
+
+```ini
+[settings]
+audio_muted=false     ; S21.5 — do NOT rename
+master_db=0.0         ; S24.2 — safe default 0.0
+sfx_db=0.0            ; S24.2 — safe default 0.0
+music_db=-6.0         ; S24.2 — safe default -6.0 (matches default_bus_layout.tres)
+```
+
+## Enforcement
+
+- Never co-mingle `[seen]` and `[settings]` keys.
+- Music default must match `default_bus_layout.tres` (-6.0 dB).
+- Old saves are forward-compatible by construction via the safe-default pattern.
+
+## Anti-patterns
+
+- Renaming `"audio_muted"` — silently breaks old saves.
+- Storing volume as linear amplitude instead of dB.
+- Omitting `_ensure_loaded()` from getters.
+
+## References
+
+- `godot/ui/first_run_state.gd`
+- `audits/battlebrotts-v2/v2-sprint-24.2.md`

--- a/docs/kb/net-new-ui-surface-eve-aesthetic-primer.md
+++ b/docs/kb/net-new-ui-surface-eve-aesthetic-primer.md
@@ -1,0 +1,81 @@
+# KB: Net-New UI Surface with EVE-Aesthetic Primer
+
+**Source:** S24.2 (Arc E — Audio Depth) — Mixer Settings Panel
+**Owner:** battlebrotts-v2
+
+---
+
+## Context
+
+BattleBrotts targets the EVE-from-WALL-E visual pillar: professional, restrained, clean, polished, smooth curves, intentional color. Apply this checklist when adding a net-new UI panel.
+
+---
+
+## Panel Container Style
+
+```gdscript
+var style := StyleBoxFlat.new()
+style.bg_color = Color("#2A2A2A")
+style.corner_radius_top_left    = 12   # >= 8px — EVE silhouette
+style.corner_radius_top_right   = 12
+style.corner_radius_bottom_left = 12
+style.corner_radius_bottom_right = 12
+style.content_margin_left   = 24.0
+style.content_margin_right  = 24.0
+style.content_margin_top    = 20.0
+style.content_margin_bottom = 20.0
+add_theme_stylebox_override("panel", style)
+```
+
+## Typography and Color
+
+```gdscript
+const COLOR_CREAM := Color("#F4E4BC")   # Primary text
+const COLOR_MUTED := Color("#A0A0A0")   # Secondary labels
+```
+
+- Title: `font_size = 28`, `COLOR_CREAM`, centered.
+- Body: `font_size = 18`, `COLOR_CREAM`.
+- No neon. No saturated accent text. One font size per role.
+
+## Layout
+
+- Single-column `VBoxContainer` with `separation = 16`.
+- Row-level `HBoxContainer` with `separation = 8-12`.
+- **No Apply/Save button.** Changes are live (`value_changed` / `toggled` write immediately).
+
+## Sliders (HSlider)
+
+- `size_flags_horizontal = Control.SIZE_EXPAND_FILL`
+- **No dB numeric readout.** Labels only ("Master", "SFX", "Music").
+- Fixed-width label column: `custom_minimum_size = Vector2(72, 0)`.
+
+## Anti-Patterns
+
+| Anti-pattern | Why |
+|---|---|
+| Hard-cornered panel | EVE silhouette is round |
+| Neon slider accent | Color as decoration |
+| dB readout label | Breaks "clean" pillar |
+| 3+ competing font sizes | Breaks "one voice per screen" |
+| Apply/Save button | Feels unfinished |
+| Emoji in labels | Violates "no emoji UI" |
+
+## Modal Presentation
+
+```gdscript
+# Guard double-open
+if get_node_or_null("PanelName") != null:
+    return
+var panel := panel_scene.instantiate() as Control
+panel.name = "PanelName"
+panel.set_anchors_preset(Control.PRESET_CENTER)
+add_child(panel)
+# Dismiss via queue_free() on Close button
+```
+
+## References
+
+- `godot/ui/mixer_settings_panel.gd`
+- `docs/kb/ux-vision.md`
+- `audits/battlebrotts-v2/v2-sprint-24.2.md`


### PR DESCRIPTION
Two KB entries from S24.2 (Mixer UI) audit.

- `docs/kb/additive-firstrunstate-schema-extension.md` — get/set_*_db helper pattern, safe defaults, schema extension rules
- `docs/kb/net-new-ui-surface-eve-aesthetic-primer.md` — StyleBoxFlat corners, COLOR_CREAM, no dB readout, live changes

Docs-only. No production code changes.