### PR TITLE
[S24.3 KB] Signal-based SFX integration + combat spam-guard patterns

### DIFF
--- a/docs/kb/combat-sfx-spam-guard.md
+++ b/docs/kb/combat-sfx-spam-guard.md
@@ -1,0 +1,136 @@
+# Combat SFX Boundary-Spam Guard Pattern
+
+**Established:** S24.3 (Combat SFX — hit + projectile)
+**Applies to:** Signal handlers that may fire at high frequency during combat simulation
+**Reference implementation:** `game_main.gd` `_on_combat_damage()` with `HIT_SFX_MIN_AMOUNT`
+
+---
+
+## Problem Statement
+
+`CombatSim.on_damage` fires for every damage event in the simulation — this includes:
+- Direct projectile hits (desired: play SFX)
+- Boundary overtime damage (undesired: ~1–3 DPS, fires continuously)
+- Splash damage sub-hits (sometimes desired, sometimes not)
+- Reflect damage ticks (usually undesired at low amounts)
+
+Without a guard, `hit.ogg` plays 10–30 times per second during boundary overtime phases, producing an audio-spam artifact that drowns out other SFX and is perceptually unpleasant.
+
+---
+
+## Approach 1: Amount Threshold (Used in S24.3)
+
+Gate playback on the damage amount exceeding a minimum threshold.
+
+```gdscript
+const HIT_SFX_MIN_AMOUNT: float = 5.0  # Suppress sub-threshold damage events
+
+func _on_combat_damage(_target, amount: float, _is_crit: bool, _pos: Vector2) -> void:
+    if amount >= HIT_SFX_MIN_AMOUNT and _hit_sfx_player != null and is_instance_valid(_hit_sfx_player):
+        _hit_sfx_player.play()
+```
+
+**How to choose the threshold:**
+- Boundary overtime DPS: typically 1–3 per tick
+- Minimum weapon damage: depends on weapon type (minigun pellets ~3–5, plasma ~10+)
+- Target threshold: slightly above the max expected spam damage, well below the min real-hit damage
+- `5.0` was chosen for S24.3 as the midpoint; may need calibration after playtest (see issue #285)
+
+**Pros:**
+- Semantically meaningful: "only play for real hits"
+- Preserves `is_crit` for future differentiation (S24.4: crit hits have `is_crit=true`, separate handler)
+- Simple, no state
+
+**Cons:**
+- Suppresses low-damage real hits (e.g., spread shotgun pellets at 4.0 damage each)
+- Threshold is a magic number requiring playtest calibration
+- Does not prevent burst spam from a very fast weapon dealing >5.0 per tick
+
+---
+
+## Approach 2: Cooldown Guard (Not used in S24.3 — documented for future use)
+
+Gate playback on a minimum time interval between plays.
+
+```gdscript
+const HIT_SFX_COOLDOWN_MS: float = 100.0  # Min ms between hit sounds
+
+var _last_hit_sfx_time_ms: float = 0.0
+
+func _on_combat_damage(_target, amount: float, _is_crit: bool, _pos: Vector2) -> void:
+    var now := Time.get_ticks_msec()
+    if now - _last_hit_sfx_time_ms >= HIT_SFX_COOLDOWN_MS:
+        _last_hit_sfx_time_ms = now
+        if _hit_sfx_player != null and is_instance_valid(_hit_sfx_player):
+            _hit_sfx_player.play()
+```
+
+**Pros:**
+- Catches all hit amounts including low-damage pellets
+- Produces a predictable, rate-limited audio cadence (~10 sounds/second max at 100ms cooldown)
+- No magic-number threshold calibration on damage values
+
+**Cons:**
+- Plays for boundary spam if the cooldown is long enough between boundary ticks
+- Adds mutable state (`_last_hit_sfx_time_ms`)
+- Rate-limiting may feel like SFX "skipping" on rapid combat exchanges
+
+---
+
+## Approach 3: Combo Guard (Threshold + Cooldown — for future consideration)
+
+```gdscript
+const HIT_SFX_MIN_AMOUNT: float = 3.0
+const HIT_SFX_COOLDOWN_MS: float = 50.0
+var _last_hit_sfx_time_ms: float = 0.0
+
+func _on_combat_damage(_target, amount: float, _is_crit: bool, _pos: Vector2) -> void:
+    if amount < HIT_SFX_MIN_AMOUNT:
+        return
+    var now := Time.get_ticks_msec()
+    if now - _last_hit_sfx_time_ms < HIT_SFX_COOLDOWN_MS:
+        return
+    _last_hit_sfx_time_ms = now
+    if _hit_sfx_player != null and is_instance_valid(_hit_sfx_player):
+        _hit_sfx_player.play()
+```
+
+**Pros:**
+- Handles both spam sources (low-amount ticks + high-frequency weapons)
+- Lower amount threshold (3.0 instead of 5.0) catches more real pellet hits
+
+**Cons:**
+- Two parameters to calibrate
+- Slightly more state
+
+---
+
+## Decision Guidance
+
+| Combat scenario | Recommended approach |
+|---|---|
+| Simple combat with clear hit/boundary distinction | Amount threshold (Approach 1) — simpler, less state |
+| Spread weapons with low per-pellet damage | Cooldown guard (Approach 2) — catches pellets that fall below amount threshold |
+| Complex combat with both issues | Combo guard (Approach 3) |
+| Post-playtest if SFX feels too sparse or too busy | Re-tune threshold/cooldown values; see issue #285 |
+
+---
+
+## S24.4 Note
+
+S24.4 adds `crit_hit.ogg` wired to `_on_combat_damage` with `is_crit=true`. The S24.3 handler will need to be extended to differentiate:
+
+```gdscript
+func _on_combat_damage(_target, amount: float, is_crit: bool, _pos: Vector2) -> void:
+    if amount >= HIT_SFX_MIN_AMOUNT:
+        if is_crit:
+            # Play crit SFX (S24.4)
+        else:
+            # Play normal hit SFX (S24.3)
+```
+
+The spam guard applies to both paths (amount threshold before the crit branch).
+
+---
+
+*Added in S24.3. See issue #285 for threshold calibration tracking.*

--- a/docs/kb/signal-based-sfx-integration.md
+++ b/docs/kb/signal-based-sfx-integration.md
@@ -1,0 +1,142 @@
+# Signal-Based SFX Integration Pattern
+
+**Established:** S24.3 (Combat SFX — hit + projectile)
+**Applies to:** Any event-driven AudioStreamPlayer wiring in `game_main.gd`
+**Reference implementation:** `game_main.gd` `_init_combat_sfx_players()`, `_on_combat_damage()`, `_on_projectile_spawned()`
+
+---
+
+## Pattern Description
+
+Wire one-shot `AudioStreamPlayer` nodes to GDScript signals for event-driven SFX playback. Each distinct sound event gets its own long-lived `AudioStreamPlayer` instance, initialized once at scene load, reused on each signal emit.
+
+---
+
+## Canonical Implementation
+
+### 1. Declare constants and member vars at file top
+
+```gdscript
+# [Sprint tag] SFX preloads — one const per event type.
+const HIT_SFX: AudioStream = preload("res://assets/audio/sfx/hit.ogg")
+const PROJECTILE_LAUNCH_SFX: AudioStream = preload("res://assets/audio/sfx/projectile_launch.ogg")
+var _hit_sfx_player: AudioStreamPlayer = null
+var _projectile_launch_sfx_player: AudioStreamPlayer = null
+```
+
+### 2. Initialize players in a dedicated `_init_*_sfx_players()` function
+
+Called from `_ready()` (or the equivalent scene init point).
+
+```gdscript
+func _init_combat_sfx_players() -> void:
+    _hit_sfx_player = AudioStreamPlayer.new()
+    _hit_sfx_player.name = "HitSfxPlayer"
+    _hit_sfx_player.bus = "SFX"      # ← MUST be set BEFORE add_child
+    _hit_sfx_player.stream = HIT_SFX
+    add_child(_hit_sfx_player)
+
+    _projectile_launch_sfx_player = AudioStreamPlayer.new()
+    _projectile_launch_sfx_player.name = "ProjectileLaunchSfxPlayer"
+    _projectile_launch_sfx_player.bus = "SFX"   # ← MUST be set BEFORE add_child
+    _projectile_launch_sfx_player.stream = PROJECTILE_LAUNCH_SFX
+    add_child(_projectile_launch_sfx_player)
+```
+
+**Critical ordering rule (S21.5 convention):** `.bus = "SFX"` must be set **before** `add_child()`. Setting it after `add_child` may not be picked up by the audio engine at play time in some Godot 4 builds. Boltz B4 gate enforces this in every PR review.
+
+### 3. Connect signals at sim creation sites
+
+Connect at every CombatSim instantiation site — both demo match and real match paths:
+
+```gdscript
+func _start_demo_match() -> void:
+    # ... sim setup ...
+    sim.on_damage.connect(_on_combat_damage)
+    sim.on_projectile_spawned.connect(_on_projectile_spawned)
+
+func _start_match(opponent_index: int) -> void:
+    # ... sim setup ...
+    sim.on_damage.connect(_on_combat_damage)
+    sim.on_projectile_spawned.connect(_on_projectile_spawned)
+```
+
+If only one site is connected, SFX will be silent in the other path. Boltz B3 verifies both connection sites.
+
+### 4. Signal handlers with null/validity guard
+
+```gdscript
+func _on_combat_damage(_target, amount: float, _is_crit: bool, _pos: Vector2) -> void:
+    if amount >= HIT_SFX_MIN_AMOUNT and _hit_sfx_player != null and is_instance_valid(_hit_sfx_player):
+        _hit_sfx_player.play()
+
+func _on_projectile_spawned(_proj) -> void:
+    if _projectile_launch_sfx_player != null and is_instance_valid(_projectile_launch_sfx_player):
+        _projectile_launch_sfx_player.play()
+```
+
+The `is_instance_valid()` check prevents crashes if the player is freed during teardown while a signal fires.
+
+---
+
+## Spam Guard
+
+For high-frequency events (damage ticks, spread weapon pellets, boundary damage), apply an amount-threshold guard:
+
+```gdscript
+const HIT_SFX_MIN_AMOUNT: float = 5.0   # Suppress sub-threshold damage (boundary ticks ~1–3)
+
+func _on_combat_damage(_target, amount: float, _is_crit: bool, _pos: Vector2) -> void:
+    if amount >= HIT_SFX_MIN_AMOUNT and ...:
+        _hit_sfx_player.play()
+```
+
+For cooldown-based guards (not used in S24.3), see `docs/kb/combat-sfx-spam-guard.md`.
+
+---
+
+## SFX Bus Routing
+
+All SFX players route to bus index 1 (`"SFX"`) in the 3-bus architecture (Master=0, SFX=1, Music=2). This ensures:
+- Volume respects the SFX slider from S24.2's `MixerSettingsPanel`
+- Per-bus mute works correctly
+- SFX doesn't bypass the master limiter
+
+Never set `.bus = "Master"` for gameplay sounds. The `"SFX"` bus (index 1) is the correct target.
+
+---
+
+## Player Naming Convention
+
+Use `PascalCase + "Player"` suffix for `AudioStreamPlayer.name`:
+- `HitSfxPlayer`
+- `ProjectileLaunchSfxPlayer`
+- `PopupWhooshPlayer` (S21.5)
+
+Named nodes are easier to find in the scene tree during debugging and are referenced by name in tests.
+
+---
+
+## Test Coverage Pattern
+
+Each new SFX player gets at minimum:
+1. **Bus routing test** — instantiate the player, set `.bus = "SFX"` before `add_child`, assert `player.bus == "SFX"` and `player.bus != "Master"`.
+2. **Asset existence test** — `FileAccess.file_exists("res://assets/audio/sfx/<file>.ogg")`.
+
+Register all test files in `test_runner.gd SPRINT_TEST_FILES` in the same PR. Missing registration = silent-0-assertion failure (B7 catch).
+
+---
+
+## Anti-Patterns
+
+| Anti-pattern | Why wrong | Correct approach |
+|---|---|---|
+| `.bus = "SFX"` after `add_child` | May not be applied at play time | Always set before `add_child` |
+| New `AudioStreamPlayer` created on every signal emit | Memory leak; audio pop artifacts | Create once in `_init_*_sfx_players()`, reuse |
+| Connecting signal in only one sim creation site | SFX silent in demo/real match path | Connect at all CombatSim instantiation sites |
+| No null guard in handler | Crash during teardown | `_player != null and is_instance_valid(_player)` |
+| `.bus = "Master"` | Bypasses SFX volume control | Use `"SFX"` (bus index 1) |
+
+---
+
+*Added in S24.3. Updated when pattern evolves.*


### PR DESCRIPTION
## Summary

Two KB entries extracted from S24.3 implementation patterns. Docs-only, no production code changes.

### `docs/kb/signal-based-sfx-integration.md`
Canonical pattern for wiring `AudioStreamPlayer` nodes to GDScript signals: initialization, `.bus` ordering convention, signal connection at all sim-creation sites, null/validity guards, test coverage shape, and anti-patterns table.

### `docs/kb/combat-sfx-spam-guard.md`
Three guard approaches (amount threshold, cooldown, combo) for high-frequency signal handlers. Includes decision guidance table, S24.4 extension note, and backlinks to issue #285 for threshold calibration.

### Related issues
- #284 (sfxr tone review, S24.3 assets)
- #285 (HIT_SFX_MIN_AMOUNT threshold tuning)
- #286 (SFX asset dir structure for Arc F)