### PR TITLE
[S24.4 KB] Cooldown-guard-before-yield + mutually-exclusive SFX branch patterns

### DIFF
--- a/docs/kb/cooldown-guard-before-yield.md
+++ b/docs/kb/cooldown-guard-before-yield.md
@@ -1,0 +1,108 @@
+# Pattern: Cooldown Guard Before Yield — Mass-Event SFX Suppression
+
+**KB category:** Audio / Signal Handling  
+**Introduced:** S24.4 — Combat SFX: critical + death  
+**Applies to:** Any `AudioStreamPlayer` handler wired to a signal that may fire N times per tick for N simultaneous entities
+
+---
+
+## Problem
+
+GDScript signals fire once per emitting call. When multiple entities (e.g., brotts) die in the same simulation tick or adjacent ticks, a signal like `on_death` fires once per brott. Without a guard, the audio handler plays the same sound N times simultaneously, creating muddy overlap instead of a single impactful audio event.
+
+**Concrete scenario:** A 4-bot match ends with 2 brotts dying within the same tick. `on_death.emit(b)` fires twice in sequence. Without a guard, `death.ogg` plays twice within milliseconds — overlap destroys the intended pathos of the sound.
+
+This pattern is distinct from the **amount-threshold guard** in `combat-sfx-spam-guard.md`, which filters by damage magnitude. The cooldown guard is for *identical events fired in rapid succession* by multiple independent emitters.
+
+---
+
+## Solution: Cooldown-Active Flag + Async Reset
+
+```gdscript
+# In game_main.gd (or equivalent game controller)
+var _death_sfx_cooldown_active: bool = false  # guard: prevent mass-death frame spam
+
+func _on_brott_death(_brott) -> void:
+    # Cooldown guard: on_death fires per-brott; in mass-death scenarios multiple
+    # brotts die in the same tick. Guard prevents overlapping playback — only
+    # the first death in a 600ms window plays. First death fires; subsequent
+    # deaths in the window are suppressed.
+    if _death_sfx_cooldown_active:
+        return
+    if _death_sfx_player != null and is_instance_valid(_death_sfx_player):
+        _death_sfx_cooldown_active = true
+        _death_sfx_player.play()
+        # Reset cooldown after 600ms to allow future matches to play death SFX.
+        await get_tree().create_timer(0.6).timeout
+        _death_sfx_cooldown_active = false
+```
+
+**Key properties:**
+1. **Guard fires before null check** — fast early exit for suppressed events (O(1), no allocations).
+2. **Flag set before `.play()`** — if `on_death` fires twice synchronously (same frame, same tick), the flag is already `true` when the second call arrives, even before `await` yields.
+3. **`await` yields control to the event loop** — the timer reset happens asynchronously; other death events arriving during the 0.6s window hit the `if _death_sfx_cooldown_active: return` check correctly.
+4. **Per-match correctness** — the flag resets after 600ms, so a second match starting immediately gets a clean state.
+
+---
+
+## Cooldown Window Sizing
+
+The 600ms window was chosen to cover the worst-case mass-death scenario for a 2v2–4-bot match (up to 4 brotts dying in 2–3 adjacent ticks at ~60fps, ~50ms window), with headroom for `death.ogg`'s 0.42s playback duration.
+
+**Rule of thumb:** `cooldown_ms ≥ asset_duration_ms + (N-1 ticks × tick_duration_ms)`.
+
+For `death.ogg` (420ms) + 3 ticks (50ms):  
+→ 420 + 50 = 470ms minimum. 600ms gives comfortable headroom.
+
+**Calibration note (issue #290):** The 600ms constant is a starting point. Post-playtest adjustment may be needed based on match pacing — see `docs/kb/` issue link.
+
+---
+
+## When to Use This Pattern
+
+| Signal characteristic | Use cooldown guard? |
+|---|---|
+| Fires once per game event (e.g., `on_projectile_spawned` per projectile) | ❌ No — each event is distinct; no suppression needed |
+| Fires N times when N entities trigger the same event (e.g., death, level-complete) | ✅ Yes — suppress duplicates in the window |
+| Fires continuously during hold (e.g., drag) | ❌ No — use debounce, not cooldown |
+| Fires at variable rate (e.g., on_damage with amount < threshold) | ❌ No — use amount threshold guard (see `combat-sfx-spam-guard.md`) |
+
+---
+
+## Anti-Patterns
+
+| Anti-pattern | Why it fails |
+|---|---|
+| `AudioStreamPlayer.playing` check instead of flag | `playing` can be `false` between play calls if the asset is very short (sub-frame). Flag is more reliable for same-tick events. |
+| Cooldown flag reset in `_process()` | `_process()` runs every frame; a frame-based reset would clear the flag too quickly. Use `create_timer()` for wall-clock precision. |
+| Setting flag AFTER `.play()` | If `on_death` fires twice in the same synchronous call stack, the second call arrives before the coroutine yields. Flag must be set BEFORE `.play()`. |
+| Resetting flag in match-start without clearing pending timers | If a match restarts quickly, a pending timer from the previous match can reset the flag mid-match. Reset flag eagerly at match start and let running timers expire harmlessly. |
+
+---
+
+## Composability with Amount-Threshold Guard
+
+Both guards can coexist in the same handler. The cooldown guard acts on *which events* pass through (suppressing duplicates); the amount threshold acts on *which events are significant enough to warrant a sound*. They are orthogonal.
+
+Example with both:
+```gdscript
+func _on_combat_damage(_target, amount: float, is_crit: bool, _pos: Vector2) -> void:
+    if is_crit:
+        # Crit branch: always plays, no amount threshold.
+        if _critical_hit_sfx_player != null and is_instance_valid(_critical_hit_sfx_player):
+            _critical_hit_sfx_player.play()
+    elif amount >= HIT_SFX_MIN_AMOUNT:
+        # Hit branch: threshold guard prevents boundary-tick spam.
+        if _hit_sfx_player != null and is_instance_valid(_hit_sfx_player):
+            _hit_sfx_player.play()
+    # (death is handled in _on_brott_death with cooldown guard — separate handler)
+```
+
+---
+
+## References
+
+- `game_main.gd` — `_on_brott_death()` (S24.4 implementation, canonical reference)
+- `docs/kb/combat-sfx-spam-guard.md` — amount-threshold pattern for high-frequency damage events
+- Issue [#290](https://github.com/brott-studio/battlebrotts-v2/issues/290) — cooldown duration calibration (post-playtest)
+- Arc E brief §2 Pillar 3 — combat SFX tone constraints and multi-death risk register

--- a/docs/kb/mutually-exclusive-sfx-branch.md
+++ b/docs/kb/mutually-exclusive-sfx-branch.md
@@ -1,0 +1,143 @@
+# Pattern: Mutually-Exclusive SFX Branch — Crit vs. Normal Hit Routing
+
+**KB category:** Audio / Signal Handling  
+**Introduced:** S24.4 — Combat SFX: critical + death  
+**Applies to:** Single-signal handlers that must route to different sounds based on event qualifier flags
+
+---
+
+## Problem
+
+The `CombatSim.on_damage` signal fires for every damage event and carries an `is_crit: bool` parameter. S24.3 wired the handler for normal hit sounds only (ignoring `_is_crit`). S24.4 needs to:
+
+1. Play a heavier `critical_hit.ogg` for crit events.
+2. Continue playing `hit.ogg` for non-crit events (amount ≥ threshold).
+3. **Never play both sounds for a single damage event.**
+
+The third requirement is the non-obvious constraint: if the handler plays both unconditionally, every crit event plays two sounds simultaneously, creating an unintended layered thud rather than a distinct crit sound.
+
+---
+
+## Solution: `if/elif` Branch with Mutually-Exclusive Arms
+
+```gdscript
+# game_main.gd — S24.4 extension of S24.3 on_damage handler
+func _on_combat_damage(_target, amount: float, is_crit: bool, _pos: Vector2) -> void:
+    # [S24.4] Crit branch: critical hits always play critical_hit SFX;
+    # normal hits guarded by threshold. Branches are mutually exclusive —
+    # one damage event plays at most one sound.
+    if is_crit:
+        if _critical_hit_sfx_player != null and is_instance_valid(_critical_hit_sfx_player):
+            _critical_hit_sfx_player.play()
+    elif amount >= HIT_SFX_MIN_AMOUNT:
+        if _hit_sfx_player != null and is_instance_valid(_hit_sfx_player):
+            _hit_sfx_player.play()
+```
+
+**Branch semantics:**
+| `is_crit` | `amount` | Sound played |
+|---|---|---|
+| `true` | any | `critical_hit.ogg` — always (crits are always significant) |
+| `false` | ≥ 5.0 | `hit.ogg` — threshold guard still applies |
+| `false` | < 5.0 | silence — boundary-tick suppression |
+
+---
+
+## Why Crits Skip the Amount Threshold
+
+The `HIT_SFX_MIN_AMOUNT = 5.0` threshold exists to suppress boundary-tick, splash, and reflect damage events — all of which are `is_crit=false` by definition (critical hits require a direct hit on a target, not environmental damage). Therefore:
+
+- **Crit arm (`if is_crit`):** No amount guard. A crit always fires the crit sound regardless of damage value. This is correct because: (1) the game can produce low-damage crits from status effects or weakened weapon state, and (2) a crit that makes no sound would be a gameplay clarity failure.
+- **Hit arm (`elif amount >= HIT_SFX_MIN_AMOUNT`):** Threshold guard retained. Non-crit boundary-tick events (amount < 5.0) remain suppressed.
+
+---
+
+## Signal Parameter Naming Convention
+
+GDScript uses leading underscores to indicate intentionally-unused parameters (suppresses compiler warnings for `-W unused_parameter`):
+
+```gdscript
+# Before S24.4 (is_crit unused — leading underscore):
+func _on_combat_damage(_target, amount: float, _is_crit: bool, _pos: Vector2) -> void:
+
+# After S24.4 (is_crit now used — underscore removed):
+func _on_combat_damage(_target, amount: float, is_crit: bool, _pos: Vector2) -> void:
+```
+
+The rename `_is_crit` → `is_crit` in S24.4 is purely a naming fix, not a signature change. The signal emitter (`combat_sim.gd`) and all other connection sites are unaffected.
+
+**Rule:** Remove the leading underscore from a parameter name when it becomes used. Keep `_` prefix on parameters that remain unused in that handler's scope.
+
+---
+
+## Extending to Additional Damage Qualifiers
+
+The `if/elif` pattern scales naturally if additional qualifiers are added to `on_damage` (e.g., `is_shield_break: bool`, `is_reflect: bool`):
+
+```gdscript
+func _on_combat_damage(_target, amount: float, is_crit: bool, _pos: Vector2) -> void:
+    if is_crit:
+        # Critical: highest priority qualifier
+        _play_if_valid(_critical_hit_sfx_player)
+    elif is_shield_break:
+        # Shield break: second-priority big moment (hypothetical S24.x)
+        _play_if_valid(_shield_break_sfx_player)
+    elif amount >= HIT_SFX_MIN_AMOUNT:
+        # Normal hit: lowest priority, still threshold-guarded
+        _play_if_valid(_hit_sfx_player)
+    # else: silence (boundary tick, splash, reflect — suppressed)
+```
+
+Priority ordering: crit > shield_break > normal_hit > silence. This makes the sound selection deterministic and auditorially correct — the "most significant" qualifier wins.
+
+---
+
+## Anti-Patterns
+
+| Anti-pattern | Why it fails |
+|---|---|
+| `if is_crit: play_crit(); if amount >= threshold: play_hit()` | Both fire on crit events above threshold — unintended layered sound. |
+| `if is_crit: play_crit(); else: play_hit()` | Plays hit sound on ALL non-crit events, including boundary-tick (amount < threshold). Removes the spam guard. |
+| Separate signal handlers for crit vs. hit | `on_damage` doesn't distinguish — you'd need two different signals from `combat_sim.gd`, which isn't the architecture. Keep qualifier routing in one handler. |
+| Checking `is_crit` after the amount threshold | `if amount >= threshold and is_crit: play_crit(); elif amount >= threshold: play_hit()` — fails for low-damage crits (which should always play). |
+
+---
+
+## Composability with Cooldown Guard
+
+For events that might fire N times per tick (see `cooldown-guard-before-yield.md`), the cooldown guard wraps the entire handler before the branch logic:
+
+```gdscript
+func _on_some_event(qualifier: bool, amount: float) -> void:
+    if _cooldown_active:
+        return  # suppress duplicates FIRST
+    if qualifier:
+        _play_if_valid(_qualifier_player)
+    elif amount >= THRESHOLD:
+        _play_if_valid(_default_player)
+```
+
+The two patterns are composable: cooldown guard deduplicates same-tick events; branch logic routes the surviving events to the correct sound.
+
+---
+
+## Test Pattern
+
+For test files covering this pattern, the key invariants are:
+
+1. `is_crit=true` → crit player is target (not hit player)
+2. `is_crit=true` → hit player is NOT target (mutual exclusion)
+3. `is_crit=false, amount >= threshold` → hit player is target (not crit player)
+4. `is_crit=false, amount < threshold` → neither player fires (silence)
+
+All four cases must be covered. See `test_s24_4_001_crit_sfx_routing.gd` (T1d–T1g) for the canonical GDScript implementation of these invariants.
+
+---
+
+## References
+
+- `game_main.gd` — `_on_combat_damage()` (S24.4 implementation, canonical reference)
+- `docs/kb/combat-sfx-spam-guard.md` — amount-threshold pattern (S24.3)
+- `docs/kb/cooldown-guard-before-yield.md` — mass-event cooldown pattern (S24.4)
+- `docs/kb/signal-based-sfx-integration.md` — full SFX wiring pattern (S24.3)
+- `godot/tests/test_s24_4_001_crit_sfx_routing.gd` — reference test implementation


### PR DESCRIPTION
## KB entries from S24.4 — Combat SFX: critical + death

Two reusable patterns captured from S24.4 implementation:

### 1. `docs/kb/cooldown-guard-before-yield.md`
The cooldown-guard-before-yield pattern for mass-event SFX suppression. Canonical use case: `on_death` fires N times per match-end tick (one per dying brott); cooldown guard ensures only the first death in a 600ms window plays, preventing muddy overlap while preserving the intended pathos. Includes: guard mechanics, cooldown window sizing formula, composability with amount-threshold guard, anti-patterns table.

### 2. `docs/kb/mutually-exclusive-sfx-branch.md`
The `if/elif` branch pattern for routing a single signal to different sounds based on qualifier flags. Canonical use case: `on_damage(is_crit: bool, amount: float)` → crit arm or hit arm (never both). Includes: why crits skip the amount threshold, parameter naming convention (`_is_crit` → `is_crit` rename), extension pattern for additional qualifiers, anti-patterns table, test invariants.

### Cross-references
Both KB files cross-reference each other and the S24.3 KB entries (`signal-based-sfx-integration.md`, `combat-sfx-spam-guard.md`) to form a complete Arc E combat SFX pattern library.

**Sprint:** S24.4 | **Arc:** E