### PR TITLE
ci(deploy): add workflow_dispatch + re-enable Build & Deploy

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -3,6 +3,7 @@ name: Build & Deploy
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
Re-enable Build & Deploy (was disabled_manually on 2026-04-21 during dashboard retirement) and add `workflow_dispatch` trigger for manual runs.

Merging this PR will trigger the first post-S17 deploy of everything on main — Arc B/C/D/E work lands at https://studio.brotatotes.com/battlebrotts-v2/game/

Surfaced by HCD asking for the live build link 2026-04-25 02:29 UTC.