### PR TITLE
design: v1.0 roguelike GDD v2 (BrottBrain cut + Bot Arena control + encounter variety)

### DIFF
--- a/docs/design/battlebrotts-v1-roguelike-gdd.md
+++ b/docs/design/battlebrotts-v1-roguelike-gdd.md
@@ -26,7 +26,7 @@ Start Run
              Retry: restart this battle with current build (see §A.4)
   → Battle 2 → reward pick → ...
   → [Battles 3–14, same pattern — encounter shapes vary per §A.9]
-  → Battle 15 → FINAL BOSS (IRONCLAD PRIME — name TBD)
+  → Battle 15 → FINAL BOSS (CEO Brott)
       Win  → Run complete → win screen
       Lose → Retries or run ends
   → Run over → new run (fresh build, fresh encounter sequence)
@@ -43,7 +43,16 @@ Total run time target: **30–50 minutes** at normal pace.
 ### A.1 Final Boss Shape
 _Locked by HCD 2026-04-25_
 
-**Decision:** Fixed boss — a single handcrafted "Champion Brott" named **[TBD — "IRONCLAD PRIME" is a placeholder, to be workshopped]** — Fortress chassis, max loadout (Railgun + Minigun, Ablative Shell, Shield Projector + Sensor Array + EMP Charge), hardcoded baseline AI (see §A.8) tuned to punish common player strategies.
+**Decision:** Fixed boss — a single handcrafted "Champion Brott" named **CEO Brott** (locked by HCD 2026-04-25 17:07 UTC) — Fortress chassis, max loadout (Railgun + Minigun, Ablative Shell, Shield Projector + Sensor Array + EMP Charge), hardcoded baseline AI (see §A.8) tuned to punish common player strategies. Visual identity: tiny corporate tie on the Fortress chassis (Arc H polish item).
+
+**Naming convention (NEW — locked by HCD 2026-04-25 17:09 UTC):** All 15 opponents in a run use **corporate-ladder titles**, scaled to tier:
+- Tier 1 (battles 1–3): Junior / Intern / Associate (e.g., "Junior Associate Brott", "Intern Brott")
+- Tier 2 (battles 4–7): Mid-management / Specialist (e.g., "Brott from Accounting", "Senior Specialist Brott")
+- Tier 3 (battles 8–11): Director / VP (e.g., "Director of Operations Brott", "VP of Engineering Brott")
+- Tier 4 (battles 12–14): C-suite / Executive (e.g., "CFO Brott", "COO Brott", "Chief Strategy Brott")
+- Battle 15: **CEO Brott** (always)
+
+Gizmo to produce a corporate-ladder title library (~15–25 titles) at S25.4 (encounter pool re-skin), mapped to (tier, archetype). Titles should lean into archetype flavor — e.g., Glass-Cannon Blitz at Tier 3 → "VP of Aggressive Sales Brott"; Mini-Boss + Escorts at Tier 4 → "CFO Brott + 2 Auditors". This makes the run feel like a labor-ladder revenge fantasy in tone, without committing to explicit narrative beats.
 
 **Why fixed:** Simple to build, no RNG in the most climactic moment, lets HCD tune it as a puzzle. The boss should feel *known* — players will talk about "beating [the boss]" not "beating a random boss." Personality > variety at the end of the run.
 
@@ -67,7 +76,7 @@ _Locked by HCD 2026-04-25 (expanded from v1 recommendation to incorporate encoun
 | 4–7 | Tier 2 | Free shape mix; ~30% Standard Duel / balance across other archetypes | Full weapon + armor + 1–2 modules |
 | 8–11 | Tier 3 | Free shape mix; introduce Counter-Build Elite | Full loadouts, counter-tuned |
 | 12–14 | Tier 4 | Free shape mix; weighted toward Counter-Build Elite + Large Swarm + Mini-boss+Escorts for climactic feel | Silver-tier templates, Disruptor/Aegis/Chrono builds |
-| 15 | Boss | IRONCLAD PRIME (always; name TBD) | Max loadout, hardcoded boss AI |
+| 15 | Boss | CEO Brott (always) | Max loadout, hardcoded boss AI |
 
 The distributions above are *seeds* for the encounter generator, not hard quotas. Final tuning happens during Arc F + Arc H playtesting.
 
@@ -138,7 +147,7 @@ _Locked by HCD 2026-04-25_
 ```
 ╔═══════════════════════════════╗
 ║   🏆 RUN COMPLETE             ║
-║   [Boss name TBD] defeated!   ║
+║   CEO Brott defeated!         ║
 ║   ─────────────────────────── ║
 ║   YOUR BUILD                  ║
 ║   [full loadout display]      ║
@@ -231,7 +240,7 @@ The BrottBrain *runtime* concept is preserved — bots still have internal AI ma
 - If two enemies are equidistant, attack the lower-HP one (focus-fire the weakest)
 - Player click-to-target overrides all priority rules for the duration of the override
 
-**Boss AI (IRONCLAD PRIME / TBD name):** Separate hardcoded behavior set — see §A.1. Does not share baseline AI rules.
+**Boss AI (CEO Brott):** Separate hardcoded behavior set — see §A.1. Does not share baseline AI rules.
 
 #### What is cut
 
@@ -302,7 +311,7 @@ At encounter generation time, the system picks the elite type that counters the 
 ---
 
 #### Archetype 7: Boss
-**Format:** 1 vs 1 (IRONCLAD PRIME — name TBD)  
+**Format:** 1 vs 1 (CEO Brott)  
 **Example composition:** Fortress chassis, Railgun + Minigun, Ablative Shell, Shield Projector + Sensor Array + EMP Charge. Hardcoded boss AI (§A.1).  
 **What makes it distinctive:** The climax. Always battle 15. Always this opponent. Hand-tuned to be hard but fair at a median run build (target: <40% first-attempt win rate at Tier-3 average build in combat sim).  
 **Design intent:** The conversation-worthy moment. "I finally beat [boss name]" is the loop closer. Players should feel they earned it.
@@ -403,7 +412,7 @@ _Up from v1's 6–8: +2 sub-sprints for encounter shape implementation, multi-ta
 - Hardcoded baseline AI + multi-target priority (2 sub-sprints)
 - Arena renderer extension (N enemies + click overlay layer) (2 sub-sprints)
 - Encounter archetype system + distribution logic (1 sub-sprint)
-- Boss loadout authoring + IRONCLAD PRIME AI (1 sub-sprint)
+- Boss loadout authoring + CEO Brott AI (1 sub-sprint)
 
 **Hard exit criteria:**
 1. Player can start a run, battle through all 15 encounters (including ≥1 swarm + ≥1 mini-boss), and reach the boss
@@ -437,7 +446,7 @@ _Up from v1's 3–4: +1 sub-sprint for the larger BrottBrain editor cut_
 
 ### Arc H — Boss + Run Polish (Target: ~4–5 sub-sprints)
 
-**Goal:** IRONCLAD PRIME (name TBD) tuned to be satisfying climax; visual run identity (§A.7) polished; first-playtest-ready build.
+**Goal:** CEO Brott tuned to be satisfying climax; visual run identity (§A.7) polished; first-playtest-ready build. Corporate tie on Fortress chassis is an Arc H polish item.
 
 **Hard exit criteria:**
 1. Boss beatable but challenging — <40% first-attempt win rate in combat sim at Tier-3 average player build
@@ -479,7 +488,7 @@ No persistent unlock trees, no items that carry across runs, no experience point
 No cutscenes, story beats, opponent backstories, dialogue beyond BrottBrain voice in trick events. Any sprint plan including story-advancing copy → STOP. Escalate.
 
 **Tripwire 4: No new opponent archetypes or roster expansion beyond the authored elite/boss set.**  
-The encounter pool + 3 authored elites + IRONCLAD PRIME is sufficient for v1.0. Any proposal for additional opponent templates beyond these → STOP. Escalate.
+The encounter pool + 3 authored elites + CEO Brott is sufficient for v1.0. Any proposal for additional opponent templates beyond these → STOP. Escalate.
 
 **Tripwire 5: No team formats.**  
 v1.0 is 1vN (player solo). Any feature touching 2v2 or player-team logic → STOP. Escalate.

--- a/docs/design/battlebrotts-v1-roguelike-gdd.md
+++ b/docs/design/battlebrotts-v1-roguelike-gdd.md
@@ -1,0 +1,367 @@
+# BattleBrotts v1.0 — Roguelike GDD
+
+**Status:** Awaiting HCD review on 7 open design questions (marked ⚠️)  
+**Pivot source:** [`memory/2026-04-25-battlebrotts-v1-roguelike-pivot.md`](../../..) — locked 2026-04-25 04:22 UTC by HCD  
+**Author:** Gizmo (design lead), spawned 2026-04-25 13:00 UTC  
+**Replaces:** `docs/gdd.md` §6 League Structure — roguelike loop supersedes league climb. All other GDD sections (§3 Customization, §4 BrottBrain, §5 Combat, §8 Arena, §10 Art Direction) remain in force unless explicitly overridden here.
+
+---
+
+## The Core Truth
+
+The fun is **watching battles happen**. The pull is **"I want to battle / try again."** Everything else is scaffolding. The roguelike framing serves this truth: every run is a fresh sequence of battles with a progressively wilder build. Short. Self-contained. Replayable.
+
+---
+
+## The Roguelike Loop (Locked)
+
+```
+Start Run
+  → Player picks starter chassis (random 3-pick? or player choice — see §A.7)
+  → Battle 1 → watch autobattle
+      Win  → Pick 1 of 3 random reward items
+      Lose → Spend a retry (3 total per run)
+             Retry: restart this battle with current build (see §A.4)
+  → Battle 2 → reward pick → ...
+  → [Battles 3–14, same pattern]
+  → Battle 15 → FINAL BOSS
+      Win  → Run complete → win screen
+      Lose → Retries or run ends
+  → Run over → new run (fresh build, fresh encounter sequence)
+```
+
+Run length: **15 battles** (locking at upper end of the 10–15 range — HCD: "longer, or slightly longer").  
+Total run time target: **30–50 minutes** at normal pace.  
+4th loss (retries exhausted) = run ends immediately.
+
+---
+
+## Section A — Open Design Questions
+
+### A.1 Final Boss Shape ⚠️
+
+**Recommendation:** Fixed boss — a single handcrafted "Champion Brott" named **IRONCLAD PRIME** — Fortress chassis, max loadout (Railgun + Minigun, Ablative Shell, Shield Projector + Sensor Array + EMP Charge), bespoke BrottBrain with 8 Behavior Cards tuned to punish common player strategies.
+
+**Why fixed:** Simple to build, no RNG in the most climactic moment, lets HCD tune it as a puzzle. The boss should feel *known* — players will talk about "beating IRONCLAD PRIME" not "beating a random boss." Personality > variety at the end of the run.
+
+**Alternative:** Small pool of 3 bosses, randomly selected at run start — adds replayability at the cost of one sprint of extra work and the need to balance 3 distinct puzzles instead of 1.
+
+---
+
+### A.2 Run Difficulty Curve ⚠️
+
+**Recommendation:** 4 difficulty tiers spread across 15 battles, using the existing `opponent_loadouts.gd` template pool (re-framed as an encounter pool, not a league ladder).
+
+| Battles | Tier | Template pool | BrottBrain complexity |
+|---------|------|---------------|----------------------|
+| 1–3 | Tier 1 | `tank_tincan`, Scrapyard-legal pool | 0–1 Behavior Cards, single weapon |
+| 4–7 | Tier 2 | Bronze-tier templates | 1–2 Behavior Cards, armor + 1 module |
+| 8–11 | Tier 3 | Silver-tier templates | 3–4 Behavior Cards, full loadouts |
+| 12–14 | Tier 4 | Silver-4 templates (Disruptor, Aegis, Chrono) | 5–6 Behavior Cards, counter-builds |
+| 15 | Boss | IRONCLAD PRIME (or boss pool — see §A.1) | 8 Behavior Cards, max loadout |
+
+**Key principle:** No stat inflation. Difficulty comes from harder BrottBrains and better loadouts, exactly as before — the same balance invariant from the original GDD §6.2 holds.
+
+**Variety rule carries forward:** no two consecutive encounters share the same archetype (TANK/GLASS_CANNON/SKIRMISHER/BRUISER/CONTROLLER). State lives on `RunState._last_opponent_archetype` (new field on the new RunState; see §B).
+
+**Alternative:** Purely random from the full pool each battle, letting difficulty vary wildly. Simpler code, but the ramp-up feel disappears — early battles can be unfair hard. Not recommended.
+
+---
+
+### A.3 Reward Pool Composition ⚠️
+
+**Recommendation:** Tiered by run progress — same tier bands as the difficulty curve.
+
+| Battles won | Legal reward items |
+|-------------|-------------------|
+| 1–3 | Tier 1–2 weapons, Plating/Reactive Mesh, Overclock/Repair Nanites/Sensor Array |
+| 4–7 | + Tier 3 weapons (Flak Cannon, Arc Emitter), Shield Projector, Afterburner |
+| 8–14 | Full item pool (Railgun, Missile Pod, Ablative Shell, EMP Charge) |
+| Boss fight | No reward — run end |
+
+**Why tiered:** Prevents first-battle Railgun pulls that skip the build arc. The power fantasy is building toward something — early rewards should feel like upgrades, not windfalls.
+
+**Mechanics:** Present 3 random items from the legal pool (deduped against currently-owned items). Player picks 1. Unpicked options are discarded — no "bank" or "defer." If the player already owns all legal items in a tier, backfill from the tier below.
+
+**Alternative:** Full item pool from battle 1. Simpler. Occasionally delightful (first-battle Railgun pick), occasionally feels unfair (Tier-4 enemy on battle 2). Post-1.0 candidate if the tiered approach feels too restrictive during playtesting.
+
+---
+
+### A.4 Retry Mechanic Specifics ⚠️
+
+**Recommendation:** Retry restarts the **current battle only**, with the current build intact. No rewind to a prior battle. No item refund.
+
+**Exact behavior:**
+- Player loses the battle → "DEFEAT" flash → UI shows: retry count remaining (e.g., "2 retries left"), button "Retry Battle" vs "Accept Loss (run ends if 0 retries)"
+- Retry: rematch against the same opponent template, same arena (re-rolled). Build is unchanged.
+- After a retry win: battle counts as won — player gets the normal reward pick.
+- When retries = 0 and the player loses: run ends immediately. No retry prompt.
+
+**Why current-battle-only:** Simple to implement (reuse existing rematch flow). Rewind-to-prior-battle is more complex (must un-apply rewards) and potentially frustrating (losing two battles worth of progress). The player's build survives a retry, which is the meaningful form of "continuation."
+
+**Note:** Retries are per-run, not per-battle. 3 retries is the total budget. A player who uses 2 retries on battle 7 has only 1 left for the rest of the run.
+
+**Alternative:** Retry rewinds one full battle — lose the battle AND the previous reward pick. More punishing. Makes retry a heavier decision. Post-1.0 difficulty mode candidate.
+
+---
+
+### A.5 Run-End UX ⚠️
+
+**Recommendation:** Two screens — Loss Screen and Win Screen — with a shared Build Summary component.
+
+**Loss Screen ("BROTT DOWN"):**
+```
+╔═══════════════════════════════╗
+║   💀 BROTT DOWN               ║
+║   Fell at Battle [N] of 15    ║
+║   ─────────────────────────── ║
+║   YOUR BUILD                  ║
+║   [Chassis icon]  [Weapon x2] ║
+║   [Armor]  [Module x3]        ║
+║   ─────────────────────────── ║
+║   Battles Won: [N-1]          ║
+║   Retries Used: [0-3]         ║
+║   Farthest Threat: [name]     ║
+║   ─────────────────────────── ║
+║       [🔁 New Run]            ║
+╚═══════════════════════════════╝
+```
+
+**Win Screen ("RUN COMPLETE"):**
+```
+╔═══════════════════════════════╗
+║   🏆 RUN COMPLETE             ║
+║   IRONCLAD PRIME defeated!    ║
+║   ─────────────────────────── ║
+║   YOUR BUILD                  ║
+║   [full loadout display]      ║
+║   ─────────────────────────── ║
+║   Battles Won: 15 / 15        ║
+║   Retries Used: [0-3]         ║
+║   Best Kill: [name]           ║
+║   ─────────────────────────── ║
+║       [🔁 New Run]            ║
+╚═══════════════════════════════╝
+```
+
+**Stats shown:** Battles won, retries used, farthest battle reached (loss) or full win flag. No elaborate stat tracking — just enough to tell the story of the run. No persistent leaderboard in v1.0.
+
+**Single button:** "New Run" on both screens. No "Return to Menu." The loop is: play → result → play again.
+
+**Alternative:** Show full battle log (who won each battle, what items were picked). More information, more screen complexity. Deferred to post-1.0 polish.
+
+---
+
+### A.6 Onboarding ⚠️
+
+**Recommendation:** First-run contextual tooltips only. No tutorial battles, no forced teaching sequence.
+
+**First run only (tracked by `first_run_state.gd`, already exists):**
+1. **Run start screen:** One-sentence copy explaining the loop: *"Build your Brott. Battle 15 enemies. Die and you get 3 retries. Beat the boss to win the run."*
+2. **First reward pick:** Tooltip overlay on the reward cards: *"Pick one — it's yours for this run."*
+3. **First BrottBrain access:** If player opens the BrottBrain editor, tooltip: *"Drag cards to teach your Brott how to fight. It'll make its own decisions in battle."*
+4. **First retry prompt:** Tooltip: *"You've got [N] retries left this run. Use one here, or accept the loss."*
+
+**No league onboarding copy.** The S21.2–S21.4 HUD onboarding work (league-surface overlays, first-encounter tooltips, shop scroll nudges) is **cut**. The roguelike loop is self-explanatory enough with run-scoped context tooltips.
+
+**Alternative:** Zero onboarding — just throw the player in. Battlebrotts is simple enough that this might work. Revisit after first playtest.
+
+---
+
+### A.7 Visual Identity for "This is a Run" ⚠️
+
+**Recommendation:** Run HUD elements — persistent indicators that frame the run context while the player is mid-run.
+
+**Run Status Bar (top of every non-arena screen during a run):**
+```
+[⚔️ Battle 6 of 15]  [💀 2 retries left]  [🔩 Build: Scout + Railgun + Ablative]
+```
+- Appears on: reward pick screen, BrottBrain editor, the "ready" screen before each battle
+- Disappears on: loss screen, win screen, main menu
+- Color shift: Battle counter turns amber at battle 12 (approaching boss zone), red at battle 14
+
+**Run framing at menu:**
+- Main menu shows "▶ Continue Run (Battle 6/15)" if a run is in progress — but note: v1.0 runs are **not persistent** (no save/resume). Once you close the browser tab, the run is gone. This button is for mid-session "go back to menu temporarily" only.
+
+**Reward pick screen:** Background color shift per tier. Battles 1–3: grey-blue (salvage vibe). Battles 4–7: bronze tint. Battles 8–14: silver-white. Boss fight prep: red/gold.
+
+**Why this works:** The run status bar is the single clearest signal. Players always know where they are. The background tinting adds atmosphere without requiring new art.
+
+**Alternative:** No persistent run bar — just show a "Battle N / 15" label at the start of each arena match. Minimal. Works. But the player has no run-context between battles (during reward pick). Not recommended.
+
+---
+
+## Section B — Keep / Cut / Re-skin Code Inventory
+
+### 🟩 KEEP
+
+| System | File(s) | Rationale |
+|--------|---------|-----------|
+| **Battle engine** | `godot/arena/arena_renderer.gd`, `godot/arena/charm_anims.gd`, `godot/game/opponent_data.gd` | This IS the game. Polish target, not a cut candidate. |
+| **Combat sim** | `godot/tests/combat_batch.gd`, `godot/tests/combat_batch_brain.gd` | Balance verification stays essential. |
+| **Chassis system** | `godot/data/chassis_data.gd` | Scout / Brawler / Fortress archetypes unchanged. |
+| **Weapon system** | `godot/data/weapon_data.gd` | Full weapon roster retained. |
+| **Armor system** | `godot/data/armor_data.gd` | Full armor roster retained (league-degradation table becomes unused but harmless). |
+| **Module system** | `godot/data/module_data.gd` | Full module roster retained. |
+| **BrottBrain system** | `godot/ui/brottbrain_screen.gd` | The main player expression surface. Keep as-is; remove the "BrottBrain unlocks at Bronze" gate — it's always available from battle 1 in the roguelike. |
+| **Behavior Cards** | All card data in `chassis_data.gd` / `brottbrain_screen.gd` | Keep all Trigger + Action cards. No cuts. |
+| **Loadout display** | `godot/ui/loadout_screen.gd` | Becomes "Current Build" — minimal re-label, same data. |
+| **Result screen** | `godot/ui/result_screen.gd` | Re-skin per §A.5 spec. Core structure (won/lost banner + continue button) stays; extend with build summary + run stats. |
+| **Item data + token router** | `godot/data/item_tokens.gd` | Reward pick system will use this to grant items. |
+| **Audio: SFX + menu music** | `godot/assets/audio/sfx/*`, `godot/assets/audio/music/menu_loop.ogg` | Menu loop applies to roguelike main menu. Hit/death/crit SFX stay. Win chime stays. |
+| **BrottBrain Trick Choices** | `godot/ui/trick_choice_modal.gd`, `godot/data/trick_choices.gd` | These become **in-run random events** — a natural fit for the roguelike. Re-skin context copy, keep mechanic. |
+| **Arena types** | Arena definitions (The Pit, Junkyard, Foundry) | All three arenas used as encounter rotation. Randomly assigned per battle. |
+| **Main menu + settings** | `godot/ui/main_menu_screen.gd`, `godot/ui/mixer_settings_panel.gd` | Keep. Main menu needs minor run-framing additions (§A.7). Settings unchanged. |
+| **Audio infrastructure** | `godot/tests/test_s21_5_*`, `test_s24_*` bus routing tests | Keep all audio tests — they verify infrastructure that doesn't change. |
+| **Bot preview** | `godot/ui/bot_preview.gd` | Keep — used in loadout display and reward pick. |
+| **`first_run_state.gd`** | `godot/ui/first_run_state.gd` | Keep — drives first-run tooltip logic (§A.6). |
+| **Test infrastructure** | `godot/tests/test_runner.gd`, `test_util.gd`, `pacing_verify.gd` | All test infra kept. |
+
+---
+
+### 🟥 CUT
+
+| System | File(s) | Rationale |
+|--------|---------|-----------|
+| **League Complete Modal** | `godot/ui/league_complete_modal.gd`, `godot/ui/league_complete_modal.tscn` | No leagues. Cut. |
+| **Opponent Select Screen** | `godot/ui/opponent_select_screen.gd` | Opponents are served by the run engine, not player-selected. Cut. |
+| **League progression logic** | `GameState._check_progression()`, `advance_league()`, `bronze_unlocked`, `silver_unlocked`, all `opponents_beaten` / `first_wins` logic | Replace with run-lifecycle methods on new `RunState`. |
+| **Economy (Bolts / shop purchases)** | `GameState.buy_*()`, `WEAPON_PRICES`, `ARMOR_PRICES`, `MODULE_PRICES`, `CHASSIS_PRICES`, `bolts` field | No shop in v1.0 roguelike. Items come from reward picks, not purchase. |
+| **Repair cost system** | `apply_match_result()` repair cost logic | No repair in roguelike. Win = reward pick. Lose = retry spend. |
+| **Shop screen** | `godot/ui/shop_screen.gd` | No shop. Cut. (Item grant / trick system still exists but is not a purchasable storefront.) |
+| **HUD onboarding (S21.2–S21.4)** | `godot/tests/test_s21_2_*`, `test_s21_4_*` — specifically league-surface and first-encounter overlays | League-surface tooltips, scroll-nudges, inline captions: cut. First-run state infra (`first_run_state.gd`) is kept; only the league-specific tooltip content is removed. |
+| **League-degradation table** | `ArmorData.REFLECT_DAMAGE_BY_LEAGUE`, `reflect_damage_for_league()` | No leagues. Can be stripped or left dormant. Lean toward stripping to reduce confusion. |
+| **BrottBrain unlock gate** | `GameState.brottbrain_unlocked`, `go_to_brottbrain()` unlock check in `game_flow.gd` | BrottBrain is always available from battle 1. Remove the gate entirely. |
+| **Arc C narrative beats** | Any narrative beat copy, modal scripts, or event popups tied to league transitions | Cut. HCD confirmed: "cut regardless of design." |
+| **Sentinel feature (Arc D)** | Any Arc D sentinel-related code if committed | Cut — does not serve the roguelike's battle-focused loop. |
+| **`first_wins` bonus system** | `GameState.first_wins[]`, first-win bolt bonus logic | No economy. Cut. |
+| **Multi-format matches (2v2, 3v3)** | `GameState` / `GameFlow` logic for team matches | v1.0 is 1v1 only. Cut the team format code. |
+
+---
+
+### 🟨 RE-SKIN
+
+| System | Current | Becomes | Files to modify |
+|--------|---------|---------|-----------------|
+| **`opponent_loadouts.gd`** | League-gated template pool, `difficulty_for(league, index)` | **Run encounter pool** — `difficulty_for(battle_index)` maps battle 1–15 to tiers 1–4 (see §A.2). Remove `unlock_league` filter; add `battle_index_to_tier()` helper. | `godot/data/opponent_loadouts.gd` |
+| **`GameState`** | Tracks bolts, owned items, league progression | **RunState (rename/replace)** — tracks current build (chassis + equipped items), retry count, battles won, current battle index. No economy. | `godot/game/game_state.gd` → `run_state.gd` |
+| **`GameFlow`** | Menu → Shop → Loadout → BrottBrain → OpponentSelect → Arena → Result | **Run flow**: Menu → RunStart (chassis pick) → [RewardPick → BrottBrain? → Arena] × 15 → BossArena → RunEnd | `godot/game/game_flow.gd` |
+| **`ResultScreen`** | "VICTORY / DEFEAT" + bolts earned | Per §A.5 — "BROTT DOWN / RUN COMPLETE" with build summary + run stats. Same file, significant copy/data changes. | `godot/ui/result_screen.gd` |
+| **`MainMenuScreen`** | Title + New Game | + Run Status Bar (§A.7) + "Continue Run" (mid-session only) | `godot/ui/main_menu_screen.gd` |
+| **Trick Choice Modal** | Scrapyard-only event; bolts/HP/item effects | **In-run random event** — fires occasionally between battles (every 3–4 battles, random). Same mechanic, same BrottBrain voice. Re-frame copy from "Scrapyard" to run context. | `godot/ui/trick_choice_modal.gd`, `godot/data/trick_choices.gd` — copy only |
+| **`LoadoutScreen`** | Full inventory management + purchase flow | **Current Build display** — read-only view of current run loadout. No buy button. Equip/unequip still works (player can rearrange what they have). | `godot/ui/loadout_screen.gd` |
+| **Reward Pick** | Does not exist (was shop) | **New screen: `reward_pick_screen.gd`** — presents 3 random items post-battle-win, player picks 1, item is immediately added to build. Uses `item_tokens.gd` for resolution. | NEW: `godot/ui/reward_pick_screen.gd` |
+| **Run Start** | Does not exist (was "New Game → Shop") | **New screen: `run_start_screen.gd`** — picks starter chassis, shows first-run tooltip (§A.6). May offer a random 3-chassis pick (⚠️ design question embedded in §A.7 starter pick). | NEW: `godot/ui/run_start_screen.gd` |
+
+---
+
+## Section C — Roadmap Proposal
+
+### Arc F — Roguelike Core Loop (Target: ~6–8 sub-sprints)
+
+**Goal:** Wire the complete roguelike run loop end-to-end — run start → battles → reward pick → boss → run end screens. The full flow should be playable with no dead ends.
+
+**Sub-sprint estimate:** 6–8 (new screens + flow rewire + RunState + encounter pool)
+
+**Hard exit criteria:**
+1. Player can start a run, battle through all 15 encounters, and reach the boss
+2. Reward pick screen works — 3 items shown, 1 selected, immediately applied to build
+3. Retry mechanic works — 3 retries tracked, run ends on 4th loss
+4. Run end screens (loss + win) display correctly with build summary
+5. `combat_batch.gd` simulations pass at >0% (engine still functional)
+6. No regressions on existing arena / combat tests
+
+**Key dependencies:**
+- HCD approves §A.1–A.7 design questions before Arc F starts
+- IRONCLAD PRIME boss loadout + BrottBrain authored (can be simple first pass)
+
+---
+
+### Arc G — Cut Pass (Target: ~3–4 sub-sprints)
+
+**Goal:** Remove all dead code from the league-campaign era — shop, league progression, economy, opponent-select screen, narrative beats — leaving a clean codebase that only contains what the roguelike needs.
+
+**Sub-sprint estimate:** 3–4 (systematic file deletions + test suite cleanup)
+
+**Hard exit criteria:**
+1. No references to `current_league`, `bronze_unlocked`, `opponents_beaten`, `bolts` in the active codebase (or they're harmlessly dormant and explicitly tagged `// DEPRECATED`)
+2. All deleted files removed from CI test matrix — no test failures from missing files
+3. `LeagueCompleteModal`, `OpponentSelectScreen`, `ShopScreen` scenes/scripts deleted
+4. Combat simulations still pass
+
+**Key dependencies:** Arc F complete (avoids cutting things that Arc F still references mid-build)
+
+---
+
+### Arc H — Boss + Run Polish (Target: ~4–5 sub-sprints)
+
+**Goal:** IRONCLAD PRIME boss tuned to be a satisfying climax; visual run identity (§A.7) polished; first-playtest-ready build.
+
+**Sub-sprint estimate:** 4–5
+
+**Hard exit criteria:**
+1. Boss is beatable but challenging — target <40% first-attempt win rate in combat sim at Tier-3 average player build
+2. Run HUD bar (battle counter + retry indicator) visible and correct on all non-arena screens
+3. Background tinting per tier band implemented
+4. First-run tooltip flow works (§A.6)
+5. HCD playtests the full run and signs off
+
+**Key dependencies:** Arc F core loop complete; HCD available for playtest at arc close
+
+---
+
+### Arc I — Ship (Target: ~2–3 sub-sprints)
+
+**Goal:** Final CI/deploy cleanup, performance verification, browser-export polish. Ship v1.0.
+
+**Sub-sprint estimate:** 2–3
+
+**Hard exit criteria:**
+1. HTML5 export loads in <5s on a mid-range device
+2. All CI tests green
+3. No known P0/P1 bugs
+4. HCD final sign-off
+
+**Key dependencies:** Arc H complete + HCD playtest pass
+
+---
+
+**Total pipeline estimate:** ~15–20 sub-sprints, ~2 weeks of pipeline clock time.
+
+---
+
+## Section D — Anti-Scope-Creep Guardrails
+
+If any of the following tripwires fires during Arcs F–I, Riv **must escalate to The Bott** before proceeding. No agent may self-authorize work that crosses a tripwire.
+
+**Tripwire 1: No new items or weapons.**  
+The existing item roster (7 weapons, 3 armors, 6 modules) is the v1.0 set. If any sprint plan proposes adding a new item type, new weapon, new chassis variant, or new module → STOP. Escalate.
+
+**Tripwire 2: No meta-progression.**  
+No persistent unlock trees, no "earned items carry across runs," no experience points, no persistent currency, no unlockable starting configurations. If any feature requires data that survives between runs → STOP. Escalate. (HCD locked this explicitly: "no, too complex.")
+
+**Tripwire 3: No narrative content.**  
+No cutscenes, no story beats, no opponent backstories, no dialogue beyond BrottBrain voice in trick events. If any sprint plan includes copy that advances a story → STOP. Escalate. (HCD locked: "cut regardless of design.")
+
+**Tripwire 4: No new opponent archetypes or roster expansion.**  
+The 19-template encounter pool is sufficient for v1.0. Difficulty comes from tier progression and BrottBrain complexity, not from new templates. If a sprint proposes a new opponent template beyond IRONCLAD PRIME → STOP. Escalate.
+
+**Tripwire 5: No team formats.**  
+v1.0 is 1v1 only. If any feature touches 2v2 or 3v3 logic → STOP. Escalate.
+
+---
+
+## Appendix: Files Touched by the Pivot (Quick Reference)
+
+| Action | Files |
+|--------|-------|
+| Delete | `godot/ui/league_complete_modal.gd`, `league_complete_modal.tscn`, `opponent_select_screen.gd`, `shop_screen.gd` |
+| Major rework | `godot/game/game_state.gd` → `run_state.gd`, `godot/game/game_flow.gd`, `godot/data/opponent_loadouts.gd`, `godot/ui/result_screen.gd` |
+| New files | `godot/ui/reward_pick_screen.gd`, `godot/ui/run_start_screen.gd` |
+| Minor rework | `godot/ui/main_menu_screen.gd`, `godot/ui/loadout_screen.gd`, `godot/ui/brottbrain_screen.gd` (remove BrottBrain unlock gate) |
+| Likely delete (test cleanup) | `godot/tests/test_s21_2_*`, `test_s21_4_003_league_surface.gd` |
+| Keep untouched | All arena, combat engine, BrottBrain card, audio, chassis/weapon/armor/module data files |
+
+---
+
+*This GDD is the design input for Arc F. HCD approves the 7 open design questions (§A.1–A.7), then Arc F planning begins.*

--- a/docs/design/battlebrotts-v1-roguelike-gdd.md
+++ b/docs/design/battlebrotts-v1-roguelike-gdd.md
@@ -1,9 +1,11 @@
-# BattleBrotts v1.0 — Roguelike GDD
+# BattleBrotts v1.0 — Roguelike GDD v2
 
-**Status:** Awaiting HCD review on 7 open design questions (marked ⚠️)  
+**Status:** HCD decisions incorporated. Ready for greenlight review.  
+**v2 revision:** 2026-04-25 ~16:26 UTC — incorporating HCD decisions from addendum  
 **Pivot source:** [`memory/2026-04-25-battlebrotts-v1-roguelike-pivot.md`](../../..) — locked 2026-04-25 04:22 UTC by HCD  
-**Author:** Gizmo (design lead), spawned 2026-04-25 13:00 UTC  
-**Replaces:** `docs/gdd.md` §6 League Structure — roguelike loop supersedes league climb. All other GDD sections (§3 Customization, §4 BrottBrain, §5 Combat, §8 Arena, §10 Art Direction) remain in force unless explicitly overridden here.
+_HCD decisions: see `memory/2026-04-25-hcd-decisions-on-gdd-v1.md`_  
+**Author:** Gizmo (design lead)  
+**Replaces:** `docs/gdd.md` §6 League Structure — roguelike loop supersedes league climb. All other GDD sections (§3 Customization, §5 Combat, §8 Arena, §10 Art Direction) remain in force unless explicitly overridden here. §4 BrottBrain is **superseded entirely** — see §A.8.
 
 ---
 
@@ -17,14 +19,14 @@ The fun is **watching battles happen**. The pull is **"I want to battle / try ag
 
 ```
 Start Run
-  → Player picks starter chassis (random 3-pick? or player choice — see §A.7)
-  → Battle 1 → watch autobattle
+  → Player picks starter chassis (random 3-pick — see §A.7)
+  → Battle 1 → watch autobattle (player can click to direct — see §A.8)
       Win  → Pick 1 of 3 random reward items
       Lose → Spend a retry (3 total per run)
              Retry: restart this battle with current build (see §A.4)
   → Battle 2 → reward pick → ...
-  → [Battles 3–14, same pattern]
-  → Battle 15 → FINAL BOSS
+  → [Battles 3–14, same pattern — encounter shapes vary per §A.9]
+  → Battle 15 → FINAL BOSS (IRONCLAD PRIME — name TBD)
       Win  → Run complete → win screen
       Lose → Retries or run ends
   → Run over → new run (fresh build, fresh encounter sequence)
@@ -36,78 +38,79 @@ Total run time target: **30–50 minutes** at normal pace.
 
 ---
 
-## Section A — Open Design Questions
+## Section A — Design Decisions
 
-### A.1 Final Boss Shape ⚠️
+### A.1 Final Boss Shape
+_Locked by HCD 2026-04-25_
 
-**Recommendation:** Fixed boss — a single handcrafted "Champion Brott" named **IRONCLAD PRIME** — Fortress chassis, max loadout (Railgun + Minigun, Ablative Shell, Shield Projector + Sensor Array + EMP Charge), bespoke BrottBrain with 8 Behavior Cards tuned to punish common player strategies.
+**Decision:** Fixed boss — a single handcrafted "Champion Brott" named **[TBD — "IRONCLAD PRIME" is a placeholder, to be workshopped]** — Fortress chassis, max loadout (Railgun + Minigun, Ablative Shell, Shield Projector + Sensor Array + EMP Charge), hardcoded baseline AI (see §A.8) tuned to punish common player strategies.
 
-**Why fixed:** Simple to build, no RNG in the most climactic moment, lets HCD tune it as a puzzle. The boss should feel *known* — players will talk about "beating IRONCLAD PRIME" not "beating a random boss." Personality > variety at the end of the run.
+**Why fixed:** Simple to build, no RNG in the most climactic moment, lets HCD tune it as a puzzle. The boss should feel *known* — players will talk about "beating [the boss]" not "beating a random boss." Personality > variety at the end of the run.
 
-**Alternative:** Small pool of 3 bosses, randomly selected at run start — adds replayability at the cost of one sprint of extra work and the need to balance 3 distinct puzzles instead of 1.
+**Boss AI behavior (hardcoded rules):**  
+Kites low-HP players. Fires EMP when player's modules are active. Engages aggressively at full health, switches to shield-projection when below 40%. Prioritizes distance management — never lets the player dictate the range. Multi-target rules do not apply (1v1 encounter only).
 
----
-
-### A.2 Run Difficulty Curve ⚠️
-
-**Recommendation:** 4 difficulty tiers spread across 15 battles, using the existing `opponent_loadouts.gd` template pool (re-framed as an encounter pool, not a league ladder).
-
-| Battles | Tier | Template pool | BrottBrain complexity |
-|---------|------|---------------|----------------------|
-| 1–3 | Tier 1 | `tank_tincan`, Scrapyard-legal pool | 0–1 Behavior Cards, single weapon |
-| 4–7 | Tier 2 | Bronze-tier templates | 1–2 Behavior Cards, armor + 1 module |
-| 8–11 | Tier 3 | Silver-tier templates | 3–4 Behavior Cards, full loadouts |
-| 12–14 | Tier 4 | Silver-4 templates (Disruptor, Aegis, Chrono) | 5–6 Behavior Cards, counter-builds |
-| 15 | Boss | IRONCLAD PRIME (or boss pool — see §A.1) | 8 Behavior Cards, max loadout |
-
-**Key principle:** No stat inflation. Difficulty comes from harder BrottBrains and better loadouts, exactly as before — the same balance invariant from the original GDD §6.2 holds.
-
-**Variety rule carries forward:** no two consecutive encounters share the same archetype (TANK/GLASS_CANNON/SKIRMISHER/BRUISER/CONTROLLER). State lives on `RunState._last_opponent_archetype` (new field on the new RunState; see §B).
-
-**Alternative:** Purely random from the full pool each battle, letting difficulty vary wildly. Simpler code, but the ramp-up feel disappears — early battles can be unfair hard. Not recommended.
+**Name TBD:** HCD to workshop the boss name. Design structure is locked; only the name is pending.
 
 ---
 
-### A.3 Reward Pool Composition ⚠️
+### A.2 Run Difficulty Curve
+_Locked by HCD 2026-04-25 (expanded from v1 recommendation to incorporate encounter shapes)_
 
-**Recommendation:** Tiered by run progress — same tier bands as the difficulty curve.
+**Decision:** 4 difficulty tiers spread across 15 battles. Each tier defines a **distribution of encounter archetypes** (see §A.9 for the full archetype library) — not just a template pool slice. Difficulty is a product of both opponent build tier AND encounter shape complexity.
 
-| Battles won | Legal reward items |
-|-------------|-------------------|
-| 1–3 | Tier 1–2 weapons, Plating/Reactive Mesh, Overclock/Repair Nanites/Sensor Array |
-| 4–7 | + Tier 3 weapons (Flak Cannon, Arc Emitter), Shield Projector, Afterburner |
-| 8–14 | Full item pool (Railgun, Missile Pod, Ablative Shell, EMP Charge) |
-| Boss fight | No reward — run end |
+| Battles | Tier | Encounter archetype distribution | Opponent loadout tier |
+|---------|------|----------------------------------|----------------------|
+| 1–3 | Tier 1 | 80% Standard Duel / 20% Small Swarm | Single-weapon, 0–1 modules |
+| 4–7 | Tier 2 | 50% Standard Duel / 25% Small Swarm / 15% Glass-Cannon Blitz / 10% Mini-boss+Escorts | Full weapon + armor + 1–2 modules |
+| 8–11 | Tier 3 | 20% Standard Duel / 30% Small Swarm / 20% Large Swarm / 20% Counter-Build Elite / 10% Mini-boss+Escorts | Full loadouts, counter-tuned |
+| 12–14 | Tier 4 | 10% Standard Duel / 20% Large Swarm / 30% Counter-Build Elite / 20% Mini-boss+Escorts / 20% Glass-Cannon Blitz | Silver-tier templates, Disruptor/Aegis/Chrono builds |
+| 15 | Boss | IRONCLAD PRIME (always) | Max loadout, hardcoded boss AI |
 
-**Why tiered:** Prevents first-battle Railgun pulls that skip the build arc. The power fantasy is building toward something — early rewards should feel like upgrades, not windfalls.
+**Key principle:** No stat inflation. Difficulty comes from harder opponent loadouts + encounter shape complexity. The balance invariant holds.
 
-**Mechanics:** Present 3 random items from the legal pool (deduped against currently-owned items). Player picks 1. Unpicked options are discarded — no "bank" or "defer." If the player already owns all legal items in a tier, backfill from the tier below.
+**Variety rule:** No two consecutive encounters may share the same archetype. State tracked on `RunState._last_encounter_archetype` (new field). If the archetype picker would repeat, re-roll once.
 
-**Alternative:** Full item pool from battle 1. Simpler. Occasionally delightful (first-battle Railgun pick), occasionally feels unfair (Tier-4 enemy on battle 2). Post-1.0 candidate if the tiered approach feels too restrictive during playtesting.
+**Run guarantee:** Each run guarantees at least one occurrence of: Small Swarm, Counter-Build Elite, and Mini-boss+Escorts (the three most tactically novel archetypes). Seeded into slots 5, 9, 12 at run generation, then shuffled within-tier constraints.
+
+**Multi-target implication:** The hardcoded baseline AI (§A.8) must handle swarm and escort encounters. Bot behavior in multi-target fights uses the priority system defined in §A.8.
 
 ---
 
-### A.4 Retry Mechanic Specifics ⚠️
+### A.3 Reward Pool Composition
+_Locked by HCD 2026-04-25 — **UNTIERED** (overrides Gizmo v1 tiered recommendation)_
 
-**Recommendation:** Retry restarts the **current battle only**, with the current build intact. No rewind to a prior battle. No item refund.
+**Decision:** Full item pool available from battle 1. No tier gates on rewards.
+
+**Rationale (HCD):** Windfall delight over tiered build-arc feel. A first-battle Railgun pull is exciting, not unfair — the player still has to win 14 more battles with whatever they've assembled.
+
+**Mechanics:** Present 3 random items from the full legal pool (deduped against currently-owned items). Player picks 1. Unpicked options discarded — no bank, no defer. If the player owns all items, backfill with a random item they already own (displayed as "Duplicate — spare parts" with no effect; a graceful edge case for long runs).
+
+**Swarm encounter rule:** "Battle won" = all enemies in the encounter are defeated. One reward pick per encounter regardless of encounter shape. Killing 3 swarm bots = one pick, not three.
+
+**Post-1.0 note:** If playtesting shows early-windfall creates trivially easy runs (Railgun on battle 1 makes everything face-rollable), revisit tiering then — not now. HCD locked this; don't second-guess it pre-playtest.
+
+---
+
+### A.4 Retry Mechanic Specifics
+_Locked by HCD 2026-04-25_
+
+**Decision:** Retry restarts the **current battle only**, with the current build intact. No rewind. No item refund.
 
 **Exact behavior:**
 - Player loses the battle → "DEFEAT" flash → UI shows: retry count remaining (e.g., "2 retries left"), button "Retry Battle" vs "Accept Loss (run ends if 0 retries)"
-- Retry: rematch against the same opponent template, same arena (re-rolled). Build is unchanged.
+- Retry: rematch against the same opponent template, same encounter shape, new arena seed. Build is unchanged.
 - After a retry win: battle counts as won — player gets the normal reward pick.
 - When retries = 0 and the player loses: run ends immediately. No retry prompt.
 
-**Why current-battle-only:** Simple to implement (reuse existing rematch flow). Rewind-to-prior-battle is more complex (must un-apply rewards) and potentially frustrating (losing two battles worth of progress). The player's build survives a retry, which is the meaningful form of "continuation."
-
-**Note:** Retries are per-run, not per-battle. 3 retries is the total budget. A player who uses 2 retries on battle 7 has only 1 left for the rest of the run.
-
-**Alternative:** Retry rewinds one full battle — lose the battle AND the previous reward pick. More punishing. Makes retry a heavier decision. Post-1.0 difficulty mode candidate.
+**Note:** Retries are per-run, not per-battle. A player who burns 2 retries on battle 7 has 1 left for the rest of the run.
 
 ---
 
-### A.5 Run-End UX ⚠️
+### A.5 Run-End UX
+_Locked by HCD 2026-04-25_
 
-**Recommendation:** Two screens — Loss Screen and Win Screen — with a shared Build Summary component.
+**Decision:** Two screens — Loss Screen ("BROTT DOWN") and Win Screen ("RUN COMPLETE") — with shared Build Summary component. Single "New Run" button on both.
 
 **Loss Screen ("BROTT DOWN"):**
 ```
@@ -131,7 +134,7 @@ Total run time target: **30–50 minutes** at normal pace.
 ```
 ╔═══════════════════════════════╗
 ║   🏆 RUN COMPLETE             ║
-║   IRONCLAD PRIME defeated!    ║
+║   [Boss name TBD] defeated!   ║
 ║   ─────────────────────────── ║
 ║   YOUR BUILD                  ║
 ║   [full loadout display]      ║
@@ -144,50 +147,177 @@ Total run time target: **30–50 minutes** at normal pace.
 ╚═══════════════════════════════╝
 ```
 
-**Stats shown:** Battles won, retries used, farthest battle reached (loss) or full win flag. No elaborate stat tracking — just enough to tell the story of the run. No persistent leaderboard in v1.0.
-
-**Single button:** "New Run" on both screens. No "Return to Menu." The loop is: play → result → play again.
-
-**Alternative:** Show full battle log (who won each battle, what items were picked). More information, more screen complexity. Deferred to post-1.0 polish.
+**Stats shown:** Battles won, retries used, farthest battle reached (loss) or full win flag. No persistent leaderboard in v1.0. Single "New Run" button on both — no "Return to Menu."
 
 ---
 
-### A.6 Onboarding ⚠️
+### A.6 Onboarding
+_Locked by HCD 2026-04-25 — cuts S21.2–S21.4 entirely_
 
-**Recommendation:** First-run contextual tooltips only. No tutorial battles, no forced teaching sequence.
+**Decision:** First-run contextual tooltips only. No tutorial battles. No forced teaching sequence.
 
-**First run only (tracked by `first_run_state.gd`, already exists):**
-1. **Run start screen:** One-sentence copy explaining the loop: *"Build your Brott. Battle 15 enemies. Die and you get 3 retries. Beat the boss to win the run."*
-2. **First reward pick:** Tooltip overlay on the reward cards: *"Pick one — it's yours for this run."*
-3. **First BrottBrain access:** If player opens the BrottBrain editor, tooltip: *"Drag cards to teach your Brott how to fight. It'll make its own decisions in battle."*
-4. **First retry prompt:** Tooltip: *"You've got [N] retries left this run. Use one here, or accept the loss."*
+**First run only (tracked by `first_run_state.gd`):**
+1. **Run start screen:** *"Build your Brott. Battle 15 enemies. Die and you get 3 retries. Beat the boss to win the run."*
+2. **First battle (before round starts):** *"Click the arena to send your Brott somewhere. Click an enemy to target them. Or just watch — it'll fight on its own."*
+3. **First reward pick:** Tooltip overlay on the reward cards: *"Pick one — it's yours for this run."*
+4. **First retry prompt:** *"You've got [N] retries left this run. Use one here, or accept the loss."*
 
-**No league onboarding copy.** The S21.2–S21.4 HUD onboarding work (league-surface overlays, first-encounter tooltips, shop scroll nudges) is **cut**. The roguelike loop is self-explanatory enough with run-scoped context tooltips.
+**No BrottBrain editor tooltip** — the editor is cut. No mention of cards, programming, or BrottBrain as a player-facing concept.
 
-**Alternative:** Zero onboarding — just throw the player in. Battlebrotts is simple enough that this might work. Revisit after first playtest.
+**No league onboarding copy.** S21.2–S21.4 HUD onboarding work is cut entirely.
 
 ---
 
-### A.7 Visual Identity for "This is a Run" ⚠️
+### A.7 Visual Identity for "This is a Run"
+_Locked by HCD 2026-04-25_
 
-**Recommendation:** Run HUD elements — persistent indicators that frame the run context while the player is mid-run.
+**Decision:** Run HUD elements — persistent indicators that frame the run context while the player is mid-run.
 
 **Run Status Bar (top of every non-arena screen during a run):**
 ```
 [⚔️ Battle 6 of 15]  [💀 2 retries left]  [🔩 Build: Scout + Railgun + Ablative]
 ```
-- Appears on: reward pick screen, BrottBrain editor, the "ready" screen before each battle
+- Appears on: reward pick screen, run start screen, the "ready" screen before each battle
 - Disappears on: loss screen, win screen, main menu
 - Color shift: Battle counter turns amber at battle 12 (approaching boss zone), red at battle 14
 
-**Run framing at menu:**
-- Main menu shows "▶ Continue Run (Battle 6/15)" if a run is in progress — but note: v1.0 runs are **not persistent** (no save/resume). Once you close the browser tab, the run is gone. This button is for mid-session "go back to menu temporarily" only.
-
 **Reward pick screen:** Background color shift per tier. Battles 1–3: grey-blue (salvage vibe). Battles 4–7: bronze tint. Battles 8–14: silver-white. Boss fight prep: red/gold.
 
-**Why this works:** The run status bar is the single clearest signal. Players always know where they are. The background tinting adds atmosphere without requiring new art.
+**Main menu:** Shows "▶ Continue Run (Battle 6/15)" if a run is in progress mid-session. Note: v1.0 runs are **not persistent** (no save/resume across sessions). In-session only.
 
-**Alternative:** No persistent run bar — just show a "Battle N / 15" label at the start of each arena match. Minimal. Works. But the player has no run-context between battles (during reward pick). Not recommended.
+---
+
+### A.8 Bot Arena Control Scheme & Baseline AI
+_Q2 — Locked by HCD 2026-04-25 — **replaces BrottBrain editor entirely**_
+
+**Decision:** Bot Arena two-click control during battle. BrottBrain editor is cut in full. The bot fights autonomously via hardcoded baseline AI; the player has exactly two direct intervention affordances.
+
+#### Two-click affordances
+
+**Click 1 — Click-to-Move:** Click anywhere on the arena floor → player bot navigates to that point. Once at the waypoint, bot resumes autonomous behavior (engage nearest enemy, apply baseline AI rules).
+
+**Click 2 — Click-to-Target:** Click on an enemy bot → that enemy becomes the forced target. Bot fights autonomously against it until the target dies or the player issues a new override.
+
+Player can intervene at any time or sit back entirely and watch autonomous combat. The two affordances correspond exactly to the two interventions a player naturally wants: *"go over there"* and *"shoot that one."* In swarm encounters, click-to-target becomes a genuine tactical decision (prioritize escorts or boss?). The scheme holds cleanly at 1v1, 1v3, and 1v8.
+
+#### Q2-derivative design decisions (all resolved)
+
+| # | Question | Decision |
+|---|---|---|
+| 1 | Click-to-move duration | Bot moves to waypoint then resumes autonomous. No timer. Override ends on arrival. |
+| 2 | Click-to-target duration | Until target dies OR player issues a new move or target override. |
+| 3 | Visual feedback | **Waypoint:** yellow diamond marker at clicked floor position, fades on arrival. **Target:** orange reticle ring on targeted enemy, persists while override active. **Bot state:** pulsing outline on player bot during any active override (yellow = moving, orange = targeting). |
+| 4 | Module triggering | **Auto-fired by baseline AI.** Repair Nanites fire at <30% HP. EMP fires when enemy is within 3 tiles. Afterburner fires when HP <40% and enemy is adjacent. No player-facing module buttons. Simplest viable. |
+| 5 | Click rate-limit | **Unlimited.** No cooldown. Rapid clicks = player engaged and tactics. Never punish engagement. |
+| 6 | Click priority hierarchy | **Latest click wins entirely.** No queue. New click immediately cancels prior override and executes. If you click move mid-target-override, bot abandons target and moves. If you click target mid-move, bot stops and targets. Clean, instant, no ambiguity. |
+
+#### Hardcoded baseline AI behavior
+
+The BrottBrain *runtime* concept is preserved — bots still have internal AI making decisions — but the card-driven system is replaced with hardcoded rules. The player cannot modify these rules.
+
+**Default engagement loop:**
+1. Identify closest enemy within attack range → attack
+2. If no enemy in range → advance toward nearest enemy
+3. If HP < 40% and enemy is melee range → attempt to create distance (kite)
+4. Apply module auto-fire rules (see above)
+
+**Multi-target priority (swarm/escort encounters):**
+- Default: attack nearest enemy
+- If an enemy is within melee range of the player bot, it becomes the priority target (override nearest rule)
+- If two enemies are equidistant, attack the lower-HP one (focus-fire the weakest)
+- Player click-to-target overrides all priority rules for the duration of the override
+
+**Boss AI (IRONCLAD PRIME / TBD name):** Separate hardcoded behavior set — see §A.1. Does not share baseline AI rules.
+
+#### What is cut
+
+The BrottBrain editor (card-based visual editor) is **cut entirely**. No drag-and-drop, no Trigger/Action cards, no 8-slot system, no BrottBrain unlock gate, no BrottBrain editor onboarding tooltips. The word "BrottBrain" does not appear in any player-facing UI.
+
+The underlying `brottbrain.gd` class is **re-implemented** as a hardcoded baseline AI engine (same class name, same interface, different internals). See Section B for full cut/re-skin inventory.
+
+---
+
+### A.9 Encounter Shape Library
+_NEW — Locked by HCD 2026-04-25 ("anything is fair game for Gizmo to design")_
+
+Encounters are no longer exclusively 1v1. Seven encounter archetypes form the shape vocabulary for all 15 battles. Each archetype has distinct tactical characteristics, implementation requirements, and a defined place in the tier distribution (§A.2).
+
+---
+
+#### Archetype 1: Standard Duel
+**Format:** 1 vs 1  
+**Example composition:** Player Brott vs one opponent template (tier-matched)  
+**What makes it distinctive:** The baseline. No multi-target complexity. Pure 1v1 combat performance — loadout vs loadout, AI vs AI (with player click-to-target intervention).  
+**Design intent:** Establish baseline difficulty. Comfortable early on; by Tier 4, the Tier-4 opponent is a genuine threat even 1v1. Used in 80% of Tier 1 encounters so new players find their footing.
+
+---
+
+#### Archetype 2: Small Swarm
+**Format:** 1 vs 3  
+**Example composition:** Player vs 3 Scout-class bots, each at ~45% normal HP (individual threat low, collective DPS moderate)  
+**What makes it distinctive:** First encounter with multi-target combat. Click-to-target becomes a real decision — pick the nearest flanker, the one that's low, or the one that's kiting you. Baseline AI prioritizes nearest; player can override.  
+**Design intent:** Introduce multi-target mechanics gently. The swarm is beatable by watching the AI handle it, but optimal play (target the weakest first, avoid letting them surround) rewards engagement. Three enemies die in roughly 3 distinct phases.
+
+---
+
+#### Archetype 3: Large Swarm
+**Format:** 1 vs 5–6  
+**Example composition:** Player vs 5 Micro-Scout-class bots, each at ~20% normal HP (individually trivial, collectively lethal if ignored)  
+**What makes it distinctive:** Pure chaos. The arena is full of bots. Click-to-target matters a lot here — the baseline AI will pick off bots one at a time; good targeting focuses the weakest cluster to prevent being surrounded. Audio is a stress test (lots of hit SFX). Visually overwhelming by design.  
+**Design intent:** Peak variety encounter. Short but intense. Should feel like a "holy shit" moment. Appears only in Tier 3+ to ensure players have enough HP/modules to survive the burst.
+
+---
+
+#### Archetype 4: Mini-Boss + Escorts
+**Format:** 1 vs 1 (strong) + 2 (weak)  
+**Example composition:** Player vs one Fortress-class bot at ~130% normal HP + 2 Scout flankers at ~60% normal HP  
+**What makes it distinctive:** Forces a target priority decision with real consequences. Kill escorts first (remove flanking pressure, then 1v1 the Fortress) or burn down the Fortress fast (ignore escorts' chip damage). Neither is obviously correct — depends on player build. Click-to-target is the key skill expression.  
+**Design intent:** The tactically richest standard encounter. Tests whether the player is engaged or just watching. The "correct" priority depends on the player's chassis and loadout, creating implicit build-narrative moments.
+
+---
+
+#### Archetype 5: Counter-Build Elite
+**Format:** 1 vs 1 (hand-tuned)  
+**Example composition:** Player vs one hand-authored opponent designed to punish the most common player build strategies:
+- *Anti-Range Elite:* Fortress chassis, EMP Charge + high mobility module — punishes players sitting at range with Railgun/Missile Pod
+- *Anti-Melee Elite:* Scout chassis, Afterburner + Sensor Array — punishes players rushing in with Shotgun/Flak Cannon
+- *Anti-Module Elite:* EMP-heavy Brawler that strips modules aggressively  
+
+At encounter generation time, the system picks the elite type that counters the player's current build. If no strong counter exists (player build is balanced), pick Anti-Range as default.  
+**What makes it distinctive:** It "knows" your build. Players will feel targeted — in a fun way. Teaches that no build is perfectly universal.  
+**Design intent:** Pressure-test the player's adaptation reflex. The encounter is beatable even by the "wrong" build if the player uses click-to-target intelligently (kite, control range, pick off before the counter advantage kicks in).
+
+---
+
+#### Archetype 6: Glass-Cannon Blitz
+**Format:** 1 vs 1 (fragile / high offense)  
+**Example composition:** Player vs Scout chassis, 2 weapons (Flak Cannon + Arc Emitter), no armor, no modules — maximum DPS, paper-thin HP (≈40% normal HP)  
+**What makes it distinctive:** An all-or-nothing opponent. If left to fire freely for 10 seconds, it shreds. But it dies extremely fast. Tests the player's ability to immediately engage (click-to-target + click-to-advance) rather than letting the AI manage pace. Opposite feel from a Fortress duel.  
+**Design intent:** Introduce time pressure. Great for mid-Tier variety (Tier 2–4). Rewards an aggressive approach. Very satisfying kill once the player learns "go at it immediately."
+
+---
+
+#### Archetype 7: Boss
+**Format:** 1 vs 1 (IRONCLAD PRIME — name TBD)  
+**Example composition:** Fortress chassis, Railgun + Minigun, Ablative Shell, Shield Projector + Sensor Array + EMP Charge. Hardcoded boss AI (§A.1).  
+**What makes it distinctive:** The climax. Always battle 15. Always this opponent. Hand-tuned to be hard but fair at a median run build (target: <40% first-attempt win rate at Tier-3 average build in combat sim).  
+**Design intent:** The conversation-worthy moment. "I finally beat [boss name]" is the loop closer. Players should feel they earned it.
+
+---
+
+**Archetype implementation checklist (for Arc F planning):**
+
+| Archetype | Arena renderer changes | Baseline AI changes | Data requirements |
+|---|---|---|---|
+| Standard Duel | None (existing 1v1) | None | None |
+| Small Swarm | Render 3 enemy bots | Multi-target priority rules | 3x lightweight templates |
+| Large Swarm | Render 5–6 enemy bots | Same as swarm, optimized for density | 5–6x micro templates |
+| Mini-boss + Escorts | Render 3 enemy bots, mixed chassis sizes | Multi-target priority (distinguish escort vs boss) | 1x Fortress template, 2x Scout templates |
+| Counter-Build Elite | None (1v1 renderer) | None (hardcoded opponent AI) | 3 authored elite loadouts |
+| Glass-Cannon Blitz | None (1v1 renderer) | None | 1 authored loadout |
+| Boss | None (1v1 renderer) | Boss-specific hardcoded rules | 1 authored boss loadout |
+
+Multi-target archetypes (Swarms, Mini-boss) require arena renderer extension (§B Re-skin) and multi-target baseline AI (§A.8). These are the core new implementation work in Arc F.
 
 ---
 
@@ -197,25 +327,23 @@ Total run time target: **30–50 minutes** at normal pace.
 
 | System | File(s) | Rationale |
 |--------|---------|-----------|
-| **Battle engine** | `godot/arena/arena_renderer.gd`, `godot/arena/charm_anims.gd`, `godot/game/opponent_data.gd` | This IS the game. Polish target, not a cut candidate. |
-| **Combat sim** | `godot/tests/combat_batch.gd`, `godot/tests/combat_batch_brain.gd` | Balance verification stays essential. |
+| **Battle engine** | `godot/arena/arena_renderer.gd`, `godot/arena/charm_anims.gd`, `godot/game/opponent_data.gd` | This IS the game. Polish target. |
+| **Combat sim** | `godot/tests/combat_batch.gd`, `godot/tests/combat_batch_brain.gd` | Balance verification stays essential. Update to support multi-target encounters. |
 | **Chassis system** | `godot/data/chassis_data.gd` | Scout / Brawler / Fortress archetypes unchanged. |
 | **Weapon system** | `godot/data/weapon_data.gd` | Full weapon roster retained. |
 | **Armor system** | `godot/data/armor_data.gd` | Full armor roster retained (league-degradation table becomes unused but harmless). |
 | **Module system** | `godot/data/module_data.gd` | Full module roster retained. |
-| **BrottBrain system** | `godot/ui/brottbrain_screen.gd` | The main player expression surface. Keep as-is; remove the "BrottBrain unlocks at Bronze" gate — it's always available from battle 1 in the roguelike. |
-| **Behavior Cards** | All card data in `chassis_data.gd` / `brottbrain_screen.gd` | Keep all Trigger + Action cards. No cuts. |
 | **Loadout display** | `godot/ui/loadout_screen.gd` | Becomes "Current Build" — minimal re-label, same data. |
-| **Result screen** | `godot/ui/result_screen.gd` | Re-skin per §A.5 spec. Core structure (won/lost banner + continue button) stays; extend with build summary + run stats. |
+| **Result screen** | `godot/ui/result_screen.gd` | Re-skin per §A.5 spec. Core structure stays; extend with build summary + run stats. |
 | **Item data + token router** | `godot/data/item_tokens.gd` | Reward pick system will use this to grant items. |
-| **Audio: SFX + menu music** | `godot/assets/audio/sfx/*`, `godot/assets/audio/music/menu_loop.ogg` | Menu loop applies to roguelike main menu. Hit/death/crit SFX stay. Win chime stays. |
-| **BrottBrain Trick Choices** | `godot/ui/trick_choice_modal.gd`, `godot/data/trick_choices.gd` | These become **in-run random events** — a natural fit for the roguelike. Re-skin context copy, keep mechanic. |
+| **Audio: SFX + menu music** | `godot/assets/audio/sfx/*`, `godot/assets/audio/music/menu_loop.ogg` | Menu loop applies to roguelike main menu. All combat SFX stay. |
+| **BrottBrain Trick Choices** | `godot/ui/trick_choice_modal.gd`, `godot/data/trick_choices.gd` | In-run random events — natural roguelike fit. Re-skin context copy, keep mechanic. |
 | **Arena types** | Arena definitions (The Pit, Junkyard, Foundry) | All three arenas used as encounter rotation. Randomly assigned per battle. |
-| **Main menu + settings** | `godot/ui/main_menu_screen.gd`, `godot/ui/mixer_settings_panel.gd` | Keep. Main menu needs minor run-framing additions (§A.7). Settings unchanged. |
-| **Audio infrastructure** | `godot/tests/test_s21_5_*`, `test_s24_*` bus routing tests | Keep all audio tests — they verify infrastructure that doesn't change. |
+| **Main menu + settings** | `godot/ui/main_menu_screen.gd`, `godot/ui/mixer_settings_panel.gd` | Keep. Main menu needs minor run-framing additions (§A.7). |
 | **Bot preview** | `godot/ui/bot_preview.gd` | Keep — used in loadout display and reward pick. |
 | **`first_run_state.gd`** | `godot/ui/first_run_state.gd` | Keep — drives first-run tooltip logic (§A.6). |
 | **Test infrastructure** | `godot/tests/test_runner.gd`, `test_util.gd`, `pacing_verify.gd` | All test infra kept. |
+| **Opponent template data** | `godot/data/opponent_loadouts.gd` (data only) | Re-skinned (see below) — template records kept, league indexing replaced. |
 
 ---
 
@@ -223,19 +351,21 @@ Total run time target: **30–50 minutes** at normal pace.
 
 | System | File(s) | Rationale |
 |--------|---------|-----------|
-| **League Complete Modal** | `godot/ui/league_complete_modal.gd`, `godot/ui/league_complete_modal.tscn` | No leagues. Cut. |
-| **Opponent Select Screen** | `godot/ui/opponent_select_screen.gd` | Opponents are served by the run engine, not player-selected. Cut. |
-| **League progression logic** | `GameState._check_progression()`, `advance_league()`, `bronze_unlocked`, `silver_unlocked`, all `opponents_beaten` / `first_wins` logic | Replace with run-lifecycle methods on new `RunState`. |
-| **Economy (Bolts / shop purchases)** | `GameState.buy_*()`, `WEAPON_PRICES`, `ARMOR_PRICES`, `MODULE_PRICES`, `CHASSIS_PRICES`, `bolts` field | No shop in v1.0 roguelike. Items come from reward picks, not purchase. |
-| **Repair cost system** | `apply_match_result()` repair cost logic | No repair in roguelike. Win = reward pick. Lose = retry spend. |
-| **Shop screen** | `godot/ui/shop_screen.gd` | No shop. Cut. (Item grant / trick system still exists but is not a purchasable storefront.) |
-| **HUD onboarding (S21.2–S21.4)** | `godot/tests/test_s21_2_*`, `test_s21_4_*` — specifically league-surface and first-encounter overlays | League-surface tooltips, scroll-nudges, inline captions: cut. First-run state infra (`first_run_state.gd`) is kept; only the league-specific tooltip content is removed. |
-| **League-degradation table** | `ArmorData.REFLECT_DAMAGE_BY_LEAGUE`, `reflect_damage_for_league()` | No leagues. Can be stripped or left dormant. Lean toward stripping to reduce confusion. |
-| **BrottBrain unlock gate** | `GameState.brottbrain_unlocked`, `go_to_brottbrain()` unlock check in `game_flow.gd` | BrottBrain is always available from battle 1. Remove the gate entirely. |
-| **Arc C narrative beats** | Any narrative beat copy, modal scripts, or event popups tied to league transitions | Cut. HCD confirmed: "cut regardless of design." |
-| **Sentinel feature (Arc D)** | Any Arc D sentinel-related code if committed | Cut — does not serve the roguelike's battle-focused loop. |
+| **BrottBrain editor screen** | `godot/ui/brottbrain_screen.gd` + all associated `.tscn` scenes | Editor cut in full. Replaced by hardcoded baseline AI. No player-facing editor. |
+| **BrottBrain unlock gate** | `GameState.brottbrain_unlocked`, unlock check in `game_flow.gd` | Editor doesn't exist. Gate is moot. Remove. |
+| **Behavior Card content** | All Trigger/Action card definitions in `brottbrain_screen.gd` `TRIGGER_DISPLAY` / `ACTION_DISPLAY` tables | No longer player-facing. Cut as UI content. Underlying `BrottBrain.Trigger` / `Action` enums may be repurposed or deleted. |
+| **League Complete Modal** | `godot/ui/league_complete_modal.gd`, `.tscn` | No leagues. Cut. |
+| **Opponent Select Screen** | `godot/ui/opponent_select_screen.gd` | Opponents served by run engine, not player-selected. Cut. |
+| **League progression logic** | `GameState._check_progression()`, `advance_league()`, `bronze_unlocked`, `silver_unlocked`, `opponents_beaten`, `first_wins` | Replace with run-lifecycle on new `RunState`. |
+| **Economy (Bolts / shop)** | `GameState.buy_*()`, all price tables, `bolts` field, `shop_screen.gd` | No shop. Items from reward picks only. |
+| **Repair cost system** | `apply_match_result()` repair cost logic | No repair in roguelike. |
+| **HUD onboarding (S21.2–S21.4)** | `godot/tests/test_s21_2_*`, `test_s21_4_003_league_surface.gd`, `test_s21_3_arena_onboarding.gd` | League-surface onboarding fully cut. `first_run_state.gd` infra kept; only league-specific content removed. |
+| **League-degradation table** | `ArmorData.REFLECT_DAMAGE_BY_LEAGUE`, `reflect_damage_for_league()` | No leagues. Strip to reduce confusion. |
+| **Arc C narrative beats** | Any league-transition story modals, narrative copy, popup scripts | HCD: "cut regardless of design." |
+| **Sentinel feature (Arc D)** | Any committed Arc D sentinel code | Does not serve battle-focused loop. |
+| **BrottBrain editor onboarding** | S21.2–S21.4 editor-specific tutorial work | Editor cut; onboarding is moot. Subsumed by §A.6 two-click tooltip. |
+| **Multi-format matches** | 2v2 / 3v3 logic in GameState / GameFlow | v1.0 is 1vN (player solo always). Team format code cut. |
 | **`first_wins` bonus system** | `GameState.first_wins[]`, first-win bolt bonus logic | No economy. Cut. |
-| **Multi-format matches (2v2, 3v3)** | `GameState` / `GameFlow` logic for team matches | v1.0 is 1v1 only. Cut the team format code. |
 
 ---
 
@@ -243,70 +373,75 @@ Total run time target: **30–50 minutes** at normal pace.
 
 | System | Current | Becomes | Files to modify |
 |--------|---------|---------|-----------------|
-| **`opponent_loadouts.gd`** | League-gated template pool, `difficulty_for(league, index)` | **Run encounter pool** — `difficulty_for(battle_index)` maps battle 1–15 to tiers 1–4 (see §A.2). Remove `unlock_league` filter; add `battle_index_to_tier()` helper. | `godot/data/opponent_loadouts.gd` |
-| **`GameState`** | Tracks bolts, owned items, league progression | **RunState (rename/replace)** — tracks current build (chassis + equipped items), retry count, battles won, current battle index. No economy. | `godot/game/game_state.gd` → `run_state.gd` |
-| **`GameFlow`** | Menu → Shop → Loadout → BrottBrain → OpponentSelect → Arena → Result | **Run flow**: Menu → RunStart (chassis pick) → [RewardPick → BrottBrain? → Arena] × 15 → BossArena → RunEnd | `godot/game/game_flow.gd` |
-| **`ResultScreen`** | "VICTORY / DEFEAT" + bolts earned | Per §A.5 — "BROTT DOWN / RUN COMPLETE" with build summary + run stats. Same file, significant copy/data changes. | `godot/ui/result_screen.gd` |
-| **`MainMenuScreen`** | Title + New Game | + Run Status Bar (§A.7) + "Continue Run" (mid-session only) | `godot/ui/main_menu_screen.gd` |
-| **Trick Choice Modal** | Scrapyard-only event; bolts/HP/item effects | **In-run random event** — fires occasionally between battles (every 3–4 battles, random). Same mechanic, same BrottBrain voice. Re-frame copy from "Scrapyard" to run context. | `godot/ui/trick_choice_modal.gd`, `godot/data/trick_choices.gd` — copy only |
-| **`LoadoutScreen`** | Full inventory management + purchase flow | **Current Build display** — read-only view of current run loadout. No buy button. Equip/unequip still works (player can rearrange what they have). | `godot/ui/loadout_screen.gd` |
-| **Reward Pick** | Does not exist (was shop) | **New screen: `reward_pick_screen.gd`** — presents 3 random items post-battle-win, player picks 1, item is immediately added to build. Uses `item_tokens.gd` for resolution. | NEW: `godot/ui/reward_pick_screen.gd` |
-| **Run Start** | Does not exist (was "New Game → Shop") | **New screen: `run_start_screen.gd`** — picks starter chassis, shows first-run tooltip (§A.6). May offer a random 3-chassis pick (⚠️ design question embedded in §A.7 starter pick). | NEW: `godot/ui/run_start_screen.gd` |
+| **`brottbrain.gd`** | Card-driven behavior engine (evaluates Trigger/Action cards) | **Hardcoded baseline AI** — same class name, same public API (`get_action()`, `set_target()`), completely different internals. New multi-target priority logic (§A.8). | `godot/brain/brottbrain.gd` — gut and rewrite internals |
+| **`arena_renderer.gd`** | Renders exactly 2 bots (1 player, 1 enemy) | **Multi-target renderer** — render N enemy bots (up to 8). Add click-overlay layer: waypoint diamond, target reticle, bot override-active indicator. | `godot/arena/arena_renderer.gd` — extend bot array, add click layer |
+| **`opponent_loadouts.gd`** | League-gated template pool | **Run encounter pool** — `difficulty_for(battle_index)` maps 1–15 to tiers. Add encounter archetype tags per template. Add `archetype_for(battle_index, last_archetype)` generator with no-repeat rule. | `godot/data/opponent_loadouts.gd` |
+| **`GameState`** | Tracks bolts, owned items, league progression | **RunState (rename)** — tracks current build, retry count, battles won, current battle index, last encounter archetype. | `godot/game/game_state.gd` → `run_state.gd` |
+| **`GameFlow`** | Menu → Shop → Loadout → BrottBrain → OpponentSelect → Arena → Result | **Run flow**: Menu → RunStart → [RewardPick → Arena] × 15 → BossArena → RunEnd | `godot/game/game_flow.gd` |
+| **`ResultScreen`** | "VICTORY / DEFEAT" + bolts earned | Per §A.5 — "BROTT DOWN / RUN COMPLETE" with build summary + run stats. | `godot/ui/result_screen.gd` |
+| **`LoadoutScreen`** | Full inventory management + purchase flow | **Current Build display** — read-only view of run loadout. No buy button. Equip/unequip for item rearrangement only. | `godot/ui/loadout_screen.gd` |
+| **Reward Pick** | Does not exist (was shop) | **New screen: `reward_pick_screen.gd`** — 3 random items post-battle-win, player picks 1, immediately added to build. Full pool from battle 1 (§A.3). | NEW: `godot/ui/reward_pick_screen.gd` |
+| **Run Start** | Does not exist (was "New Game → Shop") | **New screen: `run_start_screen.gd`** — random 3-chassis pick, first-run tooltip. | NEW: `godot/ui/run_start_screen.gd` |
+| **Trick Choice Modal** | Scrapyard-only event | **In-run random event** — fires every 3–4 battles. Re-frame copy from "Scrapyard" to run context. | `godot/ui/trick_choice_modal.gd`, `godot/data/trick_choices.gd` — copy only |
 
 ---
 
-## Section C — Roadmap Proposal
+## Section C — Roadmap
 
-### Arc F — Roguelike Core Loop (Target: ~6–8 sub-sprints)
+### Arc F — Roguelike Core Loop (Target: ~8–10 sub-sprints)
+_Up from v1's 6–8: +2 sub-sprints for encounter shape implementation, multi-target AI, and click-overlay_
 
-**Goal:** Wire the complete roguelike run loop end-to-end — run start → battles → reward pick → boss → run end screens. The full flow should be playable with no dead ends.
+**Goal:** Wire the complete roguelike run loop end-to-end — run start → battles (all encounter shapes) → reward pick → boss → run end. Multi-target encounters playable. Click-to-move and click-to-target functional.
 
-**Sub-sprint estimate:** 6–8 (new screens + flow rewire + RunState + encounter pool)
+**Sub-sprint breakdown:**
+- RunState + GameFlow rewire (2 sub-sprints)
+- RewardPick screen + RunStart screen (2 sub-sprints)
+- Hardcoded baseline AI + multi-target priority (2 sub-sprints)
+- Arena renderer extension (N enemies + click overlay layer) (2 sub-sprints)
+- Encounter archetype system + distribution logic (1 sub-sprint)
+- Boss loadout authoring + IRONCLAD PRIME AI (1 sub-sprint)
 
 **Hard exit criteria:**
-1. Player can start a run, battle through all 15 encounters, and reach the boss
-2. Reward pick screen works — 3 items shown, 1 selected, immediately applied to build
+1. Player can start a run, battle through all 15 encounters (including ≥1 swarm + ≥1 mini-boss), and reach the boss
+2. Reward pick screen works — 3 items shown, 1 selected, immediately applied
 3. Retry mechanic works — 3 retries tracked, run ends on 4th loss
-4. Run end screens (loss + win) display correctly with build summary
-5. `combat_batch.gd` simulations pass at >0% (engine still functional)
-6. No regressions on existing arena / combat tests
+4. Run end screens work with build summary
+5. Click-to-move and click-to-target functional in arena with correct visual feedback
+6. Multi-target renderer works for up to 6 enemies simultaneously
+7. `combat_batch.gd` simulations pass against multi-target encounter templates
+8. No regressions on existing arena / combat tests
 
-**Key dependencies:**
-- HCD approves §A.1–A.7 design questions before Arc F starts
-- IRONCLAD PRIME boss loadout + BrottBrain authored (can be simple first pass)
+**Key dependencies:** HCD greenlights this GDD (all 9 sections) before Arc F starts.
 
 ---
 
-### Arc G — Cut Pass (Target: ~3–4 sub-sprints)
+### Arc G — Cut Pass (Target: ~4–5 sub-sprints)
+_Up from v1's 3–4: +1 sub-sprint for the larger BrottBrain editor cut_
 
-**Goal:** Remove all dead code from the league-campaign era — shop, league progression, economy, opponent-select screen, narrative beats — leaving a clean codebase that only contains what the roguelike needs.
-
-**Sub-sprint estimate:** 3–4 (systematic file deletions + test suite cleanup)
+**Goal:** Remove all dead code — BrottBrain editor, league progression, shop, economy, opponent-select screen, narrative beats, S21.2–S21.4 test files, and associated test suite cleanup.
 
 **Hard exit criteria:**
-1. No references to `current_league`, `bronze_unlocked`, `opponents_beaten`, `bolts` in the active codebase (or they're harmlessly dormant and explicitly tagged `// DEPRECATED`)
-2. All deleted files removed from CI test matrix — no test failures from missing files
-3. `LeagueCompleteModal`, `OpponentSelectScreen`, `ShopScreen` scenes/scripts deleted
-4. Combat simulations still pass
+1. No references to `current_league`, `bronze_unlocked`, `opponents_beaten`, `bolts` in active codebase
+2. `BrottBrainScreen`, `LeagueCompleteModal`, `OpponentSelectScreen`, `ShopScreen` scenes/scripts deleted
+3. All deleted files removed from CI test matrix — no test failures from missing files
+4. Behavior Card `TRIGGER_DISPLAY` / `ACTION_DISPLAY` tables removed from codebase
+5. Combat simulations still pass
 
-**Key dependencies:** Arc F complete (avoids cutting things that Arc F still references mid-build)
+**Key dependencies:** Arc F complete (avoid cutting things Arc F still references mid-build)
 
 ---
 
 ### Arc H — Boss + Run Polish (Target: ~4–5 sub-sprints)
 
-**Goal:** IRONCLAD PRIME boss tuned to be a satisfying climax; visual run identity (§A.7) polished; first-playtest-ready build.
-
-**Sub-sprint estimate:** 4–5
+**Goal:** IRONCLAD PRIME (name TBD) tuned to be satisfying climax; visual run identity (§A.7) polished; first-playtest-ready build.
 
 **Hard exit criteria:**
-1. Boss is beatable but challenging — target <40% first-attempt win rate in combat sim at Tier-3 average player build
+1. Boss beatable but challenging — <40% first-attempt win rate in combat sim at Tier-3 average player build
 2. Run HUD bar (battle counter + retry indicator) visible and correct on all non-arena screens
-3. Background tinting per tier band implemented
-4. First-run tooltip flow works (§A.6)
-5. HCD playtests the full run and signs off
-
-**Key dependencies:** Arc F core loop complete; HCD available for playtest at arc close
+3. Background tinting per tier implemented
+4. First-run tooltip flow works (§A.6) including new two-click arena tooltip
+5. All 7 encounter archetypes authored and tested
+6. HCD playtests full run and signs off
 
 ---
 
@@ -314,19 +449,15 @@ Total run time target: **30–50 minutes** at normal pace.
 
 **Goal:** Final CI/deploy cleanup, performance verification, browser-export polish. Ship v1.0.
 
-**Sub-sprint estimate:** 2–3
-
 **Hard exit criteria:**
 1. HTML5 export loads in <5s on a mid-range device
 2. All CI tests green
 3. No known P0/P1 bugs
 4. HCD final sign-off
 
-**Key dependencies:** Arc H complete + HCD playtest pass
-
 ---
 
-**Total pipeline estimate:** ~15–20 sub-sprints, ~2 weeks of pipeline clock time.
+**Total pipeline estimate:** ~17–22 sub-sprints (up from v1's 15–20). Increase absorbed by encounter shape design + multi-target systems + larger BrottBrain cut.
 
 ---
 
@@ -335,33 +466,38 @@ Total run time target: **30–50 minutes** at normal pace.
 If any of the following tripwires fires during Arcs F–I, Riv **must escalate to The Bott** before proceeding. No agent may self-authorize work that crosses a tripwire.
 
 **Tripwire 1: No new items or weapons.**  
-The existing item roster (7 weapons, 3 armors, 6 modules) is the v1.0 set. If any sprint plan proposes adding a new item type, new weapon, new chassis variant, or new module → STOP. Escalate.
+The existing item roster (7 weapons, 3 armors, 6 modules) is the v1.0 set. Any proposal to add a new item type, weapon, chassis variant, or module → STOP. Escalate.
 
 **Tripwire 2: No meta-progression.**  
-No persistent unlock trees, no "earned items carry across runs," no experience points, no persistent currency, no unlockable starting configurations. If any feature requires data that survives between runs → STOP. Escalate. (HCD locked this explicitly: "no, too complex.")
+No persistent unlock trees, no items that carry across runs, no experience points, no persistent currency. Any feature requiring data that survives between runs → STOP. Escalate.
 
 **Tripwire 3: No narrative content.**  
-No cutscenes, no story beats, no opponent backstories, no dialogue beyond BrottBrain voice in trick events. If any sprint plan includes copy that advances a story → STOP. Escalate. (HCD locked: "cut regardless of design.")
+No cutscenes, story beats, opponent backstories, dialogue beyond BrottBrain voice in trick events. Any sprint plan including story-advancing copy → STOP. Escalate.
 
-**Tripwire 4: No new opponent archetypes or roster expansion.**  
-The 19-template encounter pool is sufficient for v1.0. Difficulty comes from tier progression and BrottBrain complexity, not from new templates. If a sprint proposes a new opponent template beyond IRONCLAD PRIME → STOP. Escalate.
+**Tripwire 4: No new opponent archetypes or roster expansion beyond the authored elite/boss set.**  
+The encounter pool + 3 authored elites + IRONCLAD PRIME is sufficient for v1.0. Any proposal for additional opponent templates beyond these → STOP. Escalate.
 
 **Tripwire 5: No team formats.**  
-v1.0 is 1v1 only. If any feature touches 2v2 or 3v3 logic → STOP. Escalate.
+v1.0 is 1vN (player solo). Any feature touching 2v2 or player-team logic → STOP. Escalate.
+
+**Tripwire 6: No BrottBrain editor revival. No new Behavior Card content.**  
+The card-based editor is cut. No drag-and-drop UI, no card slots, no Trigger/Action card system in any form, no "lite editor" or "minimal card system" variant. Any sprint plan that resurrects BrottBrain as a player-facing editor → STOP. Escalate. HCD rejected the editor explicitly and permanently; do not relitigate.
 
 ---
 
-## Appendix: Files Touched by the Pivot (Quick Reference)
+## Appendix: Files Touched by v1.0 Pivot + v2 Updates
 
 | Action | Files |
 |--------|-------|
-| Delete | `godot/ui/league_complete_modal.gd`, `league_complete_modal.tscn`, `opponent_select_screen.gd`, `shop_screen.gd` |
+| Delete | `godot/ui/brottbrain_screen.gd` + scenes, `league_complete_modal.gd/.tscn`, `opponent_select_screen.gd`, `shop_screen.gd` |
+| Gut + rewrite | `godot/brain/brottbrain.gd` (keep API, replace internals with baseline AI) |
+| Extend | `godot/arena/arena_renderer.gd` (N-enemy renderer + click overlay) |
 | Major rework | `godot/game/game_state.gd` → `run_state.gd`, `godot/game/game_flow.gd`, `godot/data/opponent_loadouts.gd`, `godot/ui/result_screen.gd` |
 | New files | `godot/ui/reward_pick_screen.gd`, `godot/ui/run_start_screen.gd` |
-| Minor rework | `godot/ui/main_menu_screen.gd`, `godot/ui/loadout_screen.gd`, `godot/ui/brottbrain_screen.gd` (remove BrottBrain unlock gate) |
-| Likely delete (test cleanup) | `godot/tests/test_s21_2_*`, `test_s21_4_003_league_surface.gd` |
-| Keep untouched | All arena, combat engine, BrottBrain card, audio, chassis/weapon/armor/module data files |
+| Minor rework | `godot/ui/main_menu_screen.gd`, `godot/ui/loadout_screen.gd` |
+| Delete (test cleanup) | `godot/tests/test_s21_2_*`, `test_s21_4_003_league_surface.gd`, `test_s21_3_arena_onboarding.gd` |
+| Keep untouched | All chassis/weapon/armor/module data files, audio assets, combat SFX, `first_run_state.gd`, `trick_choice_modal.gd` |
 
 ---
 
-*This GDD is the design input for Arc F. HCD approves the 7 open design questions (§A.1–A.7), then Arc F planning begins.*
+*This GDD v2 incorporates HCD decisions from `memory/2026-04-25-hcd-decisions-on-gdd-v1.md`. Ready for HCD greenlight review. On greenlight, Arc F planning begins.*

--- a/docs/design/battlebrotts-v1-roguelike-gdd.md
+++ b/docs/design/battlebrotts-v1-roguelike-gdd.md
@@ -55,25 +55,29 @@ Kites low-HP players. Fires EMP when player's modules are active. Engages aggres
 ---
 
 ### A.2 Run Difficulty Curve
-_Locked by HCD 2026-04-25 (expanded from v1 recommendation to incorporate encounter shapes)_
+_Locked by HCD 2026-04-25 (expanded from v1 recommendation to incorporate encounter shapes; further refined 2026-04-25 16:40 UTC: shape decoupled from difficulty)_
 
-**Decision:** 4 difficulty tiers spread across 15 battles. Each tier defines a **distribution of encounter archetypes** (see §A.9 for the full archetype library) — not just a template pool slice. Difficulty is a product of both opponent build tier AND encounter shape complexity.
+**Decision:** 4 difficulty tiers spread across 15 battles. **Difficulty (stats / loadout / AI quality) tracks tiers; encounter shape varies freely from Tier 1 onward.** Any archetype can appear in any tier as long as the constituent opponents are scaled to the tier's difficulty band. A Small Swarm in Tier 1 is just three *weak* bots; the shape doesn't carry the difficulty.
+
+**Refinement vs the v2 first pass (2026-04-25 16:40 UTC HCD note):** Earlier draft over-weighted Standard Duel in Tier 1 (80%) on the assumption that swarm shapes were inherently harder. They aren't — a swarm is only as hard as the bots in it. Shape variety is a player-experience lever; difficulty is a separate stat-and-AI lever. They should be tuned independently.
 
 | Battles | Tier | Encounter archetype distribution | Opponent loadout tier |
 |---------|------|----------------------------------|----------------------|
-| 1–3 | Tier 1 | 80% Standard Duel / 20% Small Swarm | Single-weapon, 0–1 modules |
-| 4–7 | Tier 2 | 50% Standard Duel / 25% Small Swarm / 15% Glass-Cannon Blitz / 10% Mini-boss+Escorts | Full weapon + armor + 1–2 modules |
-| 8–11 | Tier 3 | 20% Standard Duel / 30% Small Swarm / 20% Large Swarm / 20% Counter-Build Elite / 10% Mini-boss+Escorts | Full loadouts, counter-tuned |
-| 12–14 | Tier 4 | 10% Standard Duel / 20% Large Swarm / 30% Counter-Build Elite / 20% Mini-boss+Escorts / 20% Glass-Cannon Blitz | Silver-tier templates, Disruptor/Aegis/Chrono builds |
-| 15 | Boss | IRONCLAD PRIME (always) | Max loadout, hardcoded boss AI |
+| 1–3 | Tier 1 | Free shape mix (any archetype except Boss). Suggested seed: ~40% Standard Duel / ~25% Small Swarm / ~15% Glass-Cannon Blitz / ~10% Large Swarm / ~10% Mini-boss+Escorts | Single-weapon, 0–1 modules; opponents in swarms are individually weak |
+| 4–7 | Tier 2 | Free shape mix; ~30% Standard Duel / balance across other archetypes | Full weapon + armor + 1–2 modules |
+| 8–11 | Tier 3 | Free shape mix; introduce Counter-Build Elite | Full loadouts, counter-tuned |
+| 12–14 | Tier 4 | Free shape mix; weighted toward Counter-Build Elite + Large Swarm + Mini-boss+Escorts for climactic feel | Silver-tier templates, Disruptor/Aegis/Chrono builds |
+| 15 | Boss | IRONCLAD PRIME (always; name TBD) | Max loadout, hardcoded boss AI |
 
-**Key principle:** No stat inflation. Difficulty comes from harder opponent loadouts + encounter shape complexity. The balance invariant holds.
+The distributions above are *seeds* for the encounter generator, not hard quotas. Final tuning happens during Arc F + Arc H playtesting.
+
+**Key principle:** No stat inflation. Difficulty comes from opponent loadout strength + AI behavior quality + encounter density (a swarm of T2 bots is harder than a swarm of T1 bots, not because the *shape* changed but because the bots got stronger). The balance invariant holds.
 
 **Variety rule:** No two consecutive encounters may share the same archetype. State tracked on `RunState._last_encounter_archetype` (new field). If the archetype picker would repeat, re-roll once.
 
 **Run guarantee:** Each run guarantees at least one occurrence of: Small Swarm, Counter-Build Elite, and Mini-boss+Escorts (the three most tactically novel archetypes). Seeded into slots 5, 9, 12 at run generation, then shuffled within-tier constraints.
 
-**Multi-target implication:** The hardcoded baseline AI (§A.8) must handle swarm and escort encounters. Bot behavior in multi-target fights uses the priority system defined in §A.8.
+**Multi-target implication:** The hardcoded baseline AI (§A.8) must handle swarm and escort encounters from battle 1 onward. Bot behavior in multi-target fights uses the priority system defined in §A.8. Renderer must support multi-bot from Arc F's earliest sub-sprints, not as a Tier-3 add.
 
 ---
 
@@ -248,7 +252,7 @@ Encounters are no longer exclusively 1v1. Seven encounter archetypes form the sh
 **Format:** 1 vs 1  
 **Example composition:** Player Brott vs one opponent template (tier-matched)  
 **What makes it distinctive:** The baseline. No multi-target complexity. Pure 1v1 combat performance — loadout vs loadout, AI vs AI (with player click-to-target intervention).  
-**Design intent:** Establish baseline difficulty. Comfortable early on; by Tier 4, the Tier-4 opponent is a genuine threat even 1v1. Used in 80% of Tier 1 encounters so new players find their footing.
+**Design intent:** Establish baseline difficulty. Comfortable early on; by Tier 4, the Tier-4 opponent is a genuine threat even 1v1. Common but not dominant in Tier 1 — shape variety is an early-run lever, not just a late-run reward.
 
 ---
 
@@ -264,7 +268,7 @@ Encounters are no longer exclusively 1v1. Seven encounter archetypes form the sh
 **Format:** 1 vs 5–6  
 **Example composition:** Player vs 5 Micro-Scout-class bots, each at ~20% normal HP (individually trivial, collectively lethal if ignored)  
 **What makes it distinctive:** Pure chaos. The arena is full of bots. Click-to-target matters a lot here — the baseline AI will pick off bots one at a time; good targeting focuses the weakest cluster to prevent being surrounded. Audio is a stress test (lots of hit SFX). Visually overwhelming by design.  
-**Design intent:** Peak variety encounter. Short but intense. Should feel like a "holy shit" moment. Appears only in Tier 3+ to ensure players have enough HP/modules to survive the burst.
+**Design intent:** Peak variety encounter. Short but intense. Should feel like a "holy shit" moment. Can appear from Tier 1 onward; difficulty is governed by the per-bot loadout tier (a Tier-1 Large Swarm is six *very* weak bots), not by gating the shape itself.
 
 ---
 


### PR DESCRIPTION
## v1.0 Roguelike GDD v2 — Ready for HCD Greenlight

All 7 open design questions from v1 are now resolved by HCD decisions (2026-04-25). This PR is ready for final greenlight to launch Arc F planning.

**HCD decisions addendum:** `memory/2026-04-25-hcd-decisions-on-gdd-v1.md`

---

## v2 changes vs v1

### Q1 / Q3 / Q4 / Q5 / Q6 / Q7 — Locked
All 6 non-Q2 questions locked to Gizmo v1 recommendations by HCD. Each section is now annotated "Locked by HCD 2026-04-25." Boss name "IRONCLAD PRIME" is marked TBD (HCD to workshop name; structure is locked).

### Q2 — Full rewrite: BrottBrain editor cut, Bot Arena two-click control
**The biggest change.** HCD rejected the BrottBrain card editor entirely and chose Bot Arena's two-click control scheme:
- Click anywhere on the arena → bot navigates there, then resumes autonomous behavior
- Click an enemy → that enemy becomes the forced target until it dies or a new override fires
- All 6 Q2-derivative open questions resolved: move/target duration, visual feedback (waypoint diamond, target reticle, override pulse), modules auto-fired by baseline AI, clicks unlimited, latest-click-wins priority hierarchy

**Cut entirely:** `brottbrain_screen.gd`, all editor UI scenes, Behavior Card content, BrottBrain unlock progression, S21.2–S21.4 editor onboarding.
**Re-skinned:** `brottbrain.gd` → hardcoded baseline AI (same class API, new internals with multi-target priority).

### NEW §A.9 — 7 Encounter Archetypes
Encounters are no longer exclusively 1v1. HCD opened the floor to swarms and any shape Gizmo designs. Seven archetypes designed:
1. **Standard Duel** (1v1) — baseline
2. **Small Swarm** (1v3 weak) — introduces multi-target
3. **Large Swarm** (1v5–6 micro bots) — peak chaos
4. **Mini-boss + Escorts** (1v Fortress + 2 Scouts) — target priority puzzle
5. **Counter-Build Elite** (1v1, hand-tuned to punish player build) — adaptation test
6. **Glass-Cannon Blitz** (1v1 fragile/high-DPS) — time pressure
7. **Boss** (IRONCLAD PRIME / name TBD) — climax

### §A.2 Rewrite — Tier distribution uses encounter shapes
Each of the 4 tiers now specifies a distribution of encounter archetypes (e.g., Tier 1 = 80% Standard Duel / 20% Small Swarm; Tier 4 = 10% Duel / 20% Large Swarm / 30% Counter-Build Elite / 20% Mini-boss+Escorts / 20% Glass-Cannon). Variety rule: no two consecutive encounters share the same archetype. Run guarantees at least one Small Swarm, Counter-Build Elite, and Mini-boss+Escorts per run.

### §A.3 — UNTIERED reward pool (HCD locked)
Full item pool from battle 1. Overrides Gizmo v1 tiered recommendation per HCD decision. Swarm win = defeat all enemies = one reward pick per encounter.

### Section B — Major update
- 🟥 Cut: BrottBrain editor screen + scenes, unlock progression, S21.2–S21.4 test files, Behavior Card content
- 🟨 Re-skin: `brottbrain.gd` → hardcoded baseline AI with multi-target support; `arena_renderer.gd` → extend to N enemies + click-overlay layer
- 🟩 Keeps confirmed: battle engine, charm anims, opponent template data, item/loadout system, arena physics, all audio

### Section C — Roadmap revised
- Arc F: ~8–10 sub-sprints (was 6–8), +2 for encounter shapes + multi-target AI + click overlay
- Arc G: ~4–5 sub-sprints (was 3–4), +1 for larger BrottBrain editor cut
- Total: ~17–22 sub-sprints (was 15–20)

### Section D — New Tripwire 6
"No BrottBrain editor revival. No new Behavior Card content." Any sprint plan that resurrects the card editor in any form → STOP. Escalate.

---

### What's needed to launch Arc F

HCD greenlights this PR → The Bott spawns Ett for Arc F planning.

---

*GDD v2 authored by Gizmo. The Bott will surface to HCD for greenlight.*