### PR TITLE
[S25.2] Multi-target arena renderer + click overlay

### DIFF
--- a/godot/arena/arena_renderer.gd
+++ b/godot/arena/arena_renderer.gd
@@ -103,6 +103,15 @@ const _DEBUG_VELOCITY_SCALE: float = 0.15  # px per (px/s) — keeps arrows shor
 const _DEBUG_COLOR_COMPUTED := Color(0.2, 1.0, 1.0, 0.9)  # cyan
 const _DEBUG_COLOR_VELOCITY := Color(1.0, 0.2, 1.0, 0.9)  # magenta
 
+## S25.2: Click overlay state
+var _waypoint_pos: Vector2 = Vector2.INF        # INF = no active waypoint
+var _waypoint_fade_t: float = 0.0               # 0 = hidden, 1 = full alpha
+var _reticle_target_id: int = -1                # -1 = no active reticle (index into sim.brotts)
+var _pulse_accum: float = 0.0                   # accumulator for player outline pulse
+
+## S25.2: Player brain reference (cached at setup for click handler)
+var _player_brain: BrottBrain = null
+
 func setup(p_sim: CombatSim, p_offset: Vector2) -> void:
 	sim = p_sim
 	arena_offset = p_offset
@@ -122,6 +131,72 @@ func _unhandled_input(event: InputEvent) -> void:
 		if event.keycode == KEY_F3:
 			debug_velocity_overlay = not debug_velocity_overlay
 			print("[S17.2-004] velocity debug overlay toggled: ", debug_velocity_overlay)
+			return
+
+	# S25.2: Click handler — routes left-clicks to floor or enemy dispatch.
+	if sim == null or sim.match_over:
+		return
+	if not (event is InputEventMouseButton):
+		return
+	var mb := event as InputEventMouseButton
+	if mb.button_index != MOUSE_BUTTON_LEFT or not mb.pressed:
+		return
+
+	# Bounds check: ignore clicks outside the arena rect.
+	var arena_rect := Rect2(arena_offset, Vector2(ARENA_PX, ARENA_PX))
+	if not arena_rect.has_point(mb.position):
+		return
+	var arena_local: Vector2 = mb.position - arena_offset
+
+	# Hit-test enemies first; floor click otherwise.
+	var hit_idx := _hit_test_enemy(arena_local)
+	if hit_idx != -1:
+		_handle_enemy_click(hit_idx)
+	else:
+		_handle_floor_click(arena_local)
+
+## S25.2: Register the player brain so the click handler can set overrides.
+func set_player_brain(brain: BrottBrain) -> void:
+	_player_brain = brain
+
+## S25.2: Hit-test enemies. Returns index in sim.brotts of clicked enemy, or -1.
+## Iterates in reverse render order so last-drawn (visually topmost) wins on overlap.
+func _hit_test_enemy(arena_local: Vector2) -> int:
+	if sim == null:
+		return -1
+	for i in range(sim.brotts.size() - 1, -1, -1):
+		var b: BrottState = sim.brotts[i]
+		if not b.alive or b.team == 0:
+			continue
+		var dist: float = (b.position - arena_local).length()
+		if dist <= BOT_RADIUS + 4.0:
+			return i
+	return -1
+
+## S25.2: Floor click — set waypoint, clear target override (latest-wins).
+func _handle_floor_click(arena_local: Vector2) -> void:
+	_waypoint_pos = arena_local
+	_waypoint_fade_t = 1.0
+	_reticle_target_id = -1
+	if _player_brain != null:
+		_player_brain.set_move_override(arena_local)
+
+## S25.2: Enemy click — set reticle, clear waypoint (latest-wins).
+func _handle_enemy_click(target_idx: int) -> void:
+	_reticle_target_id = target_idx
+	_waypoint_pos = Vector2.INF
+	_waypoint_fade_t = 0.0
+	if _player_brain != null:
+		_player_brain.set_target_override(target_idx)
+
+## S25.2: Helper — find player brott (team == 0).
+func _get_player_brott() -> BrottState:
+	if sim == null:
+		return null
+	for b: BrottState in sim.brotts:
+		if b.team == 0:
+			return b
+	return null
 
 func _get_weapon_shake_class(source: BrottState) -> String:
 	# Determine shake intensity based on weapon type
@@ -341,7 +416,33 @@ func get_time_scale() -> float:
 
 func tick_visuals() -> void:
 	frame_count += 1
-	
+
+	# S25.2: Pulse accumulator + overlay state cleanup (waypoint fade on arrival,
+	# reticle dead-target poll). Runs even during hit-stop freeze so reticle
+	# clears promptly if a target dies during freeze.
+	_pulse_accum += 1.0 / 60.0
+	if _waypoint_pos != Vector2.INF:
+		var player_b := _get_player_brott()
+		if player_b != null:
+			var dist: float = (player_b.position - _waypoint_pos).length()
+			if dist < 8.0:
+				_waypoint_fade_t -= (1.0 / 60.0) / 0.4  # fade over 0.4s
+				if _waypoint_fade_t <= 0.0:
+					_waypoint_pos = Vector2.INF
+					_waypoint_fade_t = 0.0
+					if _player_brain != null:
+						_player_brain.clear_move_override()
+	if _reticle_target_id != -1:
+		var target_alive := false
+		if _reticle_target_id >= 0 and _reticle_target_id < sim.brotts.size():
+			var tgt: BrottState = sim.brotts[_reticle_target_id]
+			if tgt.alive:
+				target_alive = true
+		if not target_alive:
+			_reticle_target_id = -1
+			if _player_brain != null:
+				_player_brain.clear_target_override()
+
 	# Hit-stop freeze
 	if death_freeze_timer > 0:
 		death_freeze_timer -= 1.0
@@ -630,6 +731,10 @@ func _draw() -> void:
 	for b: BrottState in sim.brotts:
 		_draw_brott(b, draw_offset)
 
+	# S25.2: Click overlay layer (waypoint diamond, reticle ring, player pulse).
+	# Drawn after bots so it sits visually on top.
+	_draw_click_overlay(draw_offset)
+
 	# [S17.2-004] Dev-only velocity debug overlay (additive, OFF by default).
 	if debug_velocity_overlay:
 		_draw_debug_velocity_overlay(draw_offset)
@@ -858,6 +963,24 @@ func _draw_brott(b: BrottState, draw_offset: Vector2) -> void:
 	
 	# S12.3: Draw weapon silhouettes on in-game sprite (24×24 scale)
 	_draw_ingame_weapons(b, pos)
+
+	# S25.2: Numbered enemy label (1, 2, 3, …) above bot for multi-target clarity.
+	# Index is 1-based across living enemies in sim.brotts order.
+	if b.team != 0:
+		var enemy_index := 0
+		for other: BrottState in sim.brotts:
+			if other == b:
+				break
+			if other.alive and other.team != 0:
+				enemy_index += 1
+		var label_text := str(enemy_index + 1)
+		var label_pos: Vector2 = pos + Vector2(-3, -BOT_RADIUS - 14)
+		# Dark outline for readability over arena bg + bot color.
+		for off in [Vector2(-1, 0), Vector2(1, 0), Vector2(0, -1), Vector2(0, 1)]:
+			draw_string(ThemeDB.fallback_font, label_pos + off, label_text,
+				HORIZONTAL_ALIGNMENT_LEFT, -1, 11, Color(0, 0, 0, 0.9))
+		draw_string(ThemeDB.fallback_font, label_pos, label_text,
+			HORIZONTAL_ALIGNMENT_LEFT, -1, 11, Color.WHITE)
 	
 	# Shield
 	if b.shield_active:
@@ -970,3 +1093,45 @@ func _draw_ingame_weapons(b: BrottState, pos: Vector2) -> void:
 			WeaponData.WeaponType.FLAK_CANNON:
 				# Wide short barrel
 				draw_rect(Rect2(mount + Vector2(0, -2.5), Vector2(3.0 * side, 5)), weapon_col)
+
+# ─────────────────────────────────────────────────────────────
+# S25.2: Click overlay rendering — waypoint diamond, reticle ring, player pulse.
+# ─────────────────────────────────────────────────────────────
+func _draw_click_overlay(draw_offset: Vector2) -> void:
+	# Waypoint diamond (yellow #FFD700, fades on player arrival).
+	if _waypoint_pos != Vector2.INF and _waypoint_fade_t > 0.0:
+		var wp: Vector2 = _waypoint_pos + draw_offset
+		var d := 8.0  # half-diagonal → 16px diamond
+		var diamond := PackedVector2Array([
+			wp + Vector2(0, -d),
+			wp + Vector2(d, 0),
+			wp + Vector2(0, d),
+			wp + Vector2(-d, 0),
+		])
+		var wpc := Color(1.0, 0.843, 0.0, _waypoint_fade_t)
+		draw_colored_polygon(diamond, wpc)
+		var outline := PackedVector2Array(diamond)
+		outline.append(diamond[0])
+		draw_polyline(outline, Color(1, 1, 1, _waypoint_fade_t * 0.6), 1.5)
+
+	# Reticle ring on target enemy (orange #FF8C00).
+	if _reticle_target_id != -1 and _reticle_target_id >= 0 and _reticle_target_id < sim.brotts.size():
+		var tgt: BrottState = sim.brotts[_reticle_target_id]
+		if tgt.alive:
+			var rp: Vector2 = tgt.position + draw_offset
+			draw_arc(rp, BOT_RADIUS + 6.0, 0, TAU, 32, Color(1.0, 0.549, 0.0, 0.9), 2.0)
+
+	# Player outline pulse — yellow if move-override, orange if target-override.
+	var player := _get_player_brott()
+	if player != null and player.alive and _player_brain != null:
+		var has_move: bool = _player_brain._override_move_pos != Vector2.INF
+		var has_target: bool = _player_brain._override_target_id != -1
+		if has_move or has_target:
+			var pulse_alpha: float = lerp(0.4, 1.0, 0.5 + 0.5 * sin(_pulse_accum * TAU / 0.6))
+			var pulse_color: Color
+			if has_move:
+				pulse_color = Color(1.0, 0.843, 0.0, pulse_alpha)
+			else:
+				pulse_color = Color(1.0, 0.549, 0.0, pulse_alpha)
+			var pp: Vector2 = player.position + draw_offset
+			draw_arc(pp, BOT_RADIUS + 3.0, 0, TAU, 32, pulse_color, 2.0)

--- a/godot/brain/brottbrain.gd
+++ b/godot/brain/brottbrain.gd
@@ -58,8 +58,33 @@ var weapon_mode: String = "all_fire"
 ## Target priority: "nearest", "weakest", "biggest_threat"
 var target_priority: String = "nearest"
 
-## Movement override: "", "cover", "center", "chase"
+## Movement override: "", "cover", "center", "chase", "move_to_override", "target_override"
 var movement_override: String = ""
+
+## S25.2: Player click-to-move / click-to-target overrides.
+## -1 = no target override (target_override is index into sim.brotts).
+## Vector2.INF = no move override.
+var _override_target_id: int = -1
+var _override_move_pos: Vector2 = Vector2.INF
+
+## S25.2: Set a target-override from player click. Overrides card-eval target.
+## target_id is the index of the target in sim.brotts.
+func set_target_override(target_id: int) -> void:
+	_override_target_id = target_id
+	_override_move_pos = Vector2.INF  # latest-wins: clear move override
+
+## S25.2: Clear target override (called when target dies or player clicks floor).
+func clear_target_override() -> void:
+	_override_target_id = -1
+
+## S25.2: Set a move-override from player click. Overrides card-eval movement.
+func set_move_override(pos: Vector2) -> void:
+	_override_move_pos = pos
+	_override_target_id = -1  # latest-wins: clear target override
+
+## S25.2: Clear move override (called when waypoint reached or player clicks enemy).
+func clear_move_override() -> void:
+	_override_move_pos = Vector2.INF
 
 func add_card(card: BehaviorCard) -> bool:
 	if cards.size() >= MAX_CARDS:
@@ -73,6 +98,16 @@ func clear_cards() -> void:
 ## Evaluate cards against current state. Returns true if a card fired.
 func evaluate(brott: RefCounted, enemy: RefCounted, match_time_sec: float) -> bool:
 	movement_override = ""  # Reset each tick
+	
+	## S25.2: Apply player click overrides before card evaluation.
+	## These take priority over card-driven behavior. The override sets state
+	## that S25.3 (baseline AI rewrite) reads to actually drive movement/targeting.
+	if _override_move_pos != Vector2.INF:
+		movement_override = "move_to_override"
+		return true
+	if _override_target_id != -1:
+		movement_override = "target_override"
+		return true
 	
 	for card in cards:
 		if _check_trigger(card, brott, enemy, match_time_sec):

--- a/godot/game_main.gd
+++ b/godot/game_main.gd
@@ -247,6 +247,9 @@ func _start_roguelike_match() -> void:
 	arena_renderer = ArenaRendererScene.instantiate()
 	add_child(arena_renderer)
 	arena_renderer.setup(sim, ARENA_OFFSET)
+	# S25.2: Wire player brain into renderer for click dispatch.
+	if player_brott != null and player_brott.brain != null and arena_renderer.has_method("set_player_brain"):
+		arena_renderer.set_player_brain(player_brott.brain)
 
 	_create_arena_hud()
 
@@ -422,6 +425,9 @@ func _start_demo_match() -> void:
 	arena_renderer = ArenaRendererScene.instantiate()
 	add_child(arena_renderer)
 	arena_renderer.setup(sim, ARENA_OFFSET)
+	# S25.2: Wire player brain into renderer for click dispatch.
+	if player_brott != null and player_brott.brain != null and arena_renderer.has_method("set_player_brain"):
+		arena_renderer.set_player_brain(player_brott.brain)
 	
 	# Create HUD
 	_create_arena_hud()
@@ -462,6 +468,9 @@ func _start_match(opponent_index: int) -> void:
 	arena_renderer = ArenaRendererScene.instantiate()
 	add_child(arena_renderer)
 	arena_renderer.setup(sim, ARENA_OFFSET)
+	# S25.2: Wire player brain into renderer for click dispatch.
+	if player_brott != null and player_brott.brain != null and arena_renderer.has_method("set_player_brain"):
+		arena_renderer.set_player_brain(player_brott.brain)
 	
 	# Create HUD
 	_create_arena_hud()

--- a/godot/tests/test_arena_renderer_multi.gd
+++ b/godot/tests/test_arena_renderer_multi.gd
@@ -1,0 +1,125 @@
+## test_arena_renderer_multi.gd — S25.2 multi-bot + click overlay tests
+##
+## Covers:
+## - BrottBrain override fields default state
+## - set_target_override / clear_target_override
+## - set_move_override / clear_move_override
+## - Latest-wins arbitration: floor click clears target override; enemy click clears move override
+## - evaluate() short-circuits with movement_override = "move_to_override" / "target_override"
+##   when an override is active.
+extends SceneTree
+
+func _init() -> void:
+	var pass_count := 0
+	var fail_count := 0
+
+	# T1: Default state.
+	var brain := BrottBrain.new()
+	if not (brain._override_target_id == -1):
+		push_error("FAIL: target override default -1"); fail_count += 1
+	else: pass_count += 1
+	if not (brain._override_move_pos == Vector2.INF):
+		push_error("FAIL: move override default INF"); fail_count += 1
+	else: pass_count += 1
+
+	# T2: set_target_override sets id and clears move override.
+	brain.set_move_override(Vector2(50, 50))  # seed move first
+	brain.set_target_override(3)
+	if not (brain._override_target_id == 3):
+		push_error("FAIL: set_target_override sets id"); fail_count += 1
+	else: pass_count += 1
+	if not (brain._override_move_pos == Vector2.INF):
+		push_error("FAIL: set_target_override clears move"); fail_count += 1
+	else: pass_count += 1
+
+	# T3: set_move_override sets pos and clears target override.
+	brain.set_move_override(Vector2(100, 200))
+	if not (brain._override_move_pos == Vector2(100, 200)):
+		push_error("FAIL: set_move_override sets pos"); fail_count += 1
+	else: pass_count += 1
+	if not (brain._override_target_id == -1):
+		push_error("FAIL: set_move_override clears target"); fail_count += 1
+	else: pass_count += 1
+
+	# T4: clear methods.
+	brain.clear_move_override()
+	if not (brain._override_move_pos == Vector2.INF):
+		push_error("FAIL: clear_move_override resets"); fail_count += 1
+	else: pass_count += 1
+	brain.set_target_override(7)
+	brain.clear_target_override()
+	if not (brain._override_target_id == -1):
+		push_error("FAIL: clear_target_override resets"); fail_count += 1
+	else: pass_count += 1
+
+	# T5: Latest-wins arbitration via direct override calls.
+	var brain2 := BrottBrain.new()
+	brain2.set_target_override(1)
+	if not (brain2._override_target_id == 1):
+		push_error("FAIL: pre target set"); fail_count += 1
+	else: pass_count += 1
+	brain2.set_move_override(Vector2(300, 300))  # floor click
+	if not (brain2._override_target_id == -1):
+		push_error("FAIL: floor click clears target (latest-wins)"); fail_count += 1
+	else: pass_count += 1
+	if not (brain2._override_move_pos == Vector2(300, 300)):
+		push_error("FAIL: floor click sets move"); fail_count += 1
+	else: pass_count += 1
+
+	# Inverse: move first, then enemy click clears it.
+	brain2.set_move_override(Vector2(100, 100))
+	brain2.set_target_override(0)
+	if not (brain2._override_move_pos == Vector2.INF):
+		push_error("FAIL: enemy click clears move (latest-wins)"); fail_count += 1
+	else: pass_count += 1
+	if not (brain2._override_target_id == 0):
+		push_error("FAIL: enemy click sets target"); fail_count += 1
+	else: pass_count += 1
+
+	# T6: evaluate() short-circuits when override active.
+	# Build a minimal brott + enemy that brain.evaluate can read.
+	var brain3 := BrottBrain.new()
+	var brott := BrottState.new()
+	brott.team = 0
+	brott.bot_name = "P"
+	brott.chassis_type = ChassisData.ChassisType.SCOUT
+	brott.position = Vector2(128, 128)
+	brott.setup()
+	var enemy := BrottState.new()
+	enemy.team = 1
+	enemy.bot_name = "E"
+	enemy.chassis_type = ChassisData.ChassisType.SCOUT
+	enemy.position = Vector2(256, 128)
+	enemy.setup()
+
+	# No override: movement_override stays "" after evaluate.
+	brain3.evaluate(brott, enemy, 0.0)
+	if not (brain3.movement_override == ""):
+		push_error("FAIL: evaluate no-override leaves movement_override empty (got '%s')" % brain3.movement_override); fail_count += 1
+	else: pass_count += 1
+
+	# Move override: evaluate sets "move_to_override" and returns true.
+	brain3.set_move_override(Vector2(200, 200))
+	var fired1: bool = brain3.evaluate(brott, enemy, 0.0)
+	if not fired1:
+		push_error("FAIL: evaluate returns true on move override"); fail_count += 1
+	else: pass_count += 1
+	if not (brain3.movement_override == "move_to_override"):
+		push_error("FAIL: move override sets movement_override='move_to_override' (got '%s')" % brain3.movement_override); fail_count += 1
+	else: pass_count += 1
+
+	# Target override: evaluate sets "target_override" and returns true.
+	brain3.set_target_override(1)
+	var fired2: bool = brain3.evaluate(brott, enemy, 0.0)
+	if not fired2:
+		push_error("FAIL: evaluate returns true on target override"); fail_count += 1
+	else: pass_count += 1
+	if not (brain3.movement_override == "target_override"):
+		push_error("FAIL: target override sets movement_override='target_override' (got '%s')" % brain3.movement_override); fail_count += 1
+	else: pass_count += 1
+
+	print("test_arena_renderer_multi: %d passed, %d failed" % [pass_count, fail_count])
+	if fail_count > 0:
+		quit(1)
+	else:
+		quit(0)

--- a/godot/tests/test_runner.gd
+++ b/godot/tests/test_runner.gd
@@ -104,6 +104,7 @@ const SPRINT_TEST_FILES := [
 	"res://tests/test_s24_5_001_menu_loop_seam.gd",
 	"res://tests/test_s24_5_002_menu_music_routing.gd",
 	"res://tests/test_run_state_init.gd",
+	"res://tests/test_arena_renderer_multi.gd",
 ]
 
 # [S25.1] Arc-G-pending test files: these reference APIs removed in Arc F


### PR DESCRIPTION
## S25.2 — Multi-target Arena Renderer + Click Overlay

**Arc F, Sub-sprint 2 of 9.**

### What this does
- Numbered enemy labels (1–N) for targeting clarity at 6-bot density
- BrottBrain override API: click-to-move + click-to-target with latest-wins arbitration
- Click input handler in arena_renderer with testable floor/enemy dispatch helpers
  (`_hit_test_enemy`, `_handle_floor_click`, `_handle_enemy_click`)
- Click overlay rendering: yellow #FFD700 diamond waypoint (fades on arrival),
  orange #FF8C00 reticle ring (dead-target poll), player bot pulsing outline
  (yellow/orange by override state, sin-wave alpha)
- Overlay wired to all 3 `game_main.gd` arena_renderer setup sites (roguelike, free-play, league)

### Test results
`test_arena_renderer_multi.gd`: **18/18 passed**. Full `test_runner.gd` sweep: PASS (1394 assertions, no new failures; only the pre-existing Arc-G-pending failures remain as expected).

### Acceptance gates
- [ ] 1. Arena renders 1/3/5/6 bots without visual breakage (Optic)
- [x] 2/3/4/5/6. Click overlay state logic + brain override semantics (test_arena_renderer_multi: 18/18)
- [ ] 7. FPS gate at 6-bot density (Optic headless)
- [ ] 8. Visual regression baselines (Optic screenshots)

### Notes / decisions
- **`bot_id` does not exist on BrottState** — the spec's bot_id-based hit-test was adapted to use the index in `sim.brotts` as the stable identifier (consistent within a match; bots are not removed from the array on death, only marked `!alive`). Reticle dead-target poll uses `_reticle_target_id` as an index and checks `tgt.alive`.
- **`_unhandled_input` was already used for the F3 velocity-overlay toggle** — merged the click handler into the existing function rather than redefining it; F3 still works.
- Override methods are additive to BrottBrain — the existing card-eval loop is unchanged. `evaluate()` returns early with `movement_override` set to `"move_to_override"` or `"target_override"` when an override is active. **S25.3 wires the actual movement/targeting behavior in combat_sim** (it does not currently react to those new strings).
- Numbered labels are drawn inside `_draw_brott` (not a separate loop) so the label position naturally tracks per-bot charm offsets, recoil, etc.
- Reticle dead-target poll + waypoint fade-on-arrival run in `tick_visuals()` BEFORE the hit-stop early-return, so overlay state stays in sync even during death freeze.

### Files
- `godot/arena/arena_renderer.gd`: +numbered labels, +click handler, +overlay state, +`_draw_click_overlay`
- `godot/brain/brottbrain.gd`: +override fields, +set/clear methods, +evaluate short-circuit
- `godot/game_main.gd`: `set_player_brain` wiring at 3 sites
- `godot/tests/test_arena_renderer_multi.gd`: new (18 assertions)
- `godot/tests/test_runner.gd`: registered new test in SPRINT_TEST_FILES