### PR TITLE
[S25.3] Hardcoded baseline AI (single-target)

### DIFF
--- a/godot/brain/brottbrain.gd
+++ b/godot/brain/brottbrain.gd
@@ -1,7 +1,15 @@
-## BrottBrain — behavior card system for autonomous Brott decision-making
-## Cards are evaluated top-to-bottom each tick; first match fires.
+## BrottBrain — autonomous Brott decision-making.
+## S25.3: Hardcoded baseline AI replaces card-eval loop. Card definitions retained
+## on disk for save-format compat (CUT: Arc G).
 class_name BrottBrain
 extends RefCounted
+
+## ─────────────────────────────────────────────────────────────────────────
+## CUT: Arc G — card-crafting metagame retired in Arc F roguelike pivot.
+## Enums + BehaviorCard class + cards array retained for save-format compat.
+## No active code path evaluates cards after S25.3.
+## Do not delete without a save-format migration.
+## ─────────────────────────────────────────────────────────────────────────
 
 ## Trigger types — the "WHEN" part of a behavior card
 enum Trigger {
@@ -67,6 +75,14 @@ var movement_override: String = ""
 var _override_target_id: int = -1
 var _override_move_pos: Vector2 = Vector2.INF
 
+## S25.3: Hysteresis state for kite decision — persists across ticks to prevent
+## stance flickering at the HP threshold boundary.
+var _kiting: bool = false
+
+## S25.3: Default stance per chassis (set by default_for_chassis).
+## Scout=2 (Hit&Run), Brawler=0 (Aggressive), Fortress=1 (PlayItSafe).
+var _default_stance: int = 0
+
 ## S25.2: Set a target-override from player click. Overrides card-eval target.
 ## target_id is the index of the target in sim.brotts.
 func set_target_override(target_id: int) -> void:
@@ -85,6 +101,16 @@ func set_move_override(pos: Vector2) -> void:
 ## S25.2: Clear move override (called when waypoint reached or player clicks enemy).
 func clear_move_override() -> void:
 	_override_move_pos = Vector2.INF
+
+## S25.3: Check if a module (by name) is equipped, not on cooldown, and not active.
+## Returns the slot index if ready, or -1 if not available.
+func _module_ready(brott: RefCounted, mod_name: String) -> int:
+	for i in range(brott.module_types.size()):
+		var mdata: Dictionary = ModuleData.get_module(brott.module_types[i])
+		if mdata["name"] == mod_name:
+			if brott.module_cooldowns[i] <= 0 and brott.module_active_timers[i] <= 0:
+				return i
+	return -1
 
 func add_card(card: BehaviorCard) -> bool:
 	if cards.size() >= MAX_CARDS:
@@ -109,11 +135,53 @@ func evaluate(brott: RefCounted, enemy: RefCounted, match_time_sec: float) -> bo
 		movement_override = "target_override"
 		return true
 	
-	for card in cards:
-		if _check_trigger(card, brott, enemy, match_time_sec):
-			_execute_action(card, brott)
-			return true
-	return false
+	## CUT: Arc G — card evaluation loop removed S25.3 roguelike pivot.
+	## cards array + add_card/clear_cards + BehaviorCard + Trigger/Action enums
+	## remain on disk for save-compat. See CUT block above enum Trigger.
+	## S25.3: Hardcoded baseline AI — card-eval loop removed.
+	
+	if enemy == null or not enemy.alive:
+		## No live enemy — hold stance, no overrides
+		movement_override = ""
+		return true
+	
+	var hp_pct: float = float(brott.hp) / float(brott.max_hp) if brott.max_hp > 0 else 1.0
+	
+	## --- Rule 1: Kite hysteresis ---
+	if not _kiting and hp_pct <= 0.30:
+		_kiting = true
+	elif _kiting and hp_pct >= 0.40:
+		_kiting = false
+	brott.stance = 2 if _kiting else _default_stance
+	## Note: combat_sim forces stance=0 in overtime, overriding this.
+	## That's intentional — overtime suppresses kite by design.
+	
+	## --- Rule 2: Module auto-fire (priority: Repair > EMP > Afterburner) ---
+	## Only one module fires per tick; return immediately on match to avoid double-fire.
+	if hp_pct < 0.40 and _module_ready(brott, "Repair Nanites") >= 0:
+		brott._pending_gadget = "Repair Nanites"
+		movement_override = ""
+		return true
+	
+	var enemy_has_module: bool = false
+	if enemy.module_active_timers.size() > 0:
+		for t: float in enemy.module_active_timers:
+			if t > 0:
+				enemy_has_module = true
+				break
+	if enemy_has_module and _module_ready(brott, "EMP Charge") >= 0:
+		brott._pending_gadget = "EMP Charge"
+		movement_override = ""
+		return true
+	
+	if _kiting and _module_ready(brott, "Afterburner") >= 0:
+		brott._pending_gadget = "Afterburner"
+		movement_override = ""
+		return true
+	
+	## --- Rule 3: Movement (advance/kite handled by stance via combat_sim) ---
+	movement_override = ""
+	return true
 
 func _check_trigger(card: BehaviorCard, brott: RefCounted, enemy: RefCounted, match_time_sec: float) -> bool:
 	var param: Variant = card.trigger_param
@@ -213,40 +281,17 @@ func _execute_action(card: BehaviorCard, brott: RefCounted) -> void:
 ## Pre-built BrottBrains that work out of the box for each chassis
 
 static func default_for_chassis(chassis_type: int) -> BrottBrain:
+	## S25.3: Baseline AI — no cards; stance-only configuration per chassis.
+	## Scout=2 (Hit&Run baseline), Brawler=0 (Aggressive), Fortress=1 (PlayItSafe).
 	var brain := BrottBrain.new()
 	match chassis_type:
-		0:  # Scout — Hit & Run stance, flee when hurt, afterburner when close, aggressive when enemy weak
-			brain.default_stance = 2  # Hit & Run
-			brain.add_card(BehaviorCard.new(
-				Trigger.WHEN_IM_HURT, 0.3,
-				Action.SWITCH_STANCE, 1  # Defensive — flee
-			))
-			brain.add_card(BehaviorCard.new(
-				Trigger.WHEN_THEYRE_CLOSE, 3,
-				Action.USE_GADGET, "Afterburner"  # Escape when close
-			))
-			brain.add_card(BehaviorCard.new(
-				Trigger.WHEN_THEYRE_HURT, 0.3,
-				Action.SWITCH_STANCE, 0  # Aggressive — go for the kill
-			))
-		1:  # Brawler — Aggressive stance, shield when hurt, all-fire when close
-			brain.default_stance = 0  # Go Get 'Em!
-			brain.add_card(BehaviorCard.new(
-				Trigger.WHEN_IM_HURT, 0.4,
-				Action.USE_GADGET, "Shield Projector"  # Shield when hurt
-			))
-			brain.add_card(BehaviorCard.new(
-				Trigger.WHEN_THEYRE_CLOSE, 3,
-				Action.WEAPONS, "all_fire"  # All-fire when close
-			))
-		2:  # Fortress — Play it Safe stance, shield when hurt, aggressive when enemy weak
-			brain.default_stance = 1  # Play it Safe
-			brain.add_card(BehaviorCard.new(
-				Trigger.WHEN_IM_HURT, 0.4,
-				Action.USE_GADGET, "Shield Projector"  # Shield when hurt
-			))
-			brain.add_card(BehaviorCard.new(
-				Trigger.WHEN_THEYRE_HURT, 0.3,
-				Action.SWITCH_STANCE, 0  # Aggressive when enemy weak
-			))
+		0:  # Scout
+			brain._default_stance = 2
+		1:  # Brawler
+			brain._default_stance = 0
+		2:  # Fortress
+			brain._default_stance = 1
+		_:
+			brain._default_stance = 0
+	brain.default_stance = brain._default_stance
 	return brain

--- a/godot/combat/combat_sim.gd
+++ b/godot/combat/combat_sim.gd
@@ -230,8 +230,19 @@ func _evaluate_brain(b: BrottState) -> void:
 		var enemy: BrottState = b.target
 		var fired: bool = b.brain.evaluate(b, enemy, match_time_sec)
 		
-		# Handle target priority from brain
-		if b.brain.target_priority != "nearest":
+		## S25.3: Target override from player click-to-target.
+		## Runs BEFORE priority re-pick so the override isn't silently overwritten.
+		if b.brain.movement_override == "target_override":
+			var oid: int = b.brain._override_target_id
+			if oid >= 0 and oid < brotts.size() and brotts[oid].alive:
+				b.target = brotts[oid]
+			else:
+				# Override target dead — clear override, fall through to normal re-pick
+				b.brain.clear_target_override()
+				if b.brain.target_priority != "nearest":
+					b.target = _find_target_by_priority(b, b.brain.target_priority)
+			# Either way, skip normal priority re-pick this tick
+		elif b.brain.target_priority != "nearest":
 			b.target = _find_target_by_priority(b, b.brain.target_priority)
 		
 		# Handle pending gadget activation
@@ -502,6 +513,23 @@ func _move_brott(b: BrottState) -> void:
 			if to_pillar_v.length_squared() > 0.0001:
 				var desired_vel_p: Vector2 = to_pillar_v.normalized() * b.current_speed
 				_apply_smoothed_displacement(b, _smooth_velocity(b, desired_vel_p, TICK_DELTA))
+	elif move_override == "move_to_override" and b.brain != null and b.brain._override_move_pos != Vector2.INF:
+		## S25.3: Navigate to player-clicked waypoint position.
+		b.accelerate_toward_speed(b.get_effective_speed(), TICK_DELTA)
+		var spd_mo: float = b.current_speed * TICK_DELTA
+		var to_waypoint: Vector2 = b.brain._override_move_pos - b.position
+		var dist_mo: float = to_waypoint.length()
+		const ARRIVE_RADIUS: float = 24.0  ## arrive and clear at 24px (< tile, feels responsive)
+		if dist_mo <= ARRIVE_RADIUS:
+			## Arrived — clear the override, resume autonomous
+			b.brain.clear_move_override()
+		elif dist_mo > spd_mo:
+			var desired_mo: Vector2 = to_waypoint.normalized() * b.current_speed
+			_apply_smoothed_displacement(b, _smooth_velocity(b, desired_mo, TICK_DELTA))
+		else:
+			## Within one step — snap to waypoint, clear override
+			b.position = b.brain._override_move_pos
+			b.brain.clear_move_override()
 	elif move_override == "chase":
 		# S17.3-004 (cherry-picked from PR #77 / S14.2 Slice B):
 		# close distance on enemy at stance-max speed. Symmetric with
@@ -1282,6 +1310,12 @@ func _kill_brott(b: BrottState) -> void:
 		kill_ticks[b.bot_name] = tick_count
 	if json_log_enabled:
 		_tick_events.append({"type": "bot_destroyed", "bot_id": b.bot_name, "tick": tick_count})
+	## S25.3: Clear any target_override pointing at this dead bot.
+	var dead_idx: int = brotts.find(b)
+	if dead_idx >= 0:
+		for other in brotts:
+			if other.brain != null and other.brain._override_target_id == dead_idx:
+				other.brain.clear_target_override()
 	on_death.emit(b)
 
 func _check_match_end() -> void:

--- a/godot/tests/test_baseline_ai.gd
+++ b/godot/tests/test_baseline_ai.gd
@@ -1,0 +1,140 @@
+## test_baseline_ai.gd — S25.3 Hardcoded baseline AI tests
+extends SceneTree
+
+## Helper: build a minimal BrottState
+func _make_brott(chassis: int, hp_pct: float, modules: Array = []) -> BrottState:
+	var b := BrottState.new()
+	b.team = 0
+	b.chassis_type = chassis
+	for m in modules:
+		b.module_types.append(m)
+	b.setup()
+	b.hp = b.max_hp * hp_pct
+	return b
+
+func _init() -> void:
+	var pass_count := 0
+	var fail_count := 0
+
+	## T1: Advance semantics — no override, stance = default
+	var brain1 := BrottBrain.default_for_chassis(1)  # Brawler, default_stance=0
+	var brott1 := _make_brott(1, 1.0)
+	var enemy1 := _make_brott(1, 1.0)
+	enemy1.team = 1
+	brain1.evaluate(brott1, enemy1, 0.0)
+	if not (brott1.stance == 0 and brain1.movement_override == ""):
+		push_error("T1 FAIL: advance should be stance-0, empty override (got stance=%d, override='%s')" % [brott1.stance, brain1.movement_override])
+		fail_count += 1
+	else:
+		pass_count += 1
+
+	## T2: Kite threshold — HP drops to 0.29, should set _kiting=true, stance=2
+	var brain2 := BrottBrain.default_for_chassis(1)
+	var brott2 := _make_brott(1, 0.29)
+	var enemy2 := _make_brott(1, 1.0); enemy2.team = 1
+	brain2.evaluate(brott2, enemy2, 0.0)
+	if not (brain2._kiting == true and brott2.stance == 2):
+		push_error("T2 FAIL: should kite at 0.29 HP (got _kiting=%s, stance=%d)" % [str(brain2._kiting), brott2.stance])
+		fail_count += 1
+	else:
+		pass_count += 1
+
+	## T3: Kite recovery — HP recovers to 0.41, should clear kite
+	brain2._kiting = true
+	brott2.hp = brott2.max_hp * 0.41
+	brain2.evaluate(brott2, enemy2, 0.0)
+	if not (brain2._kiting == false and brott2.stance == 0):
+		push_error("T3 FAIL: should stop kiting at 0.41 HP (got _kiting=%s, stance=%d)" % [str(brain2._kiting), brott2.stance])
+		fail_count += 1
+	else:
+		pass_count += 1
+
+	## T4: Hysteresis no-flicker — HP oscillates 0.28↔0.32, kiting stays true
+	var brain4 := BrottBrain.default_for_chassis(1)
+	brain4._kiting = false
+	var brott4 := _make_brott(1, 0.28)
+	var enemy4 := _make_brott(1, 1.0); enemy4.team = 1
+	brain4.evaluate(brott4, enemy4, 0.0)  # drops to kiting
+	var flicker := false
+	for i in range(10):
+		brott4.hp = brott4.max_hp * (0.28 if i % 2 == 0 else 0.32)
+		brain4.evaluate(brott4, enemy4, float(i) * 0.1)
+		if not brain4._kiting:
+			flicker = true
+			break
+	if flicker:
+		push_error("T4 FAIL: kiting should not flicker between 0.28-0.32")
+		fail_count += 1
+	else:
+		pass_count += 1
+
+	## T5: Repair Nanites auto-fire at HP < 0.40
+	var brain5 := BrottBrain.new()
+	var brott5 := _make_brott(1, 0.35, [ModuleData.ModuleType.REPAIR_NANITES])
+	var enemy5 := _make_brott(1, 1.0); enemy5.team = 1
+	brain5.evaluate(brott5, enemy5, 0.0)
+	if brott5._pending_gadget != "Repair Nanites":
+		push_error("T5 FAIL: Repair Nanites should auto-fire at HP 0.35 (got '%s')" % brott5._pending_gadget)
+		fail_count += 1
+	else:
+		pass_count += 1
+
+	## T6: EMP auto-fire when enemy has active module
+	var brain6 := BrottBrain.new()
+	var brott6 := _make_brott(1, 0.8, [ModuleData.ModuleType.EMP_CHARGE])
+	var enemy6 := _make_brott(1, 1.0, [ModuleData.ModuleType.SHIELD_PROJECTOR]); enemy6.team = 1
+	# Simulate active module on enemy
+	if enemy6.module_active_timers.size() > 0:
+		enemy6.module_active_timers[0] = 5.0  # mark as active
+	brain6.evaluate(brott6, enemy6, 0.0)
+	if brott6._pending_gadget != "EMP Charge":
+		push_error("T6 FAIL: EMP should auto-fire when enemy has active module (got '%s')" % brott6._pending_gadget)
+		fail_count += 1
+	else:
+		pass_count += 1
+
+	## T7: Afterburner fires when kiting
+	var brain7 := BrottBrain.new()
+	brain7._kiting = false
+	var brott7 := _make_brott(2, 0.25, [ModuleData.ModuleType.AFTERBURNER]); brott7.team = 0
+	var enemy7 := _make_brott(1, 1.0); enemy7.team = 1
+	brain7.evaluate(brott7, enemy7, 0.0)  # HP 0.25 triggers kite
+	if brott7._pending_gadget != "Afterburner":
+		push_error("T7 FAIL: Afterburner should fire when kiting (got '%s')" % brott7._pending_gadget)
+		fail_count += 1
+	else:
+		pass_count += 1
+
+	## T8: Module priority — Repair wins when all conditions met
+	var brain8 := BrottBrain.new()
+	var brott8 := _make_brott(1, 0.35, [
+		ModuleData.ModuleType.REPAIR_NANITES,
+		ModuleData.ModuleType.EMP_CHARGE,
+		ModuleData.ModuleType.AFTERBURNER
+	])
+	brain8._kiting = true
+	var enemy8 := _make_brott(1, 1.0, [ModuleData.ModuleType.SHIELD_PROJECTOR]); enemy8.team = 1
+	if enemy8.module_active_timers.size() > 0:
+		enemy8.module_active_timers[0] = 5.0
+	brain8.evaluate(brott8, enemy8, 0.0)
+	if brott8._pending_gadget != "Repair Nanites":
+		push_error("T8 FAIL: Repair should win priority over EMP+Afterburner (got '%s')" % brott8._pending_gadget)
+		fail_count += 1
+	else:
+		pass_count += 1
+
+	## T9: Public API smoke test
+	var brain9 := BrottBrain.default_for_chassis(0)
+	if not (brain9 is BrottBrain and brain9.has_method("evaluate") and
+		"movement_override" in brain9 and "weapon_mode" in brain9 and
+		"target_priority" in brain9):
+		push_error("T9 FAIL: BrottBrain public API incomplete")
+		fail_count += 1
+	else:
+		pass_count += 1
+
+	print("test_baseline_ai: %d passed, %d failed" % [pass_count, fail_count])
+	if fail_count > 0:
+		quit(1)
+	else:
+		quit(0)

--- a/godot/tests/test_runner.gd
+++ b/godot/tests/test_runner.gd
@@ -52,7 +52,6 @@ const SPRINT_TEST_FILES := [
 	"res://tests/test_sprint13_9.gd",
 	"res://tests/test_sprint13_10.gd",
 	"res://tests/test_sprint14_1_nav.gd",
-	"res://tests/test_sprint14_2_cards.gd",
 	"res://tests/test_sprint17_1_shop_scroll.gd",
 	"res://tests/test_sprint17_1_loadout_overlap.gd",
 	"res://tests/test_sprint17_1_visible_tooltips.gd",
@@ -105,6 +104,8 @@ const SPRINT_TEST_FILES := [
 	"res://tests/test_s24_5_002_menu_music_routing.gd",
 	"res://tests/test_run_state_init.gd",
 	"res://tests/test_arena_renderer_multi.gd",
+	# [S25.3] Hardcoded baseline AI — 9 conditions covering rule chain, hysteresis, module priority.
+	"res://tests/test_baseline_ai.gd",
 ]
 
 # [S25.1] Arc-G-pending test files: these reference APIs removed in Arc F
@@ -116,6 +117,9 @@ const SPRINT_TEST_FILES_ARC_G_PENDING := [
 	"res://tests/test_sprint3.gd",
 	"res://tests/test_sprint14_1.gd",
 	"res://tests/test_sprint22_2c.gd",
+	# [S25.3] Card-eval loop retired (Arc F roguelike pivot). These card-behavior
+	# tests will be deleted in Arc G when the BehaviorCard class is removed.
+	"res://tests/test_sprint14_2_cards.gd",
 ]
 
 var file_pass_count := 0

--- a/godot/tests/test_sprint4.gd
+++ b/godot/tests/test_sprint4.gd
@@ -35,13 +35,18 @@ func _init() -> void:
 	
 	# --- BROTTBRAIN UX TESTS ---
 	_test_scout_default_brain_stance()
-	_test_scout_default_brain_card_count()
+	## CUT: Arc G — card counts N/A after S25.3 baseline AI pivot; assertion retired in-place
+	# _test_scout_default_brain_card_count()
 	_test_brawler_default_brain_stance()
-	_test_brawler_default_brain_card_count()
+	## CUT: Arc G — card counts N/A after S25.3 baseline AI pivot; assertion retired in-place
+	# _test_brawler_default_brain_card_count()
 	_test_fortress_default_brain_stance()
-	_test_fortress_default_brain_card_count()
-	_test_max_cards_limit()
-	_test_brain_card_add_and_remove()
+	## CUT: Arc G — card counts N/A after S25.3 baseline AI pivot; assertion retired in-place
+	# _test_fortress_default_brain_card_count()
+	## CUT: Arc G — MAX_CARDS limit N/A after S25.3 baseline AI pivot; assertion retired in-place
+	# _test_max_cards_limit()
+	## CUT: Arc G — card add/remove N/A after S25.3 baseline AI pivot; assertions retired in-place
+	# _test_brain_card_add_and_remove()
 	
 	# --- VISUAL FEEDBACK / COMBAT TESTS ---
 	_test_brott_setup_uses_tripled_hp()
@@ -250,47 +255,52 @@ func _test_scout_default_brain_stance() -> void:
 	var brain := BrottBrain.default_for_chassis(0)
 	assert_eq(brain.default_stance, 2, "Scout default stance = 2 (Hit & Run)")
 
+## CUT: Arc G — card counts N/A after S25.3 baseline AI pivot; assertion retired in-place
 func _test_scout_default_brain_card_count() -> void:
-	print("test_scout_default_brain_card_count")
-	var brain := BrottBrain.default_for_chassis(0)
-	assert_eq(brain.cards.size(), 3, "Scout default brain has 3 cards")
+	print("test_scout_default_brain_card_count [RETIRED — Arc G]")
+	# var brain := BrottBrain.default_for_chassis(0)
+	# assert_eq(brain.cards.size(), 3, "Scout default brain has 3 cards")
 
 func _test_brawler_default_brain_stance() -> void:
 	print("test_brawler_default_brain_stance")
 	var brain := BrottBrain.default_for_chassis(1)
 	assert_eq(brain.default_stance, 0, "Brawler default stance = 0 (Go Get 'Em!)")
 
+## CUT: Arc G — card counts N/A after S25.3 baseline AI pivot; assertion retired in-place
 func _test_brawler_default_brain_card_count() -> void:
-	print("test_brawler_default_brain_card_count")
-	var brain := BrottBrain.default_for_chassis(1)
-	assert_eq(brain.cards.size(), 2, "Brawler default brain has 2 cards")
+	print("test_brawler_default_brain_card_count [RETIRED — Arc G]")
+	# var brain := BrottBrain.default_for_chassis(1)
+	# assert_eq(brain.cards.size(), 2, "Brawler default brain has 2 cards")
 
 func _test_fortress_default_brain_stance() -> void:
 	print("test_fortress_default_brain_stance")
 	var brain := BrottBrain.default_for_chassis(2)
 	assert_eq(brain.default_stance, 1, "Fortress default stance = 1 (Play it Safe)")
 
+## CUT: Arc G — card counts N/A after S25.3 baseline AI pivot; assertion retired in-place
 func _test_fortress_default_brain_card_count() -> void:
-	print("test_fortress_default_brain_card_count")
-	var brain := BrottBrain.default_for_chassis(2)
-	assert_eq(brain.cards.size(), 2, "Fortress default brain has 2 cards")
+	print("test_fortress_default_brain_card_count [RETIRED — Arc G]")
+	# var brain := BrottBrain.default_for_chassis(2)
+	# assert_eq(brain.cards.size(), 2, "Fortress default brain has 2 cards")
 
+## CUT: Arc G — MAX_CARDS limit N/A after S25.3 baseline AI pivot; assertion retired in-place
 func _test_max_cards_limit() -> void:
-	print("test_max_cards_limit")
-	var brain := BrottBrain.new()
-	for i in range(10):
-		brain.add_card(BrottBrain.BehaviorCard.new(0, 0.5, 0, 0))
-	assert_eq(brain.cards.size(), 8, "Max cards = 8")
+	print("test_max_cards_limit [RETIRED — Arc G]")
+	# var brain := BrottBrain.new()
+	# for i in range(10):
+	# 	brain.add_card(BrottBrain.BehaviorCard.new(0, 0.5, 0, 0))
+	# assert_eq(brain.cards.size(), 8, "Max cards = 8")
 
+## CUT: Arc G — card add/remove N/A after S25.3 baseline AI pivot; assertions retired in-place
 func _test_brain_card_add_and_remove() -> void:
-	print("test_brain_card_add_and_remove")
-	var brain := BrottBrain.new()
-	brain.add_card(BrottBrain.BehaviorCard.new(0, 0.3, 0, 1))
-	brain.add_card(BrottBrain.BehaviorCard.new(1, 0.7, 1, "Shield Projector"))
-	assert_eq(brain.cards.size(), 2, "2 cards added")
-	brain.cards.remove_at(0)
-	assert_eq(brain.cards.size(), 1, "1 card after removal")
-	assert_eq(brain.cards[0].trigger, 1, "Remaining card is the second one")
+	print("test_brain_card_add_and_remove [RETIRED — Arc G]")
+	# var brain := BrottBrain.new()
+	# brain.add_card(BrottBrain.BehaviorCard.new(0, 0.3, 0, 1))
+	# brain.add_card(BrottBrain.BehaviorCard.new(1, 0.7, 1, "Shield Projector"))
+	# assert_eq(brain.cards.size(), 2, "2 cards added")
+	# brain.cards.remove_at(0)
+	# assert_eq(brain.cards.size(), 1, "1 card after removal")
+	# assert_eq(brain.cards[0].trigger, 1, "Remaining card is the second one")
 
 # ============= VISUAL FEEDBACK / COMBAT =============
 


### PR DESCRIPTION
## S25.3 — Hardcoded Baseline AI

Arc F, Sub-sprint 3 of 9.

### What this does
- **BrottBrain**: card-eval loop → hardcoded rules (advance / kite-hysteresis / module-autofire)
  - `_module_ready()` helper
  - `_kiting` / `_default_stance` fields
  - `default_for_chassis()` simplified to stance-only (Scout=2, Brawler=0, Fortress=1)
  - Trigger/Action enums + BehaviorCard class + cards array remain on disk (CUT: Arc G — save-compat)
- **combat_sim.gd**: `move_to_override` (navigate to waypoint, arrive+clear at 24px) and `target_override` (`_override_target_id` → `b.target`, skip re-pick, clear on death) handlers — completes click-control integration started in S25.2
- **test_sprint4.gd**: 7 card-count assertions retired in-place (CUT: Arc G); default_stance assertions retained
- **test_sprint14_2_cards.gd**: moved to `SPRINT_TEST_FILES_ARC_G_PENDING` (whole-file card-eval test, will be deleted in Arc G with BehaviorCard class)
- **test_baseline_ai.gd**: 9 conditions covering rule chain, hysteresis, module priority, public API smoke

### Save-compat
Trigger/Action enums + BehaviorCard class + cards array retained on disk. Old saves with cards load without error; cards are ignored at evaluation time.

### Acceptance gates
All gates verified by `test_baseline_ai.gd` (9/9 passing locally) + full `test_runner.gd` PASS (1367 total assertions, 4 expected-fail Arc-G-pending files not counted).

### Local verification
- `godot --headless --script tests/test_baseline_ai.gd` → 9 passed, 0 failed
- `godot --headless --script tests/test_sprint4.gd` → 66 passed, 0 failed
- `godot --headless --script tests/test_runner.gd` → OVERALL PASS, 1367 assertions