### PR TITLE
[S25.4] Multi-target AI priority + 7-archetype encounter data

### DIFF
--- a/godot/brain/brottbrain.gd
+++ b/godot/brain/brottbrain.gd
@@ -83,6 +83,13 @@ var _kiting: bool = false
 ## Scout=2 (Hit&Run), Brawler=0 (Aggressive), Fortress=1 (PlayItSafe).
 var _default_stance: int = 0
 
+## S25.4: Enemy context for multi-target priority selection (set by combat_sim each tick).
+var _enemies_context: Array = []
+
+## S25.4: Set the enemies available for targeting this tick.
+func set_enemies_context(enemies: Array) -> void:
+	_enemies_context = enemies
+
 ## S25.2: Set a target-override from player click. Overrides card-eval target.
 ## target_id is the index of the target in sim.brotts.
 func set_target_override(target_id: int) -> void:
@@ -140,10 +147,48 @@ func evaluate(brott: RefCounted, enemy: RefCounted, match_time_sec: float) -> bo
 	## remain on disk for save-compat. See CUT block above enum Trigger.
 	## S25.3: Hardcoded baseline AI — card-eval loop removed.
 	
+	## S25.4: Empty context guard — no enemies available, no-op safely.
+	if _enemies_context.is_empty() and (enemy == null or not enemy.alive):
+		brott.target = null
+		movement_override = ""
+		return true
+	
 	if enemy == null or not enemy.alive:
 		## No live enemy — hold stance, no overrides
 		movement_override = ""
 		return true
+	
+	## S25.4: Multi-target priority selection.
+	## Override short-circuits above already handled player click-to-target.
+	## This cascade runs only when no active click override is set.
+	var alive_enemies: Array = _enemies_context.filter(func(e): return e != null and e.alive and e.hp > 0)
+	
+	if alive_enemies.is_empty():
+		## No live enemies in context — use passed `enemy` as fallback (1v1 compat)
+		if enemy != null and enemy.alive:
+			brott.target = enemy
+		else:
+			brott.target = null
+			movement_override = ""
+			return true
+	else:
+		## Priority cascade:
+		## 1. Melee-adjacent (within 48px) — pick closest melee-range attacker
+		var melee_enemies: Array = alive_enemies.filter(func(e): return brott.position.distance_to(e.position) < 48.0)
+		if not melee_enemies.is_empty():
+			melee_enemies.sort_custom(func(a, b_): return brott.position.distance_to(a.position) < brott.position.distance_to(b_.position))
+			brott.target = melee_enemies[0]
+		else:
+			## 2. Nearest; tie-break equidistant by lowest HP
+			var sorted_enemies: Array = alive_enemies.duplicate()
+			sorted_enemies.sort_custom(func(a, b_):
+				var da: float = brott.position.distance_to(a.position)
+				var db: float = brott.position.distance_to(b_.position)
+				if abs(da - db) < 1.0:  ## equidistant (within 1px epsilon)
+					return a.hp < b_.hp  ## tie-break: lower HP wins
+				return da < db  ## nearest wins
+			)
+			brott.target = sorted_enemies[0]
 	
 	var hp_pct: float = float(brott.hp) / float(brott.max_hp) if brott.max_hp > 0 else 1.0
 	

--- a/godot/combat/combat_sim.gd
+++ b/godot/combat/combat_sim.gd
@@ -226,24 +226,34 @@ func _evaluate_brain(b: BrottState) -> void:
 	b._pending_gadget = ""
 	
 	if b.brain != null:
+		## S25.4: Populate enemies context for multi-target priority selection.
+		var enemy_list: Array = []
+		for other in brotts:
+			if other.team != b.team and other.alive:
+				enemy_list.append(other)
+		b.brain.set_enemies_context(enemy_list)
+		
 		var match_time_sec: float = float(tick_count) / float(TICKS_PER_SEC)
 		var enemy: BrottState = b.target
 		var fired: bool = b.brain.evaluate(b, enemy, match_time_sec)
 		
-		## S25.3: Target override from player click-to-target.
-		## Runs BEFORE priority re-pick so the override isn't silently overwritten.
-		if b.brain.movement_override == "target_override":
-			var oid: int = b.brain._override_target_id
-			if oid >= 0 and oid < brotts.size() and brotts[oid].alive:
-				b.target = brotts[oid]
-			else:
-				# Override target dead — clear override, fall through to normal re-pick
-				b.brain.clear_target_override()
-				if b.brain.target_priority != "nearest":
-					b.target = _find_target_by_priority(b, b.brain.target_priority)
-			# Either way, skip normal priority re-pick this tick
-		elif b.brain.target_priority != "nearest":
-			b.target = _find_target_by_priority(b, b.brain.target_priority)
+		## S25.4: Skip re-pick if brain already chose a valid living enemy target.
+		var brain_set_valid: bool = (b.target != null and is_instance_valid(b.target) and b.target.alive and b.target.team != b.team)
+		if not brain_set_valid:
+			## S25.3: Target override from player click-to-target.
+			## Runs BEFORE priority re-pick so the override isn't silently overwritten.
+			if b.brain.movement_override == "target_override":
+				var oid: int = b.brain._override_target_id
+				if oid >= 0 and oid < brotts.size() and brotts[oid].alive:
+					b.target = brotts[oid]
+				else:
+					# Override target dead — clear override, fall through to normal re-pick
+					b.brain.clear_target_override()
+					if b.brain.target_priority != "nearest":
+						b.target = _find_target_by_priority(b, b.brain.target_priority)
+				# Either way, skip normal priority re-pick this tick
+			elif b.brain.target_priority != "nearest":
+				b.target = _find_target_by_priority(b, b.brain.target_priority)
 		
 		# Handle pending gadget activation
 		if b._pending_gadget != "":

--- a/godot/data/opponent_loadouts.gd
+++ b/godot/data/opponent_loadouts.gd
@@ -30,6 +30,8 @@ const LEAGUE_RANK: Dictionary = {
 	"platinum": 4,
 }
 
+## CUT: Arc G — league-era opponent templates. Replaced by ARCHETYPE_TEMPLATES for roguelike.
+## Retained for save-compat and batch test baseline. Do not delete before Arc G migration.
 # Template schema (§3.1 + S21.1 additions):
 #   id, name, archetype, tier, chassis, weapons, armor, modules, stance,
 #   unlock_league (S21.1), behavior_cards (S21.1; data-only, engine-ignored).
@@ -458,6 +460,148 @@ const TEMPLATES: Array[Dictionary] = [
 		],
 	},
 ]
+
+## ─────────────────────────────────────────────────────────────────────────
+## S25.4: Roguelike Encounter Archetype Pool
+## IDs locked: standard_duel | small_swarm | large_swarm | miniboss_escorts |
+##             counter_build_elite | glass_cannon_blitz | boss
+## ─────────────────────────────────────────────────────────────────────────
+
+## Baseline HP per tier — used to scale archetype hp_pct values.
+## Tier 1: battles 1-3, Tier 2: 4-7, Tier 3: 8-11, Tier 4: 12-14, Tier 5: Boss.
+static func _baseline_hp_for_tier(tier: int) -> int:
+	match tier:
+		1: return 80
+		2: return 120
+		3: return 160
+		4: return 200
+		_: return 240  # Boss tier
+
+## Archetype template records. enemy_specs describe the enemy composition.
+## hp_pct is relative to _baseline_hp_for_tier(tier) at generation time.
+const ARCHETYPE_TEMPLATES: Array[Dictionary] = [
+	{
+		"id": "standard_duel",
+		"display_name": "Standard Duel",
+		"enemy_specs": [
+			{"chassis": 0, "weapons": [4], "armor": 1, "modules": [], "hp_pct": 1.0, "count": 1}
+		]
+	},
+	{
+		"id": "small_swarm",
+		"display_name": "Small Swarm",
+		"enemy_specs": [
+			{"chassis": 0, "weapons": [4], "armor": 0, "modules": [], "hp_pct": 0.6, "count": 3}
+		]
+	},
+	{
+		"id": "large_swarm",
+		"display_name": "Large Swarm",
+		"enemy_specs": [
+			{"chassis": 0, "weapons": [4], "armor": 0, "modules": [], "hp_pct": 0.4, "count": 5}
+		]
+	},
+	{
+		"id": "miniboss_escorts",
+		"display_name": "Mini-boss + Escorts",
+		"enemy_specs": [
+			{"chassis": 2, "weapons": [0, 2], "armor": 3, "modules": [2], "hp_pct": 1.5, "count": 1},
+			{"chassis": 0, "weapons": [4], "armor": 0, "modules": [], "hp_pct": 0.7, "count": 2}
+		]
+	},
+	{
+		"id": "counter_build_elite",
+		"display_name": "Counter-Build Elite",
+		## enemy_specs populated dynamically by get_archetype_enemies() via build-read selector
+		"enemy_specs": []
+	},
+	{
+		"id": "glass_cannon_blitz",
+		"display_name": "Glass-Cannon Blitz",
+		"enemy_specs": [
+			{"chassis": 0, "weapons": [1, 0], "armor": 0, "modules": [], "hp_pct": 0.5, "count": 2}
+		]
+	},
+	{
+		"id": "boss",
+		"display_name": "IRONCLAD PRIME",
+		## Placeholder name — finalized in Arc H. S25.9 tunes AI.
+		"enemy_specs": [
+			{"chassis": 2, "weapons": [1, 0], "armor": 3, "modules": [2, 3, 5], "hp_pct": 2.0, "count": 1}
+		]
+	},
+]
+
+## Counter-Build Elite variant selector — reads player's RunState loadout.
+## Priority: modules ≥3 → anti_module; then primary weapon.
+static func _select_counter_build_variant(run_state) -> String:
+	if run_state == null:
+		return "anti_range"
+	var modules = run_state.equipped_modules if "equipped_modules" in run_state else []
+	if modules.size() >= 3:
+		return "anti_module"
+	var weapons = run_state.equipped_weapons if "equipped_weapons" in run_state else []
+	var primary: int = weapons[0] if weapons.size() > 0 else -1
+	if primary in [1, 3]:  # Railgun, Missile Pod
+		return "anti_range"
+	if primary in [2, 6]:  # Shotgun, Flak Cannon
+		return "anti_melee"
+	return "anti_range"
+
+## Concrete counter-build elite enemy specs per variant.
+static func _counter_build_specs(variant: String) -> Array[Dictionary]:
+	match variant:
+		"anti_range":
+			## Reactive Mesh + Rush build to close range quickly
+			return [{"chassis": 1, "weapons": [2, 0], "armor": 2, "modules": [4], "hp_pct": 1.3, "count": 1}]
+		"anti_melee":
+			## Railgun kiter to punish slow Shotgun users
+			return [{"chassis": 0, "weapons": [1], "armor": 1, "modules": [4, 3], "hp_pct": 1.3, "count": 1}]
+		"anti_module":
+			## EMP Charge + aggressive to shutdown active modules
+			return [{"chassis": 1, "weapons": [0, 4], "armor": 2, "modules": [5, 0], "hp_pct": 1.3, "count": 1}]
+		_:
+			return [{"chassis": 1, "weapons": [0], "armor": 1, "modules": [], "hp_pct": 1.3, "count": 1}]
+
+## Stub — returns the archetype id for a given battle. S25.6 completes.
+static func archetype_for(battle_index: int, last_archetype: String, _run_state) -> String:
+	return "standard_duel"  ## S25.6 implements full rotation + anti-repeat logic
+
+## Returns resolved enemy spawn specs for the given archetype + tier + player state.
+## Each returned dict: {chassis, weapons, armor, modules, hp} (hp is absolute, not pct).
+static func get_archetype_enemies(archetype_id: String, tier: int, run_state) -> Array[Dictionary]:
+	var template: Dictionary = {}
+	for t in ARCHETYPE_TEMPLATES:
+		if t["id"] == archetype_id:
+			template = t
+			break
+	if template.is_empty():
+		## Unknown archetype — fall back to standard_duel
+		return get_archetype_enemies("standard_duel", tier, run_state)
+	
+	var base_hp: int = _baseline_hp_for_tier(tier)
+	var specs: Array[Dictionary]
+	
+	if archetype_id == "counter_build_elite":
+		var variant := _select_counter_build_variant(run_state)
+		specs = _counter_build_specs(variant)
+	else:
+		specs = template["enemy_specs"].duplicate(true)
+	
+	## Expand count and compute absolute HP
+	var result: Array[Dictionary] = []
+	for spec in specs:
+		var count: int = spec.get("count", 1)
+		var hp: int = max(1, int(base_hp * float(spec["hp_pct"])))
+		for _i in range(count):
+			result.append({
+				"chassis": spec["chassis"],
+				"weapons": spec["weapons"].duplicate(),
+				"armor": spec["armor"],
+				"modules": spec["modules"].duplicate(),
+				"hp": hp,
+			})
+	return result
 
 ## §4.1 — maps (league, index) to a difficulty tier.
 ## S21.1: Bronze expanded to 5-slot curve [2,2,2,3,3] — tier-2 openers, tier-3 closers.

--- a/godot/tests/test_multi_target_ai.gd
+++ b/godot/tests/test_multi_target_ai.gd
@@ -1,0 +1,160 @@
+## test_multi_target_ai.gd — S25.4 Multi-target AI priority + archetype data tests
+extends SceneTree
+
+## Helper: build a minimal BrottState at a position with given hp.
+func _make_brott(team: int, pos: Vector2, hp_pct: float = 1.0) -> BrottState:
+	var b := BrottState.new()
+	b.team = team
+	b.chassis_type = 1  # Brawler
+	b.setup()
+	b.position = pos
+	b.hp = b.max_hp * hp_pct
+	return b
+
+func _init() -> void:
+	var pass_count := 0
+	var fail_count := 0
+
+	## ─── T1: targets nearest in 1v3 (no melee) ────────────────────────
+	var brain1 := BrottBrain.default_for_chassis(1)
+	var brott1 := _make_brott(0, Vector2(0, 0))
+	var e1a := _make_brott(1, Vector2(200, 0))   # 200px
+	var e1b := _make_brott(1, Vector2(80, 0))    # 80px (nearest non-melee)
+	var e1c := _make_brott(1, Vector2(150, 0))   # 150px
+	brain1.set_enemies_context([e1a, e1b, e1c])
+	brain1.evaluate(brott1, e1a, 0.0)
+	if brott1.target != e1b:
+		push_error("T1 FAIL: nearest non-melee should win (got dist=%f)" % (brott1.position.distance_to(brott1.target.position) if brott1.target != null else -1.0))
+		fail_count += 1
+	else:
+		pass_count += 1
+
+	## ─── T2: equidistant picks lower HP ───────────────────────────────
+	var brain2 := BrottBrain.default_for_chassis(1)
+	var brott2 := _make_brott(0, Vector2(0, 0))
+	var e2a := _make_brott(1, Vector2(100, 0), 1.0)   # full HP
+	var e2b := _make_brott(1, Vector2(0, 100), 0.4)   # equidistant, lower HP
+	brain2.set_enemies_context([e2a, e2b])
+	brain2.evaluate(brott2, e2a, 0.0)
+	if brott2.target != e2b:
+		push_error("T2 FAIL: equidistant should pick lower-HP (target.hp=%d, expected=%d)" % [brott2.target.hp if brott2.target != null else -1, int(e2b.hp)])
+		fail_count += 1
+	else:
+		pass_count += 1
+
+	## ─── T3a: melee-adjacent: closest melee wins among multiple melee ─
+	var brain3 := BrottBrain.default_for_chassis(1)
+	var brott3 := _make_brott(0, Vector2(0, 0))
+	var e3a := _make_brott(1, Vector2(30, 0))   # 30px (melee)
+	var e3b := _make_brott(1, Vector2(15, 0))   # 15px (melee, closer)
+	brain3.set_enemies_context([e3a, e3b])
+	brain3.evaluate(brott3, e3a, 0.0)
+	if brott3.target != e3b:
+		push_error("T3a FAIL: closest melee should win (expected 15px, got dist=%f)" % (brott3.position.distance_to(brott3.target.position) if brott3.target != null else -1.0))
+		fail_count += 1
+	else:
+		pass_count += 1
+
+	## ─── T3b: melee beats non-melee even if non-melee is "closer to origin sense" — actually
+	## the rule is: if any enemy is in melee, melee wins. Test: A=100px (non-melee), B=45px (melee).
+	## B wins because melee-priority cascade fires first.
+	var brain3b := BrottBrain.default_for_chassis(1)
+	var brott3b := _make_brott(0, Vector2(0, 0))
+	var e3ba := _make_brott(1, Vector2(100, 0))  # not melee
+	var e3bb := _make_brott(1, Vector2(45, 0))   # melee (within 48)
+	brain3b.set_enemies_context([e3ba, e3bb])
+	brain3b.evaluate(brott3b, e3ba, 0.0)
+	if brott3b.target != e3bb:
+		push_error("T3b FAIL: melee should beat non-melee")
+		fail_count += 1
+	else:
+		pass_count += 1
+
+	## ─── T4: player click-override beats melee ────────────────────────
+	## The override short-circuit lives at the top of evaluate() and returns
+	## before the multi-target cascade runs. brott.target is therefore NOT
+	## set by the brain in this path; combat_sim consumes the override.
+	## This test asserts that movement_override == "target_override" and
+	## _override_target_id is preserved (not clobbered by cascade).
+	var brain4 := BrottBrain.default_for_chassis(1)
+	var brott4 := _make_brott(0, Vector2(0, 0))
+	var e4a := _make_brott(1, Vector2(30, 0))   # melee — would win cascade
+	var e4b := _make_brott(1, Vector2(200, 0))  # far — but is the click-override target
+	brain4.set_target_override(1)  # index 1 = e4b in our context array
+	brain4.set_enemies_context([e4a, e4b])
+	brain4.evaluate(brott4, e4a, 0.0)
+	if brain4.movement_override != "target_override" or brain4._override_target_id != 1:
+		push_error("T4 FAIL: click-override should short-circuit (movement_override='%s', _override_target_id=%d)" % [brain4.movement_override, brain4._override_target_id])
+		fail_count += 1
+	else:
+		pass_count += 1
+
+	## ─── T5: counter-build anti_module ────────────────────────────────
+	var rs5 := RunState.new()
+	rs5.equipped_modules = [0, 1, 2]
+	rs5.equipped_weapons = [4]
+	var v5 := OpponentLoadouts._select_counter_build_variant(rs5)
+	if v5 != "anti_module":
+		push_error("T5 FAIL: 3 modules → anti_module (got '%s')" % v5)
+		fail_count += 1
+	else:
+		pass_count += 1
+
+	## ─── T6: counter-build anti_range ─────────────────────────────────
+	var rs6 := RunState.new()
+	rs6.equipped_modules = [0]
+	rs6.equipped_weapons = [1]  # Railgun
+	var v6 := OpponentLoadouts._select_counter_build_variant(rs6)
+	if v6 != "anti_range":
+		push_error("T6 FAIL: Railgun primary → anti_range (got '%s')" % v6)
+		fail_count += 1
+	else:
+		pass_count += 1
+
+	## ─── T7: counter-build anti_melee ─────────────────────────────────
+	var rs7 := RunState.new()
+	rs7.equipped_modules = []
+	rs7.equipped_weapons = [2]  # Shotgun
+	var v7 := OpponentLoadouts._select_counter_build_variant(rs7)
+	if v7 != "anti_melee":
+		push_error("T7 FAIL: Shotgun primary → anti_melee (got '%s')" % v7)
+		fail_count += 1
+	else:
+		pass_count += 1
+
+	## ─── T8: archetype templates complete ─────────────────────────────
+	var expected_ids := ["standard_duel", "small_swarm", "large_swarm", "miniboss_escorts", "counter_build_elite", "glass_cannon_blitz", "boss"]
+	var templates := OpponentLoadouts.ARCHETYPE_TEMPLATES
+	var t8_ok := true
+	if templates.size() != 7:
+		t8_ok = false
+	else:
+		var actual_ids := []
+		for t in templates:
+			actual_ids.append(t["id"])
+		for eid in expected_ids:
+			if not (eid in actual_ids):
+				t8_ok = false
+				break
+	if not t8_ok:
+		push_error("T8 FAIL: ARCHETYPE_TEMPLATES should have 7 records with locked IDs (got size=%d)" % templates.size())
+		fail_count += 1
+	else:
+		pass_count += 1
+
+	## ─── T9: empty context guard ──────────────────────────────────────
+	var brain9 := BrottBrain.default_for_chassis(1)
+	var brott9 := _make_brott(0, Vector2(0, 0))
+	brain9.set_enemies_context([])
+	brain9.evaluate(brott9, null, 0.0)
+	if brott9.target != null or brain9.movement_override != "":
+		push_error("T9 FAIL: empty context + null enemy should leave target null (target=%s, override='%s')" % [str(brott9.target), brain9.movement_override])
+		fail_count += 1
+	else:
+		pass_count += 1
+
+	print("test_multi_target_ai: %d passed, %d failed" % [pass_count, fail_count])
+	if fail_count > 0:
+		quit(1)
+	else:
+		quit(0)

--- a/godot/tests/test_runner.gd
+++ b/godot/tests/test_runner.gd
@@ -106,6 +106,8 @@ const SPRINT_TEST_FILES := [
 	"res://tests/test_arena_renderer_multi.gd",
 	# [S25.3] Hardcoded baseline AI — 9 conditions covering rule chain, hysteresis, module priority.
 	"res://tests/test_baseline_ai.gd",
+	# [S25.4] Multi-target AI priority cascade + 7-archetype encounter data.
+	"res://tests/test_multi_target_ai.gd",
 ]
 
 # [S25.1] Arc-G-pending test files: these reference APIs removed in Arc F


### PR DESCRIPTION
## S25.4 — Multi-target AI (single→multi) + Archetype Data

Arc F, Sub-sprint 4 of 9.

### What this does
- BrottBrain: melee-adjacent > equidistant-lowest-HP > nearest priority cascade
- combat_sim: enemies context populated each tick; brain-chosen target not clobbered
- opponent_loadouts: 7 archetype records (standard_duel/small_swarm/large_swarm/
  miniboss_escorts/counter_build_elite/glass_cannon_blitz/boss) + helpers
- Counter-Build Elite 3-variant selector + concrete loadouts
- 10-condition test suite (T1, T2, T3a, T3b, T4, T5, T6, T7, T8, T9)

### Local verification
- test_multi_target_ai: 10 passed, 0 failed
- test_baseline_ai: 9 passed, 0 failed (no regression)