### PR TITLE
[S25.6] Full encounter generator (weighted draw + guarantee seeds)

### DIFF
--- a/godot/data/opponent_loadouts.gd
+++ b/godot/data/opponent_loadouts.gd
@@ -563,9 +563,175 @@ static func _counter_build_specs(variant: String) -> Array[Dictionary]:
 		_:
 			return [{"chassis": 1, "weapons": [0], "armor": 1, "modules": [], "hp_pct": 1.3, "count": 1}]
 
-## Stub — returns the archetype id for a given battle. S25.6 completes.
-static func archetype_for(battle_index: int, last_archetype: String, _run_state) -> String:
-	return "standard_duel"  ## S25.6 implements full rotation + anti-repeat logic
+## ─────────────────────────────────────────────────────────────────────────
+## S25.6: Encounter Generator — pre-rolled schedule, weighted draw,
+##         no-repeat rule, guarantee seeds, boss-lock at slot 15.
+## ─────────────────────────────────────────────────────────────────────────
+
+## S25.6: Maps battle_index (0-indexed) to tier (1-5) for the roguelike run.
+## T1=idx 0-2, T2=idx 3-6, T3=idx 7-10, T4=idx 11-13, Boss=idx 14.
+## NOTE (deviation): named `difficulty_for_battle` instead of `difficulty_for`
+## to avoid colliding with the existing league-era 2-arg
+## `difficulty_for(league: String, index: int)` (still used by opponent_data.gd
+## for save-compat / batch test baseline).
+static func difficulty_for_battle(battle_index: int) -> int:
+	if battle_index >= 14: return 5   # Boss tier
+	if battle_index >= 11: return 4   # T4
+	if battle_index >= 7:  return 3   # T3
+	if battle_index >= 3:  return 2   # T2
+	return 1                           # T1
+
+## S25.6: Large Swarm hp_pct override by tier (difficulty decoupled from shape).
+const LARGE_SWARM_HP_BY_TIER: Dictionary = {1: 0.2, 2: 0.4, 3: 0.7, 4: 0.9}
+
+## S25.6: Returns resolved enemy spawn specs for the given archetype, battle index, and run state.
+## Wraps get_archetype_enemies() with tier-adaptive HP for large_swarm.
+static func compose_encounter(archetype_id: String, battle_index: int, run_state) -> Array[Dictionary]:
+	var tier := difficulty_for_battle(battle_index)
+
+	## Large Swarm: hp_pct overridden by tier (gate 6)
+	if archetype_id == "large_swarm":
+		var hp_pct: float = LARGE_SWARM_HP_BY_TIER.get(min(tier, 4), 0.9)
+		var base_hp: int = _baseline_hp_for_tier(tier)
+		## Build specs directly (don't rely on template's fixed hp_pct)
+		var count := 5 if tier <= 2 else 6
+		var hp: int = max(1, int(base_hp * hp_pct))
+		var result: Array[Dictionary] = []
+		for _i in range(count):
+			result.append({
+				"chassis": 0,
+				"weapons": [4],  ## Plasma Cutter
+				"armor": 0,
+				"modules": [],
+				"hp": hp,
+			})
+		return result
+
+	## All other archetypes use get_archetype_enemies()
+	return get_archetype_enemies(archetype_id, tier, run_state)
+
+## S25.6: Probability weights per tier. Weights are relative (don't need to sum to 100).
+const ARCHETYPE_WEIGHTS_BY_TIER: Dictionary = {
+	1: {"standard_duel": 40, "small_swarm": 30, "large_swarm": 15, "glass_cannon_blitz": 15},
+	2: {"standard_duel": 30, "small_swarm": 30, "large_swarm": 20, "counter_build_elite": 10, "glass_cannon_blitz": 10},
+	3: {"standard_duel": 20, "small_swarm": 20, "large_swarm": 20, "miniboss_escorts": 20, "counter_build_elite": 15, "glass_cannon_blitz": 5},
+	4: {"standard_duel": 15, "small_swarm": 10, "large_swarm": 15, "miniboss_escorts": 25, "counter_build_elite": 25, "glass_cannon_blitz": 10},
+}
+
+## S25.6: Pick a weighted-random archetype from a tier, excluding last_archetype.
+## rng: optional seeded RNG for test determinism; uses global randi() if null.
+static func _weighted_draw(tier: int, last_archetype: String, rng: RandomNumberGenerator) -> String:
+	var weights: Dictionary = ARCHETYPE_WEIGHTS_BY_TIER.get(min(tier, 4), ARCHETYPE_WEIGHTS_BY_TIER[4])
+
+	## Attempt up to 3 draws with no-repeat; fall back to forced pick
+	for attempt in range(4):
+		if attempt == 3:
+			## Forced fallback: pick highest-weight non-repeat
+			var best := ""
+			var best_w := -1
+			for k in weights:
+				if k != last_archetype and weights[k] > best_w:
+					best_w = weights[k]
+					best = k
+			return best if best != "" else weights.keys()[0]
+
+		## Weighted random draw
+		var total := 0
+		for w in weights.values():
+			total += w
+		var roll := (rng.randi() % total) if rng else (randi() % total)
+		var cumulative := 0
+		var drawn := ""
+		for k in weights:
+			cumulative += weights[k]
+			if roll < cumulative:
+				drawn = k
+				break
+
+		if drawn != last_archetype:
+			return drawn
+		## repeat — try again
+
+	return weights.keys()[0]  ## safety fallback
+
+## S25.6: Full encounter generator.
+## Returns the archetype ID for a given battle slot.
+## Run schedule is pre-generated on first call and cached on run_state.encounter_schedule.
+static func archetype_for(battle_index: int, run_state, rng: RandomNumberGenerator = null) -> String:
+	## Boss override FIRST — deterministic regardless of rng state (gate 3)
+	if battle_index >= 14:
+		return "boss"
+
+	## Use cached schedule if available
+	if run_state != null and "encounter_schedule" in run_state and \
+		run_state.encounter_schedule is Array and \
+		run_state.encounter_schedule.size() > battle_index:
+		return run_state.encounter_schedule[battle_index]
+
+	## Generate full 15-slot schedule and cache it
+	var schedule := _generate_run_schedule(run_state, rng if rng != null else RandomNumberGenerator.new())
+	if run_state != null:
+		run_state.encounter_schedule = schedule
+
+	if battle_index < schedule.size():
+		return schedule[battle_index]
+	return "standard_duel"  ## safety fallback
+
+## S25.6: Generate a full 15-slot encounter schedule for a run.
+static func _generate_run_schedule(_run_state, rng: RandomNumberGenerator) -> Array[String]:
+	## Step 1: Generate 15 slots with weighted draw + no-repeat
+	var schedule: Array[String] = []
+	schedule.resize(15)
+	schedule[14] = "boss"  ## Battle 15 always boss
+
+	for idx in range(14):
+		var tier := difficulty_for_battle(idx)
+		var last := schedule[idx - 1] if idx > 0 else ""
+		schedule[idx] = _weighted_draw(tier, last, rng)
+
+	## Step 2: Apply guarantee seeds (slots 5, 9, 12 → indices 4, 8, 11)
+	var guarantee_map: Dictionary = {4: "small_swarm", 8: "counter_build_elite", 11: "miniboss_escorts"}
+	for base_idx in guarantee_map:
+		var target: String = guarantee_map[base_idx]
+		var seeded_idx: int = base_idx
+		## Slide forward if repeat conflict
+		for _slide in range(3):
+			var prev := schedule[seeded_idx - 1] if seeded_idx > 0 else ""
+			var next_arc := schedule[seeded_idx + 1] if seeded_idx < 13 else ""
+			if schedule[seeded_idx] == target:
+				break  ## already this archetype, no conflict possible with itself
+			if prev != target and next_arc != target:
+				schedule[seeded_idx] = target
+				break
+			seeded_idx += 1
+			if seeded_idx >= 14:
+				seeded_idx = base_idx  ## wrap back and give up sliding
+				break
+
+	## Step 3: Post-generation sweep — ensure each guaranteed archetype appears ≥1 time
+	var required := ["small_swarm", "counter_build_elite", "miniboss_escorts"]
+	for req in required:
+		var found := false
+		for s in schedule:
+			if s == req:
+				found = true
+				break
+		if not found:
+			## Find a valid slot to overwrite (latest slot of matching tier, no consecutive repeat)
+			for idx in range(13, -1, -1):
+				var tier := difficulty_for_battle(idx)
+				## Check if this archetype is valid for this tier
+				var tier_weights: Dictionary = ARCHETYPE_WEIGHTS_BY_TIER.get(min(tier, 4), {})
+				if req not in tier_weights:
+					continue
+				## Check no consecutive repeat
+				var prev := schedule[idx - 1] if idx > 0 else ""
+				var nxt := schedule[idx + 1] if idx < 13 else "boss"
+				if prev != req and nxt != req:
+					schedule[idx] = req
+					break
+
+	return schedule
 
 ## Returns resolved enemy spawn specs for the given archetype + tier + player state.
 ## Each returned dict: {chassis, weapons, armor, modules, hp} (hp is absolute, not pct).

--- a/godot/game/run_state.gd
+++ b/godot/game/run_state.gd
@@ -30,6 +30,10 @@ var _best_kill_name: String = ""
 ## S25.5: Current encounter context (set on ARENA entry; read on retry).
 var current_encounter: Dictionary = {"archetype_id": "", "tier": 0, "arena_seed": 0}
 
+## S25.6: Pre-generated encounter schedule for this run (15 archetype IDs).
+## Populated on first call to OpponentLoadouts.archetype_for(). Reset on new run.
+var encounter_schedule: Array[String] = []
+
 ## S25.5: Fired when any run state is mutated (equipment added, battle advanced, retry used).
 signal run_state_changed
 
@@ -48,6 +52,7 @@ func _init(chassis_type: int = 0, rng_seed: int = 0) -> void:
 	_last_encounter_archetype = -1
 	_farthest_threat_name = ""
 	_best_kill_name = ""
+	encounter_schedule = []
 
 ## S25.5: Set the current encounter context (called before entering ARENA).
 func set_encounter(archetype_id: String, tier: int, arena_seed: int) -> void:

--- a/godot/game_main.gd
+++ b/godot/game_main.gd
@@ -219,17 +219,21 @@ func _show_run_start() -> void:
 
 func _on_chassis_picked(chassis_type: int) -> void:
 	game_flow.start_run(chassis_type)
-	## S25.5: Set initial encounter
+	## S25.6: Pre-generate encounter schedule, set first encounter
+	var archetype_id := OpponentLoadouts.archetype_for(0, game_flow.run_state)
 	var arena_seed := game_flow.run_state.seed * 31
-	game_flow.run_state.set_encounter("standard_duel", 1, arena_seed)
+	game_flow.run_state.set_encounter(archetype_id, OpponentLoadouts.difficulty_for_battle(0), arena_seed)
 	_start_roguelike_match()
 
 func _start_roguelike_match() -> void:
-	## S25.5: Ensure encounter is set (may already be set on retry path)
+	## S25.6: Ensure encounter is set (may already be set on retry path).
+	## If unset, derive via the encounter generator + tier mapping.
 	if game_flow.run_state != null and game_flow.run_state.current_encounter["archetype_id"] == "":
-		var tier := _tier_for_battle(game_flow.run_state.current_battle_index)
-		var arena_seed := game_flow.run_state.seed * 31 + game_flow.run_state.current_battle_index
-		game_flow.run_state.set_encounter("standard_duel", tier, arena_seed)
+		var idx := game_flow.run_state.current_battle_index
+		var archetype_id := OpponentLoadouts.archetype_for(idx, game_flow.run_state)
+		var tier := OpponentLoadouts.difficulty_for_battle(idx)
+		var arena_seed := game_flow.run_state.seed * 31 + idx
+		game_flow.run_state.set_encounter(archetype_id, tier, arena_seed)
 	## S25.1: Stub arena — builds player BrottState inline from RunState.
 	## Enemy uses OpponentData bronze/0 as stub; S25.4/S25.6 replaces.
 	_clear_screen()
@@ -292,19 +296,13 @@ func _show_retry_prompt() -> void:
 	retry.accept_loss.connect(func(): game_flow.end_run(); _show_main_menu())
 
 func _advance_to_next_battle() -> void:
-	## Set encounter for next battle (stub archetype for now; S25.6 provides full generator)
-	var tier := _tier_for_battle(game_flow.run_state.current_battle_index)
-	var arena_seed := game_flow.run_state.seed * 31 + game_flow.run_state.current_battle_index
-	game_flow.run_state.set_encounter("standard_duel", tier, arena_seed)
+	## S25.6: Use encounter generator (replaces standard_duel stub)
+	var next_idx := game_flow.run_state.current_battle_index
+	var archetype_id := OpponentLoadouts.archetype_for(next_idx, game_flow.run_state)
+	var tier := OpponentLoadouts.difficulty_for_battle(next_idx)
+	var arena_seed := game_flow.run_state.seed * 31 + next_idx
+	game_flow.run_state.set_encounter(archetype_id, tier, arena_seed)
 	_start_roguelike_match()
-
-func _tier_for_battle(battle_index: int) -> int:
-	## Stub: basic tier mapping for S25.5 (S25.6 replaces with full encounter generator)
-	if battle_index >= 14: return 5  # Boss
-	if battle_index >= 11: return 4  # Tier 4
-	if battle_index >= 7:  return 3  # Tier 3
-	if battle_index >= 3:  return 2  # Tier 2
-	return 1                          # Tier 1
 
 func _show_stub_result(won: bool) -> void:
 	## DEPRECATED S25.5 — stub result no longer used in roguelike flow.

--- a/godot/tests/test_encounter_generator.gd
+++ b/godot/tests/test_encounter_generator.gd
@@ -1,0 +1,120 @@
+## test_encounter_generator.gd — S25.6 encounter generator validation
+##
+## Gates covered:
+##   Gate 1 — no consecutive repeat across 1000 runs (absolute, 0 violations)
+##   Gate 2 — guarantee archetypes (small_swarm, counter_build_elite,
+##            miniboss_escorts) each appear ≥1 time per run, ≥99% success
+##   Gate 3 — battle 15 (index 14) always returns "boss" regardless of seed
+##   Gate 4 — difficulty_for_battle() tier mapping
+##            [1,1,1,2,2,2,2,3,3,3,3,4,4,4,5]
+##   Gate 6 — large_swarm tier-adaptive HP (0.2 / 0.4 / 0.7 / 0.9 by tier)
+##
+## NOTE: deviation from sub-sprint spec — the new tier-by-battle mapping is
+##       exposed as `difficulty_for_battle(int)` instead of `difficulty_for(int)`
+##       to avoid colliding with the existing league-era 2-arg
+##       `difficulty_for(league: String, index: int)` (still used by
+##       opponent_data.gd for save-compat / batch test baseline).
+extends SceneTree
+
+func _init() -> void:
+	var pass_count := 0
+	var fail_count := 0
+
+	## Gate 3: Battle 15 (index 14) always returns "boss"
+	var gate3_ok := true
+	for seed in range(100):
+		var rng := RandomNumberGenerator.new()
+		rng.seed = seed
+		var result := OpponentLoadouts.archetype_for(14, null, rng)
+		if result != "boss":
+			push_error("Gate 3 FAIL at seed %d: expected boss, got %s" % [seed, result])
+			gate3_ok = false
+			break
+	if gate3_ok:
+		pass_count += 1
+	else:
+		fail_count += 1
+
+	## Gate 4: difficulty_for_battle() mapping
+	var expected_tiers := [1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 5]
+	var gate4_ok := true
+	for i in range(15):
+		var t := OpponentLoadouts.difficulty_for_battle(i)
+		if t != expected_tiers[i]:
+			push_error("Gate 4 FAIL: difficulty_for_battle(%d) = %d, expected %d" % [i, t, expected_tiers[i]])
+			gate4_ok = false
+	if gate4_ok:
+		pass_count += 1
+	else:
+		fail_count += 1
+
+	## Gate 6: Large Swarm tier-adaptive HP
+	var gate6_ok := true
+	var expected_pct := {1: 0.2, 2: 0.4, 3: 0.7, 4: 0.9}
+	var idx_per_tier := {1: 0, 2: 3, 3: 7, 4: 11}
+	for tier in expected_pct:
+		var idx: int = idx_per_tier[tier]
+		var specs := OpponentLoadouts.compose_encounter("large_swarm", idx, null)
+		var base_hp := OpponentLoadouts._baseline_hp_for_tier(tier)
+		var expected_hp := int(base_hp * float(expected_pct[tier]))
+		if specs.is_empty():
+			push_error("Gate 6 FAIL T%d: compose_encounter returned no specs" % tier)
+			gate6_ok = false
+			continue
+		for spec in specs:
+			var got: int = spec.get("hp", 0)
+			if abs(got - expected_hp) > 1:  # tolerance for int truncation
+				push_error("Gate 6 FAIL T%d: hp %d, expected ~%d" % [tier, got, expected_hp])
+				gate6_ok = false
+				break
+	if gate6_ok:
+		pass_count += 1
+	else:
+		fail_count += 1
+
+	## Gates 1+2: 1000-run simulation
+	var no_repeat_violations := 0
+	var guarantee_failures := 0
+	var total_runs := 1000
+
+	for seed in range(total_runs):
+		var rng := RandomNumberGenerator.new()
+		rng.seed = seed * 7919  # diverse seeds
+		## Generate schedule using a mock run_state (just needs encounter_schedule field)
+		var mock_state := RunState.new(0, seed)
+		var schedule: Array[String] = []
+		for idx in range(15):
+			var arch := OpponentLoadouts.archetype_for(idx, mock_state, rng)
+			schedule.append(arch)
+
+		## Gate 1: no consecutive repeat (boss is at idx 14, exempted from prior-slot match)
+		for i in range(1, 15):
+			if schedule[i] == schedule[i - 1] and schedule[i] != "boss":
+				no_repeat_violations += 1
+
+		## Gate 2: guarantee archetypes present
+		var has_swarm := schedule.has("small_swarm")
+		var has_elite := schedule.has("counter_build_elite")
+		var has_miniboss := schedule.has("miniboss_escorts")
+		if not (has_swarm and has_elite and has_miniboss):
+			guarantee_failures += 1
+
+	## Gate 1: 0 violations allowed (no-repeat is absolute)
+	if no_repeat_violations == 0:
+		pass_count += 1
+	else:
+		push_error("Gate 1 FAIL: %d consecutive repeat violations in 1000 runs" % no_repeat_violations)
+		fail_count += 1
+
+	## Gate 2: ≥99% success (≤10 failures in 1000)
+	if guarantee_failures <= 10:
+		pass_count += 1
+	else:
+		push_error("Gate 2 FAIL: %d/%d runs missing a guarantee archetype (>1%%)" % [guarantee_failures, total_runs])
+		fail_count += 1
+
+	print("test_encounter_generator: %d passed, %d failed" % [pass_count, fail_count])
+	if fail_count > 0:
+		quit(1)
+	else:
+		quit(0)

--- a/godot/tests/test_runner.gd
+++ b/godot/tests/test_runner.gd
@@ -110,6 +110,8 @@ const SPRINT_TEST_FILES := [
 	"res://tests/test_multi_target_ai.gd",
 	# [S25.5] Reward pick screen + run flow — 6 conditions covering pool exclusion, seed determinism, dedup, retry seed.
 	"res://tests/test_reward_pick.gd",
+	# [S25.6] Encounter generator — pre-rolled schedule, weighted draw, no-repeat, guarantee seeds, boss-lock, large_swarm tier HP.
+	"res://tests/test_encounter_generator.gd",
 ]
 
 # [S25.1] Arc-G-pending test files: these reference APIs removed in Arc F


### PR DESCRIPTION
## S25.6 — Encounter Generator

Arc F, Sub-sprint 6 of 9.

### What this does
- `archetype_for()`: pre-rolled 15-slot run schedule with probability weights, no-repeat rule, guarantee seeds (small_swarm / counter_build_elite / miniboss_escorts ≥1 per run), boss-lock at slot 15 (idx 14)
- `compose_encounter()`: large_swarm tier-adaptive HP (0.2 → 0.4 → 0.7 → 0.9 by tier; difficulty decoupled from shape)
- `difficulty_for_battle()`: tier-by-battle-index mapping ([1,1,1,2,2,2,2,3,3,3,3,4,4,4,5])
- `game_main.gd`: replaces `standard_duel` stub + local `_tier_for_battle()` helper with `archetype_for()` / `difficulty_for_battle()`
- `run_state.gd`: `encounter_schedule: Array[String]` cache field
- `test_encounter_generator.gd`: gates 1-4+6 with 1000-run sim; registered in test_runner

### Deviation from spec
The new tier-by-battle mapping is exposed as **`difficulty_for_battle(int)`** instead of `difficulty_for(int)` to avoid colliding with the existing league-era 2-arg `difficulty_for(league: String, index: int)` (still used by `opponent_data.gd` for save-compat / batch test baseline). Same semantics; different name. Test in S25.6 updated to match.

### Test results (local)
```
test_encounter_generator: 5 passed, 0 failed
```
Full suite: `OVERALL: inline PASS | sprint files PASS` (no regressions).
