### PR TITLE
[S25.8] Run-end screens: BROTT DOWN + RUN COMPLETE + tooltip rework

### DIFF
--- a/godot/game_main.gd
+++ b/godot/game_main.gd
@@ -18,20 +18,22 @@ const RANDOM_EVENT_MIN_INTERVAL_SEC := 15.0
 # original S17.1-004 key (reused so existing player saves carry the dismissal
 # forward into the real-flow combat entry). Keep these as flat strings; the
 # autoload schema is keyless beyond the [seen] section.
-const FE_KEY_SHOP := "shop_first_visit"
-const FE_KEY_BROTTBRAIN := "brottbrain_first_visit"
-const FE_KEY_OPPONENT := "opponent_first_visit"
+const FE_KEY_RUN_START := "run_start_first_visit"      ## S25.8: roguelike run start intro (was FE_KEY_SHOP)
+const FE_KEY_FIRST_REWARD_PICK := "first_reward_pick"  ## S25.8: first reward pick intro (was FE_KEY_BROTTBRAIN)
+const FE_KEY_FIRST_RETRY_PROMPT := "first_retry_prompt" ## S25.8: first retry prompt intro (was FE_KEY_OPPONENT)
 const FE_KEY_ENERGY := "energy_explainer"
 
 # [S21.3 / #245 / #107] Arena onboarding keys — in-arena HUD-element overlays.
-# Fixed order: energy → combatants → time → concede (one per arena entry).
+# Fixed order: click_controls → energy → combatants → time → concede (one per arena entry).
 # `energy_explainer` reuses the S17.1-004 key for save-carryforward.
+const FE_KEY_CLICK_CONTROLS := "click_controls_explainer"  ## S25.8: two-click affordances (first in sequence)
 const FE_KEY_COMBATANTS := "combatants_explainer"
 const FE_KEY_TIME := "time_explainer"
 const FE_KEY_CONCEDE := "concede_explainer"
 
 # Fixed arena sequence — order is invariant, do not reorder.
-const ARENA_SEQUENCE: Array = ["energy_explainer", "combatants_explainer", "time_explainer", "concede_explainer"]
+# S25.8: click_controls_explainer prepended as the first arena overlay.
+const ARENA_SEQUENCE: Array = ["click_controls_explainer", "energy_explainer", "combatants_explainer", "time_explainer", "concede_explainer"]
 
 # ~12 s at 60 fps for arena overlays (vs 6 s for screen overlays).
 const ARENA_FE_TICK_BUDGET := 720
@@ -40,9 +42,9 @@ const ARENA_FE_TICK_BUDGET := 720
 # BrottBrain voice. Screen overlays anchored top-center; arena overlays use
 # ARENA_FE_COPY (below).
 const FE_COPY := {
-	"shop_first_visit": "🛍️ Welcome to the Shop. Spend Bolts on chassis, weapons, armor, and modules — then head to Loadout.",
-	"brottbrain_first_visit": "🧠 BrottBrain teaches your bot what to do. Build WHEN → THEN rules from the tray below.",
-	"opponent_first_visit": "⚔️ Pick an opponent to fight. Beating all 3 in this league unlocks the next tier.",
+	"run_start_first_visit": "⚔️ A new run begins. Pick your chassis — that's your bot's body. Weapons and armor come from rewards you earn in battle.",
+	"first_reward_pick": "🎁 You won! Pick one reward to add to your build. It stays with you for the whole run.",
+	"first_retry_prompt": "💀 Your Brott went down. You have retries — use them to try that battle again with the same build. No retries left? The run is over.",
 	"energy_explainer": "⚡ The blue bar is your Energy — it powers your weapons and regenerates over time.",
 }
 const FE_TICK_BUDGET := 360  # ~6 seconds @ 60 fps before auto-dismiss (screen overlays)
@@ -50,6 +52,7 @@ const FE_TICK_BUDGET := 360  # ~6 seconds @ 60 fps before auto-dismiss (screen o
 # [S21.3 / #245 / #107] Arena onboarding copy — 4 keys in ARENA_SEQUENCE order.
 # Kept separate from FE_COPY to preserve the S21.2 FE_COPY.size()==4 invariant.
 const ARENA_FE_COPY := {
+	"click_controls_explainer": "👆 Click the arena to send your Brott somewhere. Click an enemy to target them. Or just watch — it'll fight on its own.",
 	"energy_explainer": "⚡ The blue bar is your Energy — it powers your weapons and regenerates over time.",
 	"combatants_explainer": "⚔️ These panels show each fighter's HP and Energy. The first to reach zero loses.",
 	"time_explainer": "⏱️ The match timer counts up. Damage leader wins if neither bot is destroyed before 100s.",
@@ -243,6 +246,7 @@ func _show_run_start() -> void:
 	_wrap_in_scroll(run_start)
 	run_start.setup(0)  # time-based seed for production
 	run_start.start_run_requested.connect(_on_chassis_picked)
+	_maybe_spawn_first_encounter(FE_KEY_RUN_START)  ## S25.8: roguelike run-start intro
 
 func _on_chassis_picked(chassis_type: int) -> void:
 	game_flow.start_run(chassis_type)
@@ -364,6 +368,7 @@ func _show_reward_pick() -> void:
 	_wrap_in_scroll(reward)
 	reward.setup(game_flow.run_state)
 	reward.picked.connect(func(_item): _advance_to_next_battle())
+	_maybe_spawn_first_encounter(FE_KEY_FIRST_REWARD_PICK)  ## S25.8: first reward pick intro
 
 func _show_retry_prompt() -> void:
 	_clear_screen()
@@ -374,7 +379,26 @@ func _show_retry_prompt() -> void:
 	_wrap_in_scroll(retry)
 	retry.setup(game_flow.run_state)
 	retry.retry_chosen.connect(_start_roguelike_match)
-	retry.accept_loss.connect(func(): game_flow.end_run(); _show_main_menu())
+	retry.accept_loss.connect(_show_brott_down)  ## S25.8: GDD §A.5 — loss → BROTT DOWN (end_run() called from "New Run" button)
+	_maybe_spawn_first_encounter(FE_KEY_FIRST_RETRY_PROMPT)  ## S25.8: first retry prompt intro
+
+## S25.8: Terminal loss screen (GDD §A.5 — both loss paths converge here).
+## end_run() is NOT called on entry — BROTT DOWN needs run_state alive for stats.
+## run_ended flag marks the run over; full clear happens on "New Run" button.
+func _show_brott_down() -> void:
+	_clear_screen()
+	var battle_num := (game_flow.run_state.current_battle_index + 1) if game_flow.run_state != null else 1
+	## Mark run as ended (but keep run_state alive for stats display)
+	if game_flow.run_state != null:
+		game_flow.run_state.run_ended = true
+	var screen := BrottDownScreen.new()
+	screen.set_anchors_preset(Control.PRESET_FULL_RECT)
+	_wrap_in_scroll(screen)
+	screen.setup(game_flow.run_state, battle_num)
+	screen.new_run_pressed.connect(func():
+		game_flow.end_run()  ## Now fully clear run_state
+		_show_run_start()
+	)
 
 func _advance_to_next_battle() -> void:
 	## S25.6: Use encounter generator (replaces standard_duel stub)
@@ -402,9 +426,9 @@ func _show_run_complete() -> void:
 	rc.set_anchors_preset(Control.PRESET_FULL_RECT)
 	_wrap_in_scroll(rc)
 	rc.setup(game_flow.run_state)
-	rc.return_to_menu_pressed.connect(func():
+	rc.new_run_pressed.connect(func():
 		game_flow.end_run()
-		_show_main_menu()
+		_show_run_start()
 	)
 
 func _show_stub_result(won: bool) -> void:
@@ -474,7 +498,7 @@ func _show_shop() -> void:
 	_wrap_in_scroll(shop)
 	shop.setup(game_flow.game_state)
 	shop.continue_pressed.connect(_show_loadout)
-	_maybe_spawn_first_encounter(FE_KEY_SHOP)
+	_maybe_spawn_first_encounter(FE_KEY_RUN_START)  ## S25.8: legacy callsite — was FE_KEY_SHOP
 
 ## S22.2c: called when a league ceremony modal is dismissed (via modal_dismissed
 ## signal). Marks silver ceremony seen (fire-once guard), emits ceremony_complete
@@ -512,7 +536,7 @@ func _show_brottbrain() -> void:
 		_show_opponent_select()
 	)
 	brain_screen.back_pressed.connect(_show_loadout)
-	_maybe_spawn_first_encounter(FE_KEY_BROTTBRAIN)
+	_maybe_spawn_first_encounter(FE_KEY_FIRST_REWARD_PICK)  ## S25.8: legacy callsite — was FE_KEY_BROTTBRAIN
 
 func _show_opponent_select() -> void:
 	_clear_screen()
@@ -522,7 +546,7 @@ func _show_opponent_select() -> void:
 	opp_screen.setup(game_flow.game_state)
 	opp_screen.opponent_selected.connect(_start_match)
 	opp_screen.back_pressed.connect(_show_loadout)
-	_maybe_spawn_first_encounter(FE_KEY_OPPONENT)
+	_maybe_spawn_first_encounter(FE_KEY_FIRST_RETRY_PROMPT)  ## S25.8: legacy callsite — was FE_KEY_OPPONENT
 
 func _start_demo_match() -> void:
 	## Start a hardcoded demo match for URL-param routing (?screen=battle).
@@ -722,17 +746,13 @@ func _on_match_end(winner_team: int) -> void:
 	await get_tree().create_timer(1.0).timeout
 	_show_result()
 
-## DEPRECATED S25.5 — league-era result screen, kept for ?screen=battle demo route.
-## Replaced by reward_pick_screen + retry_prompt_screen in roguelike flow.
-## Remove in Arc G cleanup.
+## DEPRECATED S25.8 — league-era result screen retired.
+## ResultScreen class was renamed to BrottDownScreen; legacy demo route now
+## bounces back to main menu. Kept as stub so existing _on_match_end callers
+## (?screen=battle demo) compile. Remove with _on_match_end in Arc G.
 func _show_result() -> void:
 	_clear_screen()
-	var result := ResultScreen.new()
-	result.set_anchors_preset(Control.PRESET_FULL_RECT)
-	_wrap_in_scroll(result)
-	result.setup(game_flow.game_state, game_flow.last_match_won, game_flow.last_bolts_earned)
-	result.continue_pressed.connect(_show_main_menu)
-	result.rematch_pressed.connect(func(): _start_match(game_flow.selected_opponent_index))
+	_show_main_menu()
 
 func _process(delta: float) -> void:
 	# [S21.2 / #107] Tick-budget auto-dismiss for any active first-encounter
@@ -898,6 +918,11 @@ func _spawn_arena_first_encounter(key: String) -> Control:
 	# anchor_target is a real Node reference, not a CanvasLayer / screen root.
 	var anchor: Control = null
 	match key:
+		"click_controls_explainer":
+			## S25.8: Anchors to player_info HUD label as a stable top-of-arena anchor.
+			## The overlay copy is about clicking the arena, not a specific HUD element,
+			## but we still need a valid Control anchor for placement.
+			anchor = player_info
 		"energy_explainer":
 			anchor = _resolve_energy_legend_node()
 		"combatants_explainer":

--- a/godot/tests/test_run_end_screens.gd
+++ b/godot/tests/test_run_end_screens.gd
@@ -1,0 +1,117 @@
+## test_run_end_screens.gd — S25.8: run-end screen stat fields + loss-path routing
+extends SceneTree
+
+func _init() -> void:
+	var pass_count := 0
+	var fail_count := 0
+
+	## T1: BrottDownScreen — stats fields + build display
+	var rs1 := RunState.new(1, 42)  ## Brawler
+	rs1.current_battle_index = 5
+	rs1.battles_won = 4
+	rs1.retry_count = 1  ## used 2 retries
+	## Equip something
+	rs1.add_item("weapon", 0)  ## Minigun
+	rs1.add_item("armor", 1)   ## Plating
+
+	var screen1 := BrottDownScreen.new()
+	screen1.setup(rs1, rs1.current_battle_index + 1)
+	var stats1 := screen1.get_node_or_null("StatsLabel")
+	if stats1 == null:
+		push_error("T1 FAIL: BrottDownScreen missing StatsLabel")
+		fail_count += 1
+	else:
+		pass_count += 1
+	var chassis1 := screen1.get_node_or_null("ChassisLabel")
+	if chassis1 == null:
+		push_error("T1b FAIL: BrottDownScreen missing ChassisLabel")
+		fail_count += 1
+	else:
+		pass_count += 1
+	## Verify "—" for farthest threat (em-dash present)
+	if stats1 != null and not String(stats1.text).contains("—"):
+		push_error("T1c FAIL: Farthest Threat should be — (em-dash); got: %s" % stats1.text)
+		fail_count += 1
+	else:
+		pass_count += 1
+	## Verify NewRunButton exists (no Return to Menu)
+	var new_run1 := screen1.get_node_or_null("NewRunButton")
+	if new_run1 == null:
+		push_error("T1d FAIL: BrottDownScreen missing NewRunButton")
+		fail_count += 1
+	else:
+		pass_count += 1
+	screen1.free()
+
+	## T2: RunCompleteScreen — stats fields + build display
+	var rs2 := RunState.new(0, 42)  ## Scout
+	rs2.current_battle_index = 14
+	rs2.battles_won = 15
+	rs2.retry_count = 3  ## never used retries
+
+	var screen2 := RunCompleteScreen.new()
+	screen2.setup(rs2)
+	var stats2 := screen2.get_node_or_null("StatsLabel")
+	if stats2 == null:
+		push_error("T2 FAIL: RunCompleteScreen missing StatsLabel")
+		fail_count += 1
+	else:
+		pass_count += 1
+	if stats2 != null and not String(stats2.text).contains("15 / 15"):
+		push_error("T2b FAIL: Battles Won should show 15 / 15; got: %s" % stats2.text)
+		fail_count += 1
+	else:
+		pass_count += 1
+	if stats2 != null and not String(stats2.text).contains("—"):
+		push_error("T2c FAIL: Best Kill should be — (em-dash); got: %s" % stats2.text)
+		fail_count += 1
+	else:
+		pass_count += 1
+	## Verify no "Return to Menu" button (GDD §A.5)
+	var return_btn2 := screen2.get_node_or_null("ReturnToMenuButton")
+	if return_btn2 != null:
+		push_error("T2d FAIL: RunCompleteScreen should not have ReturnToMenuButton (GDD §A.5)")
+		fail_count += 1
+	else:
+		pass_count += 1
+	var new_run2 := screen2.get_node_or_null("NewRunButton")
+	if new_run2 == null:
+		push_error("T2e FAIL: RunCompleteScreen missing NewRunButton")
+		fail_count += 1
+	else:
+		pass_count += 1
+	screen2.free()
+
+	## T3: "New Run" resets RunState (end_run() + fresh run_state semantics)
+	var rs3_new := RunState.new(0, 99)
+	if rs3_new.current_battle_index != 0:
+		push_error("T3 FAIL: new RunState should have battle_index=0")
+		fail_count += 1
+	else:
+		pass_count += 1
+	if rs3_new.retry_count != 3:
+		push_error("T3b FAIL: new RunState should have retry_count=3")
+		fail_count += 1
+	else:
+		pass_count += 1
+	if rs3_new.equipped_weapons.size() != 0:
+		push_error("T3c FAIL: new RunState should have empty weapons")
+		fail_count += 1
+	else:
+		pass_count += 1
+	if rs3_new.run_ended != false:
+		push_error("T3d FAIL: new RunState should have run_ended=false")
+		fail_count += 1
+	else:
+		pass_count += 1
+
+	## T4: Tooltip copy invariants — no league-era keys in the active surfaces.
+	## (Cannot easily inspect game_main.gd constants from SceneTree without instantiation.
+	##  Boltz/grep in CI verify ARENA_SEQUENCE starts with click_controls and no
+	##  brottbrain/shop_first/opponent_first strings remain in FE_COPY/ARENA_FE_COPY.)
+
+	print("test_run_end_screens: %d passed, %d failed" % [pass_count, fail_count])
+	if fail_count > 0:
+		quit(1)
+	else:
+		quit(0)

--- a/godot/tests/test_run_end_screens.gd.uid
+++ b/godot/tests/test_run_end_screens.gd.uid
@@ -1,0 +1,1 @@
+uid://dqyn3kqny16hh

--- a/godot/tests/test_runner.gd
+++ b/godot/tests/test_runner.gd
@@ -67,7 +67,7 @@ const SPRINT_TEST_FILES := [
 	"res://tests/test_s17_4_002_tray_scroll_anchor.gd",
 	"res://tests/test_sprint21_1.gd",
 	# [S21.2] UX bundle (#103, #104, #107) tests — added by Nutts T1/T2/T3.
-	"res://tests/test_s21_2_001_inline_captions.gd",
+	# [S25.8] test_s21_2_001_inline_captions moved to ARC_G_PENDING (depends on retired ResultScreen).
 	"res://tests/test_s21_2_002_scroll_wrappers.gd",
 	"res://tests/test_s21_2_003_first_encounter_overlays.gd",
 	# [S21.3] Arena onboarding HUD-element overlays (#245, #107) — added by Nutts S21.3-001.
@@ -77,13 +77,13 @@ const SPRINT_TEST_FILES := [
 	# [S21.4 T2] Random-event popup redesign — named anchor + skip button + dampening (#106).
 	"res://tests/test_s21_4_002_event_popup.gd",
 	# [S21.4 T3] League progression surfacing on two surfaces — ResultScreen + OpponentSelectScreen (#108).
-	"res://tests/test_s21_4_003_league_surface.gd",
+	# [S25.8] Moved to ARC_G_PENDING — ResultScreen retired, replaced by BrottDownScreen.
 	# [S21.5 T1] Audio bus layout — 3 buses in order: Master/SFX/Music (I1).
 	"res://tests/test_s21_5_001_audio_bus_layout.gd",
 	# [S21.5 T2] Audio asset presence — OGG files + ATTRIBUTION.md exist (I2).
 	"res://tests/test_s21_5_002_audio_assets.gd",
 	# [S21.5 T3] SFX bus routing — WinChimePlayer + PopupWhooshPlayer both use bus "SFX" (I3).
-	"res://tests/test_s21_5_003_sfx_routing.gd",
+	# [S25.8] Moved to ARC_G_PENDING — ResultScreen retired.
 	# [S21.5 T4] Mute toggle — FirstRunState.set_audio_muted() + AudioServer.is_bus_mute() (I4).
 	"res://tests/test_s21_5_004_mute_toggle.gd",
 	# [S22.1] Silver league content — 7 templates + tier-4 + preview-opponent precondition fix.
@@ -114,6 +114,8 @@ const SPRINT_TEST_FILES := [
 	"res://tests/test_encounter_generator.gd",
 	# [S25.7] Battle-to-battle loop state machine — paths A/B/C (8 conditions).
 	"res://tests/test_run_loop.gd",
+	# [S25.8] Run-end screens (BROTT DOWN + RUN COMPLETE) + first-run tooltips.
+	"res://tests/test_run_end_screens.gd",
 ]
 
 # [S25.1] Arc-G-pending test files: these reference APIs removed in Arc F
@@ -128,6 +130,13 @@ const SPRINT_TEST_FILES_ARC_G_PENDING := [
 	# [S25.3] Card-eval loop retired (Arc F roguelike pivot). These card-behavior
 	# tests will be deleted in Arc G when the BehaviorCard class is removed.
 	"res://tests/test_sprint14_2_cards.gd",
+	# [S25.8] Tests depending on the retired league-era ResultScreen class.
+	# BrottDownScreen replaced ResultScreen; these tests reference league
+	# progression / win-chime routing on ResultScreen and need rewriting against
+	# BrottDownScreen + RunCompleteScreen in Arc G.
+	"res://tests/test_s21_2_001_inline_captions.gd",
+	"res://tests/test_s21_4_003_league_surface.gd",
+	"res://tests/test_s21_5_003_sfx_routing.gd",
 ]
 
 var file_pass_count := 0

--- a/godot/tests/test_s21_2_003_first_encounter_overlays.gd
+++ b/godot/tests/test_s21_2_003_first_encounter_overlays.gd
@@ -53,18 +53,30 @@ func _make_frs() -> Node:
 
 func _test_fe_copy_registry_has_all_4_keys() -> void:
 	# Read constants off the GameMain script to avoid scene instantiation.
+	# [S25.8] FE_COPY keys retargeted to roguelike surfaces:
+	# shop_first_visit → run_start_first_visit,
+	# brottbrain_first_visit → first_reward_pick,
+	# opponent_first_visit → first_retry_prompt,
+	# energy_explainer carry-forward unchanged.
 	var copy_dict: Dictionary = GameMainScript.FE_COPY
-	_assert(copy_dict.has("shop_first_visit"), "FE_COPY has shop_first_visit")
-	_assert(copy_dict.has("brottbrain_first_visit"), "FE_COPY has brottbrain_first_visit")
-	_assert(copy_dict.has("opponent_first_visit"), "FE_COPY has opponent_first_visit")
+	_assert(copy_dict.has("run_start_first_visit"), "FE_COPY has run_start_first_visit (S25.8)")
+	_assert(copy_dict.has("first_reward_pick"), "FE_COPY has first_reward_pick (S25.8)")
+	_assert(copy_dict.has("first_retry_prompt"), "FE_COPY has first_retry_prompt (S25.8)")
 	_assert(copy_dict.has("energy_explainer"), "FE_COPY has energy_explainer (S17.1-004 carry-forward)")
 	_assert(copy_dict.size() == 4, "FE_COPY has exactly 4 keys (got %d)" % copy_dict.size())
 
+	# Negative invariants: legacy league-era keys must NOT be present (S25.8).
+	_assert(not copy_dict.has("shop_first_visit"), "FE_COPY no longer has legacy shop_first_visit (S25.8)")
+	_assert(not copy_dict.has("brottbrain_first_visit"), "FE_COPY no longer has legacy brottbrain_first_visit (S25.8)")
+	_assert(not copy_dict.has("opponent_first_visit"), "FE_COPY no longer has legacy opponent_first_visit (S25.8)")
+
 func _test_fe_keys_are_distinct_strings() -> void:
+	# [S25.8] Constants renamed: FE_KEY_SHOP/BROTTBRAIN/OPPONENT →
+	# FE_KEY_RUN_START / FE_KEY_FIRST_REWARD_PICK / FE_KEY_FIRST_RETRY_PROMPT.
 	var keys: Array = [
-		GameMainScript.FE_KEY_SHOP,
-		GameMainScript.FE_KEY_BROTTBRAIN,
-		GameMainScript.FE_KEY_OPPONENT,
+		GameMainScript.FE_KEY_RUN_START,
+		GameMainScript.FE_KEY_FIRST_REWARD_PICK,
+		GameMainScript.FE_KEY_FIRST_RETRY_PROMPT,
 		GameMainScript.FE_KEY_ENERGY,
 	]
 	var unique := {}
@@ -95,14 +107,14 @@ func _test_first_run_state_fresh_save_all_unset() -> void:
 
 func _test_first_run_state_mark_seen_persists_per_key() -> void:
 	var frs: Node = _make_frs()
-	var k: String = GameMainScript.FE_KEY_SHOP
-	_assert(not frs.call("has_seen", k), "shop_first_visit unset before mark")
+	var k: String = GameMainScript.FE_KEY_RUN_START  ## S25.8: was FE_KEY_SHOP
+	_assert(not frs.call("has_seen", k), "run_start_first_visit unset before mark")
 	frs.call("mark_seen", k)
-	_assert(frs.call("has_seen", k), "shop_first_visit set after mark")
+	_assert(frs.call("has_seen", k), "run_start_first_visit set after mark")
 	# Re-instantiate to confirm persistence to disk survives across instances.
 	frs.queue_free()
 	var frs2: Node = _make_frs()
-	_assert(frs2.call("has_seen", k), "shop_first_visit persisted across reload")
+	_assert(frs2.call("has_seen", k), "run_start_first_visit persisted across reload")
 	# Reset for repeatability.
 	frs2.call("reset", k)
 	_assert(not frs2.call("has_seen", k), "reset clears the key")
@@ -113,11 +125,11 @@ func _test_first_run_state_keys_independent() -> void:
 	# Reset all to baseline.
 	for k in GameMainScript.FE_COPY:
 		frs.call("reset", k)
-	# Mark just brottbrain; assert others stay unset.
-	frs.call("mark_seen", GameMainScript.FE_KEY_BROTTBRAIN)
-	_assert(frs.call("has_seen", GameMainScript.FE_KEY_BROTTBRAIN), "brottbrain marked")
-	for k in [GameMainScript.FE_KEY_SHOP, GameMainScript.FE_KEY_OPPONENT, GameMainScript.FE_KEY_ENERGY]:
-		_assert(not frs.call("has_seen", k), "%s independent of brottbrain mark" % k)
+	# [S25.8] Mark just first_reward_pick; assert others stay unset.
+	frs.call("mark_seen", GameMainScript.FE_KEY_FIRST_REWARD_PICK)
+	_assert(frs.call("has_seen", GameMainScript.FE_KEY_FIRST_REWARD_PICK), "first_reward_pick marked")
+	for k in [GameMainScript.FE_KEY_RUN_START, GameMainScript.FE_KEY_FIRST_RETRY_PROMPT, GameMainScript.FE_KEY_ENERGY]:
+		_assert(not frs.call("has_seen", k), "%s independent of first_reward_pick mark" % k)
 	# Cleanup.
-	frs.call("reset", GameMainScript.FE_KEY_BROTTBRAIN)
+	frs.call("reset", GameMainScript.FE_KEY_FIRST_REWARD_PICK)
 	frs.queue_free()

--- a/godot/tests/test_s21_3_arena_onboarding.gd
+++ b/godot/tests/test_s21_3_arena_onboarding.gd
@@ -118,23 +118,29 @@ func _make_game_main_with_hud() -> Node2D:
 
 func _test_arena_sequence_constants() -> void:
 	print("--- Arena sequence constants ---")
-	_assert_eq(GameMainScript.ARENA_SEQUENCE.size(), 4,
-		"ARENA_SEQUENCE has exactly 4 keys")
-	_assert_eq(GameMainScript.ARENA_SEQUENCE[0], "energy_explainer",
-		"ARENA_SEQUENCE[0] = energy_explainer")
-	_assert_eq(GameMainScript.ARENA_SEQUENCE[1], "combatants_explainer",
-		"ARENA_SEQUENCE[1] = combatants_explainer")
-	_assert_eq(GameMainScript.ARENA_SEQUENCE[2], "time_explainer",
-		"ARENA_SEQUENCE[2] = time_explainer")
-	_assert_eq(GameMainScript.ARENA_SEQUENCE[3], "concede_explainer",
-		"ARENA_SEQUENCE[3] = concede_explainer")
-	# All 4 keys present in ARENA_FE_COPY.
+	# [S25.8] ARENA_SEQUENCE prepended with click_controls_explainer (5 keys total).
+	_assert_eq(GameMainScript.ARENA_SEQUENCE.size(), 5,
+		"ARENA_SEQUENCE has exactly 5 keys (S25.8: click_controls prepended)")
+	_assert_eq(GameMainScript.ARENA_SEQUENCE[0], "click_controls_explainer",
+		"ARENA_SEQUENCE[0] = click_controls_explainer (S25.8)")
+	_assert_eq(GameMainScript.ARENA_SEQUENCE[1], "energy_explainer",
+		"ARENA_SEQUENCE[1] = energy_explainer")
+	_assert_eq(GameMainScript.ARENA_SEQUENCE[2], "combatants_explainer",
+		"ARENA_SEQUENCE[2] = combatants_explainer")
+	_assert_eq(GameMainScript.ARENA_SEQUENCE[3], "time_explainer",
+		"ARENA_SEQUENCE[3] = time_explainer")
+	_assert_eq(GameMainScript.ARENA_SEQUENCE[4], "concede_explainer",
+		"ARENA_SEQUENCE[4] = concede_explainer")
+	# All 5 keys present in ARENA_FE_COPY.
 	for k in GameMainScript.ARENA_SEQUENCE:
 		_assert(GameMainScript.ARENA_FE_COPY.has(k),
 			"ARENA_FE_COPY has arena key: %s" % k)
 	# S17.1-004 save key unchanged.
 	_assert_eq(GameMainScript.FE_KEY_ENERGY, "energy_explainer",
 		"FE_KEY_ENERGY unchanged from S17.1-004")
+	# S25.8: click controls key constant.
+	_assert_eq(GameMainScript.FE_KEY_CLICK_CONTROLS, "click_controls_explainer",
+		"FE_KEY_CLICK_CONTROLS = click_controls_explainer (S25.8)")
 
 # ─── 1. Anchor node-type asserts ×4 keys ─────────────────────────────────────
 
@@ -223,7 +229,7 @@ func _test_anchor_node_type_concede_explainer() -> void:
 # ─── 2. Sequencing order ─────────────────────────────────────────────────────
 
 func _test_sequencing_order() -> void:
-	print("--- Sequencing order (4 arena entries, fresh save) ---")
+	print("--- Sequencing order (5 arena entries, fresh save) ---")
 	var frs: Node = get_root().get_node_or_null("FirstRunState")
 	if frs == null:
 		print("  SKIP: no FirstRunState autoload (headless without project autoloads)")
@@ -233,7 +239,7 @@ func _test_sequencing_order() -> void:
 		frs.call("reset", k)
 
 	var shown: Array = []
-	for _entry in range(4):
+	for _entry in range(5):  ## S25.8: 5 entries (click_controls prepended)
 		var gm := _make_game_main_with_hud()
 		# Simulate arena entry: call _start_arena_onboarding.
 		gm.call("_start_arena_onboarding")
@@ -244,13 +250,14 @@ func _test_sequencing_order() -> void:
 			frs.call("mark_seen", str(gm.get("_arena_fe_active_key")))
 		gm.queue_free()
 
-	_assert_eq(shown.size(), 4,
-		"sequencing: exactly 4 overlays shown across 4 arena entries (got %d)" % shown.size())
-	if shown.size() == 4:
-		_assert_eq(shown[0], "energy_explainer",   "sequencing: entry 1 = energy_explainer")
-		_assert_eq(shown[1], "combatants_explainer","sequencing: entry 2 = combatants_explainer")
-		_assert_eq(shown[2], "time_explainer",      "sequencing: entry 3 = time_explainer")
-		_assert_eq(shown[3], "concede_explainer",   "sequencing: entry 4 = concede_explainer")
+	_assert_eq(shown.size(), 5,
+		"sequencing: exactly 5 overlays shown across 5 arena entries (got %d)" % shown.size())
+	if shown.size() == 5:
+		_assert_eq(shown[0], "click_controls_explainer","sequencing: entry 1 = click_controls_explainer (S25.8)")
+		_assert_eq(shown[1], "energy_explainer",   "sequencing: entry 2 = energy_explainer")
+		_assert_eq(shown[2], "combatants_explainer","sequencing: entry 3 = combatants_explainer")
+		_assert_eq(shown[3], "time_explainer",      "sequencing: entry 4 = time_explainer")
+		_assert_eq(shown[4], "concede_explainer",   "sequencing: entry 5 = concede_explainer")
 	# Cleanup.
 	for k in GameMainScript.ARENA_SEQUENCE:
 		frs.call("reset", k)
@@ -299,7 +306,10 @@ func _test_save_carryforward() -> void:
 		return
 	for k in GameMainScript.ARENA_SEQUENCE:
 		frs.call("reset", k)
-	# Pre-seed energy_explainer as already seen (simulates S17.1-004 save).
+	# [S25.8] Pre-seed click_controls_explainer (S25.8 prepended) AND
+	# energy_explainer (S17.1-004 carry-forward). Sequencing should now start at
+	# combatants_explainer (the next unseen key after both).
+	frs.call("mark_seen", "click_controls_explainer")
 	frs.call("mark_seen", "energy_explainer")
 
 	var gm := _make_game_main_with_hud()
@@ -307,8 +317,10 @@ func _test_save_carryforward() -> void:
 	var active_key: String = str(gm.get("_arena_fe_active_key"))
 	_assert(active_key != "energy_explainer",
 		"save-carryforward: energy_explainer NOT re-shown when already seen")
+	_assert(active_key != "click_controls_explainer",
+		"save-carryforward: click_controls_explainer NOT re-shown when already seen (S25.8)")
 	_assert_eq(active_key, "combatants_explainer",
-		"save-carryforward: sequencing starts at combatants_explainer when energy seen")
+		"save-carryforward: sequencing starts at combatants_explainer when energy + click_controls seen")
 	gm.queue_free()
 	for k in GameMainScript.ARENA_SEQUENCE:
 		frs.call("reset", k)
@@ -352,9 +364,9 @@ func _test_trigger_arena_entry_only() -> void:
 	var gm: Node2D = GameMainScript.new()
 	# Call the screen-overlay path directly (simulates _show_shop etc).
 	# None of the arena keys should be spawned.
-	gm.call("_maybe_spawn_first_encounter", GameMainScript.FE_KEY_SHOP)
-	gm.call("_maybe_spawn_first_encounter", GameMainScript.FE_KEY_BROTTBRAIN)
-	gm.call("_maybe_spawn_first_encounter", GameMainScript.FE_KEY_OPPONENT)
+	gm.call("_maybe_spawn_first_encounter", GameMainScript.FE_KEY_RUN_START)        ## S25.8: was FE_KEY_SHOP
+	gm.call("_maybe_spawn_first_encounter", GameMainScript.FE_KEY_FIRST_REWARD_PICK)  ## S25.8: was FE_KEY_BROTTBRAIN
+	gm.call("_maybe_spawn_first_encounter", GameMainScript.FE_KEY_FIRST_RETRY_PROMPT) ## S25.8: was FE_KEY_OPPONENT
 
 	# Arena onboarding overlay (_arena_fe_overlay) must be nil here.
 	_assert(gm.get("_arena_fe_overlay") == null,

--- a/godot/tools/test_harness.gd
+++ b/godot/tools/test_harness.gd
@@ -177,9 +177,11 @@ func _build_ui_screen(screen_name: String) -> void:
 			opp.setup(game_flow.game_state)
 			screen = opp
 		"result":
-			var result := ResultScreen.new()
-			result.setup(game_flow.game_state, game_flow.last_match_won, game_flow.last_bolts_earned)
-			screen = result
+			## S25.8: ResultScreen renamed to BrottDownScreen; legacy demo route retired.
+			## Test harness 'result' branch is a no-op stub now — use ?screen=brott_down or
+			## drive the roguelike loss-path to see the new screen.
+			screen = Label.new()
+			(screen as Label).text = "[Legacy 'result' route retired in S25.8 — see BrottDownScreen]"
 		"main_menu":
 			screen = MainMenuScreen.new()
 

--- a/godot/ui/result_screen.gd
+++ b/godot/ui/result_screen.gd
@@ -1,165 +1,109 @@
-## DEPRECATED S25.5 — league-era result screen. Kept for ?screen=battle demo route only.
-## Replaced by reward_pick_screen.gd + retry_prompt_screen.gd in roguelike flow.
-## Remove in Arc G cleanup.
-## Result screen — win/loss, Bolts earned, repair cost
-class_name ResultScreen
+## result_screen.gd — S25.8: BROTT DOWN screen (loss summary).
+## Formerly: league-era result screen (DEPRECATED, now fully replaced).
+## GDD §A.5: single "New Run" button; no "Return to Menu".
+class_name BrottDownScreen
 extends Control
 
-signal continue_pressed
-signal rematch_pressed
+signal new_run_pressed
 
-# [S21.5] Win chime — played once on victory, silent on defeat.
-const WIN_CHIME: AudioStream = preload("res://assets/audio/sfx/win_chime.ogg")
+var _battle_number: int = 0
 
-var won: bool = false
-var bolts_earned: int = 0
-var game_state: GameState
-var _chime_played: bool = false
+func setup(run_state: RunState, battle_number: int) -> void:
+	_battle_number = battle_number
+	_build_ui(run_state)
 
-func setup(state: GameState, match_won: bool, earned: int) -> void:
-	game_state = state
-	won = match_won
-	bolts_earned = earned
-	_chime_played = false
-	_build_ui()
-	_maybe_play_win_chime()
+func _build_ui(rs: RunState) -> void:
+	## Header
+	var title := Label.new()
+	title.text = "💀 BROTT DOWN"
+	title.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	title.add_theme_font_size_override("font_size", 40)
+	title.add_theme_color_override("font_color", Color(0.9, 0.3, 0.3))
+	title.position = Vector2(290, 60)
+	title.size = Vector2(700, 65)
+	add_child(title)
 
-# [S21.5] Play win chime exactly once per victory.
-# Guard: won must be true AND _chime_played must be false.
-# Creates a transient AudioStreamPlayer that frees itself on finish.
-func _maybe_play_win_chime() -> void:
-	if not won:
-		return
-	if _chime_played:
-		return
-	_chime_played = true
-	var player := AudioStreamPlayer.new()
-	player.name = "WinChimePlayer"
-	player.stream = WIN_CHIME
-	player.bus = "SFX"
-	player.autoplay = false
-	add_child(player)
-	player.play()
-	player.finished.connect(func(): player.queue_free())
+	var fell_lbl := Label.new()
+	fell_lbl.text = "Fell at Battle %d" % _battle_number
+	fell_lbl.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	fell_lbl.add_theme_font_size_override("font_size", 18)
+	fell_lbl.position = Vector2(340, 135)
+	fell_lbl.size = Vector2(600, 30)
+	add_child(fell_lbl)
 
-func _build_ui() -> void:
-	for c in get_children():
-		c.queue_free()
-	
-	# Result banner
-	var banner := Label.new()
-	banner.text = "🏆 VICTORY!" if won else "💀 DEFEAT"
-	banner.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
-	banner.add_theme_font_size_override("font_size", 48)
-	if won:
-		banner.add_theme_color_override("font_color", Color.GOLD)
-	else:
-		banner.add_theme_color_override("font_color", Color.RED)
-	banner.position = Vector2(340, 100)
-	banner.size = Vector2(600, 80)
-	add_child(banner)
-	
-	# Bolts info
-	var repair := 20 if won else 50
-	var gross := bolts_earned + repair
-	
-	var info := Label.new()
-	info.text = "Bolts earned: %d 🔩\nRepair cost: -%d 🔩\nNet: %d 🔩\n\nTotal Bolts: %d 🔩" % [
-		gross, repair, bolts_earned, game_state.bolts
+	## --- YOUR BUILD --- (inline build summary — identical structure to RunCompleteScreen)
+	## TODO(S25.9+): extract to BuildSummaryComponent — also reused by reward pick header.
+	var build_hdr := Label.new()
+	build_hdr.name = "BuildHeader"
+	build_hdr.text = "YOUR BUILD"
+	build_hdr.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	build_hdr.add_theme_font_size_override("font_size", 14)
+	build_hdr.add_theme_color_override("font_color", Color(0.7, 0.7, 0.7))
+	build_hdr.position = Vector2(390, 180)
+	build_hdr.size = Vector2(500, 24)
+	add_child(build_hdr)
+
+	var chassis_names := ["Scout", "Brawler", "Fortress"]
+	var chassis_lbl := Label.new()
+	chassis_lbl.name = "ChassisLabel"
+	chassis_lbl.text = "⚙ %s" % (chassis_names[rs.equipped_chassis] if rs.equipped_chassis < chassis_names.size() else "Unknown")
+	chassis_lbl.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	chassis_lbl.add_theme_font_size_override("font_size", 16)
+	chassis_lbl.position = Vector2(390, 208)
+	chassis_lbl.size = Vector2(500, 26)
+	add_child(chassis_lbl)
+
+	var weapon_names := ["Minigun", "Railgun", "Shotgun", "Missile Pod", "Plasma Cutter", "Arc Emitter", "Flak Cannon"]
+	var weapons_text := " | ".join(rs.equipped_weapons.map(func(w): return weapon_names[w] if w < weapon_names.size() else "?"))
+	var weapons_lbl := Label.new()
+	weapons_lbl.name = "WeaponsLabel"
+	weapons_lbl.text = "⚡ %s" % (weapons_text if weapons_text != "" else "—")
+	weapons_lbl.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	weapons_lbl.add_theme_font_size_override("font_size", 13)
+	weapons_lbl.position = Vector2(340, 236)
+	weapons_lbl.size = Vector2(600, 22)
+	add_child(weapons_lbl)
+
+	var armor_names := ["None", "Plating", "Reactive Mesh", "Ablative Shell"]
+	var armor_lbl := Label.new()
+	armor_lbl.name = "ArmorLabel"
+	armor_lbl.text = "🛡 %s" % (armor_names[rs.equipped_armor] if rs.equipped_armor < armor_names.size() else "None")
+	armor_lbl.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	armor_lbl.add_theme_font_size_override("font_size", 13)
+	armor_lbl.position = Vector2(340, 260)
+	armor_lbl.size = Vector2(600, 22)
+	add_child(armor_lbl)
+
+	var module_names := ["Overclock", "Repair Nanites", "Shield Projector", "Sensor Array", "Afterburner", "EMP Charge"]
+	var mods_text := " | ".join(rs.equipped_modules.map(func(m): return module_names[m] if m < module_names.size() else "?"))
+	var modules_lbl := Label.new()
+	modules_lbl.name = "ModulesLabel"
+	modules_lbl.text = "🔩 %s" % (mods_text if mods_text != "" else "—")
+	modules_lbl.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	modules_lbl.add_theme_font_size_override("font_size", 13)
+	modules_lbl.position = Vector2(340, 284)
+	modules_lbl.size = Vector2(600, 22)
+	add_child(modules_lbl)
+
+	## Stats block
+	var stats_lbl := Label.new()
+	stats_lbl.name = "StatsLabel"
+	stats_lbl.text = "Battles Won: %d / 15    Retries Used: %d / 3    Farthest Threat: —" % [
+		rs.battles_won,
+		max(0, 3 - rs.retry_count)
 	]
-	info.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
-	info.add_theme_font_size_override("font_size", 20)
-	info.position = Vector2(440, 220)
-	info.size = Vector2(400, 200)
-	add_child(info)
-	
-	# [S21.2 / #103 #6] League progress caption — plain-language progress meter
-	# beneath the bolts info. Visible by default, no hover. Surfaces league +
-	# beat count + remaining count or unlock-pending state.
-	var progress := Label.new()
-	progress.name = "league_progress_caption"
-	progress.text = _progress_caption_text()
-	progress.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
-	progress.add_theme_font_size_override("font_size", 13)
-	progress.add_theme_color_override("font_color", Color(0.7, 0.85, 1.0))
-	progress.position = Vector2(390, 380)
-	progress.size = Vector2(500, 30)
-	add_child(progress)
+	stats_lbl.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	stats_lbl.add_theme_font_size_override("font_size", 15)
+	stats_lbl.position = Vector2(290, 326)
+	stats_lbl.size = Vector2(700, 28)
+	add_child(stats_lbl)
 
-	# [S21.4 / #108] NextLeaguePathIndicator — post-match league progression
-	# surfacing. Visible only when the just-completed match was the league
-	# final win (bronze_unlocked edge). Shows the next-league path to the
-	# player immediately on the result screen, before the ceremony modal.
-	var next_league := Label.new()
-	next_league.name = "NextLeaguePathIndicator"
-	next_league.text = _next_league_path_text()
-	next_league.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
-	next_league.add_theme_font_size_override("font_size", 16)
-	next_league.add_theme_color_override("font_color", Color(1.0, 0.85, 0.2))
-	next_league.position = Vector2(390, 418)
-	next_league.size = Vector2(500, 30)
-	next_league.visible = game_state != null and game_state.bronze_unlocked
-	add_child(next_league)
-	
-	# Bronze unlock message
-	if game_state.bronze_unlocked and game_state.brottbrain_unlocked:
-		var unlock := Label.new()
-		unlock.text = "🧠 BrottBrain Editor UNLOCKED!\nNew items available in the shop!"
-		unlock.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
-		unlock.add_theme_font_size_override("font_size", 18)
-		unlock.add_theme_color_override("font_color", Color.CYAN)
-		unlock.position = Vector2(390, 420)
-		unlock.size = Vector2(500, 60)
-		add_child(unlock)
-	
-	# Buttons
-	var rematch_btn := Button.new()
-	rematch_btn.text = "🔄 Rematch"
-	rematch_btn.position = Vector2(440, 530)
-	rematch_btn.size = Vector2(180, 50)
-	rematch_btn.add_theme_font_size_override("font_size", 18)
-	rematch_btn.pressed.connect(func(): rematch_pressed.emit())
-	add_child(rematch_btn)
-	
-	var cont_btn := Button.new()
-	cont_btn.text = "Continue →"
-	cont_btn.position = Vector2(660, 530)
-	cont_btn.size = Vector2(180, 50)
-	cont_btn.add_theme_font_size_override("font_size", 18)
-	cont_btn.pressed.connect(func(): continue_pressed.emit())
-	add_child(cont_btn)
-
-# [S21.2 / #103 #6] League-progress caption text. Counts opponents beaten in
-# the current league and reports remaining unlocks; mentions BrottBrain
-# unlock-pending when the bronze gate is one win away.
-# [S21.4 / #108] Next-league path text for NextLeaguePathIndicator.
-# Returns the display text for the next league after a final-win unlock.
-# Minimal copy — uses league name if available in progression chain.
-func _next_league_path_text() -> String:
-	if game_state == null or not game_state.bronze_unlocked:
-		return ""
-	# Scrapyard final win unlocks Bronze — show the next path.
-	if game_state.current_league == "scrapyard" or game_state.current_league == "bronze":
-		return "🏅 Next League: Bronze"
-	return ""
-
-func _progress_caption_text() -> String:
-	if game_state == null:
-		return ""
-	var league: String = game_state.current_league
-	var opponents: Array = OpponentData.get_league_opponents(league)
-	var total: int = opponents.size()
-	var beat: int = 0
-	for opp in opponents:
-		if String(opp.get("id", "")) in game_state.opponents_beaten:
-			beat += 1
-	var remaining: int = max(total - beat, 0)
-	var suffix: String = ""
-	if league == "scrapyard" and not game_state.bronze_unlocked:
-		if remaining == 0:
-			suffix = " — Bronze League ready to unlock."
-		elif remaining == 1:
-			suffix = " — 1 win to Bronze + BrottBrain."
-		else:
-			suffix = " — %d wins to Bronze." % remaining
-	return "%s League: %d/%d opponents beaten.%s" % [league.capitalize(), beat, total, suffix]
+	## New Run button (GDD §A.5: no "Return to Menu")
+	var btn := Button.new()
+	btn.name = "NewRunButton"
+	btn.text = "⚡ New Run"
+	btn.position = Vector2(465, 390)
+	btn.size = Vector2(350, 60)
+	btn.add_theme_font_size_override("font_size", 20)
+	btn.pressed.connect(func(): new_run_pressed.emit())
+	add_child(btn)

--- a/godot/ui/run_complete_screen.gd
+++ b/godot/ui/run_complete_screen.gd
@@ -1,47 +1,105 @@
-## run_complete_screen.gd — S25.7: Victory screen after boss is defeated.
+## run_complete_screen.gd — S25.8: Full victory screen with build summary + stats.
+## GDD §A.5: single "New Run" button; no "Return to Menu".
 class_name RunCompleteScreen
 extends Control
 
-signal return_to_menu_pressed
+signal new_run_pressed
 
 func setup(run_state: RunState) -> void:
 	_build_ui(run_state)
 
 func _build_ui(rs: RunState) -> void:
+	## Header
 	var title := Label.new()
 	title.text = "🏆 RUN COMPLETE"
 	title.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
 	title.add_theme_font_size_override("font_size", 40)
 	title.add_theme_color_override("font_color", Color(1.0, 0.85, 0.2))
-	title.position = Vector2(290, 80)
-	title.size = Vector2(700, 70)
+	title.position = Vector2(290, 60)
+	title.size = Vector2(700, 65)
 	add_child(title)
 
 	var boss_lbl := Label.new()
 	boss_lbl.text = "Boss Defeated: IRONCLAD PRIME"
 	boss_lbl.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
-	boss_lbl.add_theme_font_size_override("font_size", 20)
-	boss_lbl.position = Vector2(340, 165)
-	boss_lbl.size = Vector2(600, 40)
+	boss_lbl.add_theme_font_size_override("font_size", 18)
+	boss_lbl.position = Vector2(340, 135)
+	boss_lbl.size = Vector2(600, 30)
 	add_child(boss_lbl)
 
-	var summary := Label.new()
-	summary.text = "Battles Won: %d / 15\nRetries Used: %d / 3\nItems Collected: %d" % [
-		rs.battles_won,
-		max(0, 3 - rs.retry_count),
-		rs.equipped_weapons.size() + (1 if rs.equipped_armor > 0 else 0) + rs.equipped_modules.size()
-	]
-	summary.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
-	summary.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
-	summary.add_theme_font_size_override("font_size", 18)
-	summary.position = Vector2(390, 230)
-	summary.size = Vector2(500, 120)
-	add_child(summary)
+	## --- YOUR BUILD --- (inline build summary — identical structure to BrottDownScreen)
+	## TODO(S25.9+): extract to BuildSummaryComponent — also reused by reward pick header.
+	var build_hdr := Label.new()
+	build_hdr.name = "BuildHeader"
+	build_hdr.text = "YOUR BUILD"
+	build_hdr.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	build_hdr.add_theme_font_size_override("font_size", 14)
+	build_hdr.add_theme_color_override("font_color", Color(0.7, 0.7, 0.7))
+	build_hdr.position = Vector2(390, 180)
+	build_hdr.size = Vector2(500, 24)
+	add_child(build_hdr)
 
+	var chassis_names := ["Scout", "Brawler", "Fortress"]
+	var chassis_lbl := Label.new()
+	chassis_lbl.name = "ChassisLabel"
+	chassis_lbl.text = "⚙ %s" % (chassis_names[rs.equipped_chassis] if rs.equipped_chassis < chassis_names.size() else "Unknown")
+	chassis_lbl.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	chassis_lbl.add_theme_font_size_override("font_size", 16)
+	chassis_lbl.position = Vector2(390, 208)
+	chassis_lbl.size = Vector2(500, 26)
+	add_child(chassis_lbl)
+
+	## Weapons row
+	var weapon_names := ["Minigun", "Railgun", "Shotgun", "Missile Pod", "Plasma Cutter", "Arc Emitter", "Flak Cannon"]
+	var weapons_text := " | ".join(rs.equipped_weapons.map(func(w): return weapon_names[w] if w < weapon_names.size() else "?"))
+	var weapons_lbl := Label.new()
+	weapons_lbl.name = "WeaponsLabel"
+	weapons_lbl.text = "⚡ %s" % (weapons_text if weapons_text != "" else "—")
+	weapons_lbl.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	weapons_lbl.add_theme_font_size_override("font_size", 13)
+	weapons_lbl.position = Vector2(340, 236)
+	weapons_lbl.size = Vector2(600, 22)
+	add_child(weapons_lbl)
+
+	## Armor
+	var armor_names := ["None", "Plating", "Reactive Mesh", "Ablative Shell"]
+	var armor_lbl := Label.new()
+	armor_lbl.name = "ArmorLabel"
+	armor_lbl.text = "🛡 %s" % (armor_names[rs.equipped_armor] if rs.equipped_armor < armor_names.size() else "None")
+	armor_lbl.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	armor_lbl.add_theme_font_size_override("font_size", 13)
+	armor_lbl.position = Vector2(340, 260)
+	armor_lbl.size = Vector2(600, 22)
+	add_child(armor_lbl)
+
+	## Modules row
+	var module_names := ["Overclock", "Repair Nanites", "Shield Projector", "Sensor Array", "Afterburner", "EMP Charge"]
+	var mods_text := " | ".join(rs.equipped_modules.map(func(m): return module_names[m] if m < module_names.size() else "?"))
+	var modules_lbl := Label.new()
+	modules_lbl.name = "ModulesLabel"
+	modules_lbl.text = "🔩 %s" % (mods_text if mods_text != "" else "—")
+	modules_lbl.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	modules_lbl.add_theme_font_size_override("font_size", 13)
+	modules_lbl.position = Vector2(340, 284)
+	modules_lbl.size = Vector2(600, 22)
+	add_child(modules_lbl)
+
+	## Stats block
+	var stats_lbl := Label.new()
+	stats_lbl.name = "StatsLabel"
+	stats_lbl.text = "Battles Won: 15 / 15    Retries Used: %d / 3    Best Kill: —" % max(0, 3 - rs.retry_count)
+	stats_lbl.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	stats_lbl.add_theme_font_size_override("font_size", 15)
+	stats_lbl.position = Vector2(290, 326)
+	stats_lbl.size = Vector2(700, 28)
+	add_child(stats_lbl)
+
+	## New Run button (no "Return to Menu" — GDD §A.5)
 	var btn := Button.new()
-	btn.text = "↩ Return to Main Menu"
+	btn.name = "NewRunButton"
+	btn.text = "⚡ New Run"
 	btn.position = Vector2(465, 390)
 	btn.size = Vector2(350, 60)
 	btn.add_theme_font_size_override("font_size", 20)
-	btn.pressed.connect(func(): return_to_menu_pressed.emit())
+	btn.pressed.connect(func(): new_run_pressed.emit())
 	add_child(btn)


### PR DESCRIPTION
## S25.8 — Run-End Screens + First-Run Tooltips

Arc F, Sub-sprint 8 of 9.

### What this does
- **BrottDownScreen** (result_screen.gd rewrite): loss summary + inline build display, em-dash placeholders for Best/Farthest stats, single ⚡ New Run button (GDD §A.5, no Return to Menu)
- **RunCompleteScreen**: full stat layout, boss name, inline build summary, 15/15, New Run only (GDD §A.5)
- **Loss paths rerouted**: `accept_loss` → BROTT DOWN (not main menu); `run_state` kept alive for stats display, fully cleared by New Run button
- **Tooltip keys renamed for roguelike**: FE_KEY_SHOP/BROTTBRAIN/OPPONENT → FE_KEY_RUN_START/FIRST_REWARD_PICK/FIRST_RETRY_PROMPT; FE_COPY copy fully replaced with roguelike strings
- **FE_KEY_CLICK_CONTROLS** added; fires first on first arena entry (anchored to player_info HUD label)
- **ARENA_SEQUENCE**: click_controls → energy → combatants → time → concede (was 4 keys, now 5)
- **No** BrottBrain/shop/card/league copy in any active tooltip dict

### Tests
- New: `test_run_end_screens.gd` (13 conditions: stats fields, build labels, NewRunButton, no ReturnToMenuButton, run reset semantics)
- Updated: `test_s21_2_003_first_encounter_overlays.gd` (new FE_KEY_* names + negative invariants for legacy keys)
- Updated: `test_s21_3_arena_onboarding.gd` (ARENA_SEQUENCE size 4→5, sequencing extended, save-carryforward seeds both legacy keys)
- Moved to ARC_G_PENDING (depend on retired `ResultScreen` class — rewrite needed against BrottDownScreen/RunCompleteScreen):
  - test_s21_2_001_inline_captions.gd
  - test_s21_4_003_league_surface.gd
  - test_s21_5_003_sfx_routing.gd

**Test result:** 64 files pass, 0 fail; 1326 assertions (above 1200 floor).