### PR TITLE
fix(boss): IRONCLAD PRIME → CEO Brott (HCD lock 2026-04-25)

### DIFF
--- a/godot/brain/brottbrain.gd
+++ b/godot/brain/brottbrain.gd
@@ -86,7 +86,7 @@ var _default_stance: int = 0
 ## S25.9: Boss AI flag. When true, _evaluate_boss() runs instead of baseline.
 var is_boss: bool = false
 
-## S25.9: Boss brain factory — returns a BrottBrain configured for IRONCLAD PRIME.
+## S25.9: Boss brain factory — returns a BrottBrain configured for CEO Brott.
 static func boss_ai() -> BrottBrain:
 	var brain := BrottBrain.new()
 	brain.is_boss = true
@@ -129,7 +129,7 @@ func _module_ready(brott: RefCounted, mod_name: String) -> int:
 				return i
 	return -1
 
-## S25.9: Boss AI rule chain for IRONCLAD PRIME.
+## S25.9: Boss AI rule chain for CEO Brott.
 ## Priority: executioner mode (player low HP) > module auto-fire > movement.
 ## Boss does NOT use Afterburner flee — ever.
 func _evaluate_boss(brott: RefCounted, enemy: RefCounted) -> bool:

--- a/godot/data/opponent_loadouts.gd
+++ b/godot/data/opponent_loadouts.gd
@@ -524,7 +524,7 @@ const ARCHETYPE_TEMPLATES: Array[Dictionary] = [
 	},
 	{
 		"id": "boss",
-		"display_name": "IRONCLAD PRIME",
+		"display_name": "CEO Brott",
 		## Placeholder name — finalized in Arc H. S25.9 tunes AI.
 		"enemy_specs": [
 			{"chassis": 2, "weapons": [1, 0], "armor": 3, "modules": [2, 3, 5], "hp_pct": 2.0, "count": 1}

--- a/godot/ui/run_complete_screen.gd
+++ b/godot/ui/run_complete_screen.gd
@@ -20,7 +20,7 @@ func _build_ui(rs: RunState) -> void:
 	add_child(title)
 
 	var boss_lbl := Label.new()
-	boss_lbl.text = "Boss Defeated: IRONCLAD PRIME"
+	boss_lbl.text = "Boss Defeated: CEO Brott"
 	boss_lbl.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
 	boss_lbl.add_theme_font_size_override("font_size", 18)
 	boss_lbl.position = Vector2(340, 135)


### PR DESCRIPTION
S25.9 shipped boss with placeholder `IRONCLAD PRIME`; HCD locked final name as **CEO Brott** at 17:09 UTC (4 hrs before S25.9 merge). Riv read stale GDD. Patching 3 player-facing/code refs.

Non-blocking, no test impact. Code-comment changes are cosmetic.

## Files
- `godot/ui/run_complete_screen.gd` — RUN COMPLETE screen string
- `godot/data/opponent_loadouts.gd` — boss `display_name`
- `godot/brain/brottbrain.gd` — 2 doc comments

## Out of scope (carry-forward)
Corporate-ladder titles for the 14 non-boss opponents — separate Gizmo task that did not land in S25.4. Surfacing to HCD as Arc-G/interstitial decision.