### PR TITLE
[sprint-27.4] [SI4-001] Arc I: combat sim aggregator + dashboard slot

### DIFF
--- a/.github/workflows/sim.yml
+++ b/.github/workflows/sim.yml
@@ -6,18 +6,27 @@ on:
       n_runs:
         description: 'Number of parallel sim runs'
         required: false
-        default: '10'
+        default: '20'
       seed_base:
-        description: 'Base seed (leave blank for auto)'
+        description: 'Base seed (blank = auto)'
         required: false
         default: ''
+      commit_report:
+        description: 'Commit report to studio-audits (true/false)'
+        required: false
+        default: 'false'
   schedule:
-    # Nightly at 3 AM UTC
     - cron: '0 3 * * *'
+
+concurrency:
+  group: sim
+  cancel-in-progress: false
 
 jobs:
   sim:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
 
@@ -34,7 +43,7 @@ jobs:
 
       - name: Run combat sims
         run: |
-          N="${{ github.event.inputs.n_runs || '10' }}"
+          N="${{ github.event.inputs.n_runs || '20' }}"
           SEED="${{ github.event.inputs.seed_base }}"
           chmod +x godot/tests/auto/sim_runner.sh
           if [[ -n "${SEED}" ]]; then
@@ -42,6 +51,54 @@ jobs:
           else
             bash godot/tests/auto/sim_runner.sh "${N}"
           fi
+
+      - name: Aggregate sim stats
+        if: always()
+        run: |
+          RESULTS_DIR=$(ls -dt /tmp/sim_results_* 2>/dev/null | head -1)
+          if [[ -z "${RESULTS_DIR}" ]]; then
+            echo "No results directory found." >&2
+            exit 0
+          fi
+          DATE=$(date -u +%Y-%m-%d)
+          mkdir -p /tmp/sim-report
+          python3 godot/tests/auto/sim_aggregate.py "${RESULTS_DIR}" \
+            --output "/tmp/sim-report/${DATE}.md" \
+            --seed-base "${{ github.event.inputs.seed_base || 'auto' }}" \
+            --n-runs "${{ github.event.inputs.n_runs || '20' }}"
+          echo "--- Sim Report ---"
+          cat "/tmp/sim-report/${DATE}.md"
+
+      - name: Commit report to studio-audits
+        if: always() && (github.event_name == 'schedule' || github.event.inputs.commit_report == 'true')
+        env:
+          GH_TOKEN: ${{ secrets.BROTT_STUDIO_PAT }}
+        run: |
+          set -euo pipefail
+          DATE=$(date -u +%Y-%m-%d)
+          REPORT="/tmp/sim-report/${DATE}.md"
+          if [[ ! -f "${REPORT}" ]]; then
+            echo "No report to commit." >&2
+            exit 0
+          fi
+          git clone --depth=1 \
+            "https://x-access-token:${GH_TOKEN}@github.com/brott-studio/studio-audits.git" \
+            /tmp/studio-audits-push
+          cd /tmp/studio-audits-push
+          mkdir -p sim-reports/battlebrotts-v2
+          cp "${REPORT}" "sim-reports/battlebrotts-v2/${DATE}.md"
+          python3 .github/scripts/update-sim-tile.py \
+            --report "sim-reports/battlebrotts-v2/${DATE}.md" \
+            --project battlebrotts-v2 || true
+          git config user.name "The Bott"
+          git config user.email "thebott@brott-studio.studio"
+          git add "sim-reports/battlebrotts-v2/${DATE}.md" README.md
+          if git diff --cached --quiet; then
+            echo "No changes to commit."
+            exit 0
+          fi
+          git commit -m "sim-report(battlebrotts-v2): ${DATE} [skip ci]"
+          git push origin main
 
       - name: Upload sim results
         if: always()

--- a/godot/tests/auto/sim_aggregate.py
+++ b/godot/tests/auto/sim_aggregate.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""
+sim_aggregate.py — Aggregate combat sim JSON results into a Markdown report.
+
+Usage:
+    python3 sim_aggregate.py RESULTS_DIR [--output REPORT_FILE]
+                                         [--seed-base N] [--n-runs N]
+"""
+
+import argparse
+import json
+import sys
+from collections import defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+from statistics import median
+
+SCHEMA_VERSION = 1
+BALANCE_MIN = 0.30
+BALANCE_MAX = 0.70
+BALANCE_MIN_RUNS = 5
+
+
+def load_results(results_dir: Path) -> tuple[list[dict], dict]:
+    """Returns (valid_runs, error_counts)."""
+    error_counts = {"parse_errors": 0, "schema_skips": 0, "missing_fields": 0}
+    valid_runs = []
+    required_fields = {
+        "schema_version", "seed", "chassis", "chassis_name",
+        "battles_won", "battles_lost", "total_ticks",
+        "terminal_state", "wall_clock_seconds",
+    }
+    for f in sorted(results_dir.glob("run_*.json")):
+        try:
+            with open(f) as fh:
+                data = json.load(fh)
+        except (json.JSONDecodeError, OSError):
+            error_counts["parse_errors"] += 1
+            continue
+        if data.get("schema_version") != SCHEMA_VERSION:
+            error_counts["schema_skips"] += 1
+            continue
+        missing = required_fields - data.keys()
+        if missing:
+            error_counts["missing_fields"] += 1
+            continue
+        valid_runs.append(data)
+    return valid_runs, error_counts
+
+
+def aggregate(runs: list[dict]) -> dict:
+    """Returns per-chassis and overall stats dict."""
+    if not runs:
+        return {}
+    by_chassis: dict[str, list[dict]] = defaultdict(list)
+    for r in runs:
+        by_chassis[r["chassis_name"]].append(r)
+
+    def chassis_stats(group: list[dict]) -> dict:
+        n = len(group)
+        wins = sum(1 for r in group if r["terminal_state"] == "win")
+        deaths = sum(1 for r in group if r["terminal_state"] == "death")
+        timeouts = sum(1 for r in group if r["terminal_state"] == "timeout")
+        total_battles_won = sum(r["battles_won"] for r in group)
+        total_battles_lost = sum(r["battles_lost"] for r in group)
+        total_battles = total_battles_won + total_battles_lost
+        return {
+            "runs": n,
+            "win_rate": wins / n,
+            "death_rate": deaths / n,
+            "timeout_rate": timeouts / n,
+            "median_battles_won": median(r["battles_won"] for r in group),
+            "median_total_ticks": median(r["total_ticks"] for r in group),
+            "median_wall_clock_s": median(r["wall_clock_seconds"] for r in group),
+            "battle_win_rate": total_battles_won / total_battles if total_battles > 0 else 0.0,
+        }
+
+    result = {}
+    for name, group in sorted(by_chassis.items()):
+        result[name] = chassis_stats(group)
+    result["ALL"] = chassis_stats(runs)
+    return result
+
+
+def _append_failures(lines: list, error_counts: dict) -> None:
+    lines.append("## Failures")
+    lines.append("")
+    lines.append(f"- Parse errors: {error_counts.get('parse_errors', 0)}")
+    lines.append(f"- Schema skips (version mismatch): {error_counts.get('schema_skips', 0)}")
+    lines.append(f"- Missing fields: {error_counts.get('missing_fields', 0)}")
+    lines.append("")
+
+
+def render_markdown(stats: dict, meta: dict) -> str:
+    """Returns the full Markdown report string."""
+    now = meta.get("generated_at", datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M"))
+    date_str = meta.get("date", now[:10])
+    runs_collected = meta.get("runs_collected", 0)
+    runs_attempted = meta.get("runs_attempted", runs_collected)
+    seed_base = meta.get("seed_base", "auto")
+    error_counts = meta.get("error_counts", {})
+
+    lines = [
+        f"# Combat Sim Report — {date_str}",
+        "",
+        f"**Generated:** {now} UTC  ",
+        f"**Runs collected:** {runs_collected} (of {runs_attempted} attempted)  ",
+        f"**Seed base:** {seed_base}",
+        "",
+    ]
+
+    if not stats:
+        lines.append("_No valid runs collected._")
+        lines.append("")
+        _append_failures(lines, error_counts)
+        return "\n".join(lines)
+
+    lines.append("## Per-chassis aggregates")
+    lines.append("")
+    lines.append(
+        "| Chassis | Runs | Run win % | Battle win % | Death % | Timeout % | "
+        "Median battles won | Median ticks | Median wall-clock (s) |"
+    )
+    lines.append("|---|---|---|---|---|---|---|---|---|")
+
+    chassis_names = [k for k in stats if k != "ALL"]
+    for name in sorted(chassis_names):
+        s = stats[name]
+        lines.append(
+            f"| {name} | {s['runs']} | {s['win_rate']*100:.1f}% | "
+            f"{s['battle_win_rate']*100:.1f}% | {s['death_rate']*100:.1f}% | "
+            f"{s['timeout_rate']*100:.1f}% | {s['median_battles_won']:.1f} | "
+            f"{s['median_total_ticks']:.0f} | {s['median_wall_clock_s']:.3f} |"
+        )
+    if "ALL" in stats:
+        s = stats["ALL"]
+        lines.append(
+            f"| **ALL** | {s['runs']} | {s['win_rate']*100:.1f}% | "
+            f"{s['battle_win_rate']*100:.1f}% | {s['death_rate']*100:.1f}% | "
+            f"{s['timeout_rate']*100:.1f}% | {s['median_battles_won']:.1f} | "
+            f"{s['median_total_ticks']:.0f} | {s['median_wall_clock_s']:.3f} |"
+        )
+    lines.append("")
+
+    lines.append("## ⚠️ Balance flags")
+    lines.append("")
+    flags = []
+    for name in sorted(chassis_names):
+        s = stats[name]
+        if s["runs"] >= BALANCE_MIN_RUNS:
+            wr = s["win_rate"]
+            if wr < BALANCE_MIN:
+                flags.append(f"- **{name}**: run win-rate {wr*100:.1f}% (below {BALANCE_MIN*100:.0f}% floor)")
+            elif wr > BALANCE_MAX:
+                flags.append(f"- **{name}**: run win-rate {wr*100:.1f}% (above {BALANCE_MAX*100:.0f}% ceiling)")
+    if flags:
+        lines.extend(flags)
+    else:
+        lines.append("_No balance issues detected._")
+    lines.append("")
+
+    _append_failures(lines, error_counts)
+    return "\n".join(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Aggregate combat sim results into a Markdown report.")
+    parser.add_argument("results_dir", type=Path, help="Directory containing run_NNN.json files")
+    parser.add_argument("--output", type=Path, default=None, help="Output file (default: stdout)")
+    parser.add_argument("--seed-base", default="auto", help="Seed base used for this run")
+    parser.add_argument("--n-runs", type=int, default=None, help="Number of runs attempted")
+    args = parser.parse_args()
+
+    if not args.results_dir.is_dir():
+        print(f"ERROR: results_dir '{args.results_dir}' not found.", file=sys.stderr)
+        sys.exit(1)
+
+    valid_runs, error_counts = load_results(args.results_dir)
+    stats = aggregate(valid_runs)
+    now = datetime.now(timezone.utc)
+    meta = {
+        "generated_at": now.strftime("%Y-%m-%d %H:%M"),
+        "date": now.strftime("%Y-%m-%d"),
+        "runs_collected": len(valid_runs),
+        "runs_attempted": args.n_runs if args.n_runs is not None else len(valid_runs),
+        "seed_base": args.seed_base,
+        "error_counts": error_counts,
+    }
+    report = render_markdown(stats, meta)
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(report)
+        print(f"Report written to {args.output}", file=sys.stderr)
+    else:
+        print(report)
+
+
+if __name__ == "__main__":
+    main()

--- a/godot/tests/auto/sim_aggregate_test.py
+++ b/godot/tests/auto/sim_aggregate_test.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Unit tests for sim_aggregate.py"""
+
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from sim_aggregate import load_results, aggregate, render_markdown, BALANCE_MIN_RUNS
+
+
+def _make_run(
+    chassis_name="SCOUT", chassis=0, terminal_state="win",
+    battles_won=7, battles_lost=1, total_ticks=10000,
+    wall_clock_seconds=20.0, seed=1, schema_version=1,
+) -> dict:
+    return {
+        "schema_version": schema_version,
+        "seed": seed,
+        "chassis": chassis,
+        "chassis_name": chassis_name,
+        "battles_won": battles_won,
+        "battles_lost": battles_lost,
+        "total_ticks": total_ticks,
+        "terminal_state": terminal_state,
+        "reward_picks": [],
+        "final_loadout": {},
+        "wall_clock_seconds": wall_clock_seconds,
+    }
+
+
+def _write_run(directory: Path, index: int, data: dict) -> None:
+    (directory / f"run_{index:03d}.json").write_text(json.dumps(data))
+
+
+class TestLoadResults(unittest.TestCase):
+    def test_empty_dir(self):
+        with tempfile.TemporaryDirectory() as d:
+            runs, errs = load_results(Path(d))
+        self.assertEqual(runs, [])
+        self.assertEqual(errs["parse_errors"], 0)
+
+    def test_malformed_json(self):
+        with tempfile.TemporaryDirectory() as d:
+            dp = Path(d)
+            (dp / "run_000.json").write_text("{not valid json}")
+            _write_run(dp, 1, _make_run())
+            runs, errs = load_results(dp)
+        self.assertEqual(len(runs), 1)
+        self.assertEqual(errs["parse_errors"], 1)
+
+    def test_schema_mismatch(self):
+        with tempfile.TemporaryDirectory() as d:
+            dp = Path(d)
+            _write_run(dp, 0, _make_run(schema_version=99))
+            runs, errs = load_results(dp)
+        self.assertEqual(len(runs), 0)
+        self.assertEqual(errs["schema_skips"], 1)
+
+
+class TestAggregate(unittest.TestCase):
+    def test_empty_runs(self):
+        stats = aggregate([])
+        self.assertEqual(stats, {})
+
+    def test_zero_battles(self):
+        runs = [_make_run(battles_won=0, battles_lost=0, seed=i) for i in range(3)]
+        try:
+            stats = aggregate(runs)
+            self.assertAlmostEqual(stats["SCOUT"]["battle_win_rate"], 0.0)
+        except ZeroDivisionError:
+            self.fail("aggregate() raised ZeroDivisionError on zero battles")
+
+    def test_win_rate_calculation(self):
+        runs = (
+            [_make_run(terminal_state="win", seed=i) for i in range(3)] +
+            [_make_run(terminal_state="death", seed=i+100) for i in range(7)]
+        )
+        stats = aggregate(runs)
+        self.assertAlmostEqual(stats["SCOUT"]["win_rate"], 0.30)
+        self.assertAlmostEqual(stats["SCOUT"]["death_rate"], 0.70)
+
+
+class TestBalanceFlags(unittest.TestCase):
+    def _render(self, runs):
+        stats = aggregate(runs)
+        meta = {"runs_collected": len(runs), "runs_attempted": len(runs), "error_counts": {}}
+        return render_markdown(stats, meta)
+
+    def _flags_block(self, report):
+        return report.split("## ⚠️ Balance flags")[1].split("## Failures")[0]
+
+    def test_flag_below_30(self):
+        # 0% win rate with 6 runs → flagged
+        runs = [_make_run(terminal_state="death", seed=i) for i in range(6)]
+        report = self._render(runs)
+        self.assertIn("**SCOUT**", self._flags_block(report))
+        self.assertIn("below", self._flags_block(report))
+
+    def test_flag_above_70(self):
+        # 100% win rate with 6 runs → flagged
+        runs = [_make_run(terminal_state="win", seed=i) for i in range(6)]
+        report = self._render(runs)
+        self.assertIn("**SCOUT**", self._flags_block(report))
+        self.assertIn("above", self._flags_block(report))
+
+    def test_no_flag_at_exactly_30(self):
+        # Exactly 30%: 3 wins / 10 runs → NOT flagged (strict <)
+        runs = (
+            [_make_run(terminal_state="win", seed=i) for i in range(3)] +
+            [_make_run(terminal_state="death", seed=i+100) for i in range(7)]
+        )
+        report = self._render(runs)
+        self.assertNotIn("**SCOUT**", self._flags_block(report))
+
+    def test_no_flag_at_exactly_70(self):
+        # Exactly 70%: 7 wins / 10 runs → NOT flagged (strict >)
+        runs = (
+            [_make_run(terminal_state="win", seed=i) for i in range(7)] +
+            [_make_run(terminal_state="death", seed=i+100) for i in range(3)]
+        )
+        report = self._render(runs)
+        self.assertNotIn("**SCOUT**", self._flags_block(report))
+
+    def test_insufficient_data_no_flag(self):
+        # 4 runs at 0% → NOT flagged (runs < BALANCE_MIN_RUNS=5)
+        runs = [_make_run(terminal_state="death", seed=i) for i in range(BALANCE_MIN_RUNS - 1)]
+        report = self._render(runs)
+        self.assertNotIn("**SCOUT**", self._flags_block(report))
+
+    def test_no_valid_runs_no_crash(self):
+        report = render_markdown({}, {"runs_collected": 0, "runs_attempted": 0, "error_counts": {}})
+        self.assertIn("No valid runs collected", report)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
idempotency-key: sprint-27.4

## Summary

Arc I S(I).4 — Pillar 3 aggregation layer.

## Files added/modified

- `godot/tests/auto/sim_aggregate.py` (~130 LOC) — Python 3 aggregator. Per-chassis stats, balance flags (<30%/>70% win-rate with ≥5 runs), Markdown output to stdout or file.
- `godot/tests/auto/sim_aggregate_test.py` (~90 LOC) — unittest suite. Edge cases: empty dir, malformed JSON, schema mismatch, balance-flag boundaries, zero-division safety.
- `.github/workflows/sim.yml` — Updated: N=20 default, aggregation step always runs, nightly report committed to studio-audits, `commit_report` dispatch input, concurrency group.

## studio-audits changes (direct push to main)

- `.github/scripts/update-sim-tile.py` — updates SIM-REPORT block in README.md idempotently
- `README.md` — SIM-REPORT placeholder block added

## Acceptance criterion

Arc brief: chassis with <30% or >70% win-rate flagged in report. Balance flag logic implemented and unit-tested (boundary conditions at exactly 30%/70% are NOT flagged — strict < / >).

## Unit tests

All tests pass locally (`python3 -m unittest godot/tests/auto/sim_aggregate_test -v`).