### PR TITLE
[sprint-28.2] Scrapyard opponent variety fix (#295)

### DIFF
--- a/docs/gdd.md
+++ b/docs/gdd.md
@@ -814,6 +814,7 @@ Encounters are drawn from a fixed catalog of archetypes (`ARCHETYPE_TEMPLATES` i
 | `miniboss_escorts` | Mini-boss + Escorts | 1 Fortress (Minigun + Shotgun, Ablative Shell, Shield Projector, hp_pct 1.5) + 2 Scout escorts (hp_pct 0.7) |
 | `counter_build_elite` | Counter-Build Elite | Variant chosen dynamically by reading the player's loadout (anti-module / anti-range / anti-melee). |
 | `glass_cannon_blitz` | Glass-Cannon Blitz | 2 enemies: Scout chassis, Railgun + Minigun, no armor, hp_pct 0.5 |
+| `brawler_rush` | Brawler Rush | 1 enemy: Brawler chassis, Shotgun, no armor, hp_pct 0.75 |
 | `boss` | CEO Brott | Battle 15 only (see §13.8). |
 
 **Large Swarm tier override** (`LARGE_SWARM_HP_BY_TIER`, S25.6): hp_pct is decoupled from the template and set by tier — 0.2 (T1), 0.4 (T2), 0.7 (T3), 0.9 (T4) — with enemy count rising from 5 (T1–2) to 6 (T3–4).
@@ -824,14 +825,17 @@ Weights are relative (don't need to sum to 100). Picker excludes the immediately
 
 | Archetype | T1 | T2 | T3 | T4 |
 |---|---|---|---|---|
-| `standard_duel` | 55 | 30 | 20 | 15 |
+| `standard_duel` | 40 | 30 | 20 | 15 |
 | `small_swarm` | 15 | 30 | 20 | 10 |
-| `large_swarm` | 15 | 20 | 20 | 15 |
+| `large_swarm` | 10 | 20 | 20 | 15 |
 | `glass_cannon_blitz` | 15 | 10 | 5 | 10 |
+| `brawler_rush` | 20 | — | — | — |
 | `counter_build_elite` | — | 10 | 15 | 25 |
 | `miniboss_escorts` | — | — | 20 | 25 |
 
 *(Source: `ARCHETYPE_WEIGHTS_BY_TIER`, S25.6.)*
+
+*(Sprint-28.2: `brawler_rush` added to T1 archetype pool for chassis variety — Arc J #295.)*
 
 #### Run guarantees
 

--- a/godot/data/opponent_loadouts.gd
+++ b/godot/data/opponent_loadouts.gd
@@ -116,11 +116,11 @@ const TEMPLATES: Array[Dictionary] = [
 	},
 	{
 		"id": "glass_junksniper",
-		"name": "Workshop Sniper Brott",
+		"name": "Junkyard Zapper Brott",
 		"archetype": Archetype.GLASS_CANNON,
 		"tier": 1,
 		"chassis": ChassisData.ChassisType.SCOUT,
-		"weapons": [WeaponData.WeaponType.RAILGUN],
+		"weapons": [WeaponData.WeaponType.ARC_EMITTER],
 		"armor": ArmorData.ArmorType.NONE,
 		"modules": [],
 		"stance": 2,

--- a/godot/data/opponent_loadouts.gd
+++ b/godot/data/opponent_loadouts.gd
@@ -114,6 +114,45 @@ const TEMPLATES: Array[Dictionary] = [
 		"unlock_league": "scrapyard",
 		"behavior_cards": [],
 	},
+	{
+		"id": "glass_junksniper",
+		"name": "Workshop Sniper Brott",
+		"archetype": Archetype.GLASS_CANNON,
+		"tier": 1,
+		"chassis": ChassisData.ChassisType.SCOUT,
+		"weapons": [WeaponData.WeaponType.RAILGUN],
+		"armor": ArmorData.ArmorType.NONE,
+		"modules": [],
+		"stance": 2,
+		"unlock_league": "scrapyard",
+		"behavior_cards": [],
+	},
+	{
+		"id": "skirmish_buzzsaw",
+		"name": "Apprentice Brott",
+		"archetype": Archetype.SKIRMISHER,
+		"tier": 1,
+		"chassis": ChassisData.ChassisType.SCOUT,
+		"weapons": [WeaponData.WeaponType.FLAK_CANNON],
+		"armor": ArmorData.ArmorType.REACTIVE_MESH,
+		"modules": [],
+		"stance": 2,
+		"unlock_league": "scrapyard",
+		"behavior_cards": [],
+	},
+	{
+		"id": "bruiser_scrapdog",
+		"name": "Floor Supervisor Brott",
+		"archetype": Archetype.BRUISER,
+		"tier": 2,
+		"chassis": ChassisData.ChassisType.BRAWLER,
+		"weapons": [WeaponData.WeaponType.SHOTGUN],
+		"armor": ArmorData.ArmorType.NONE,
+		"modules": [],
+		"stance": 0,
+		"unlock_league": "scrapyard",
+		"behavior_cards": [],
+	},
 	# ── S21.1 Bronze content drop (Gizmo spec §4) ───────────────────────────────
 	{
 		"id": "tank_rustwall",
@@ -523,6 +562,13 @@ const ARCHETYPE_TEMPLATES: Array[Dictionary] = [
 		]
 	},
 	{
+		"id": "brawler_rush",
+		"display_name": "Brawler Rush",
+		"enemy_specs": [
+			{"chassis": 1, "weapons": [2], "armor": 0, "modules": [], "hp_pct": 0.75, "count": 1}
+		]
+	},
+	{
 		"id": "boss",
 		"display_name": "CEO Brott",
 		## Placeholder name — finalized in Arc H. S25.9 tunes AI.
@@ -612,7 +658,7 @@ static func compose_encounter(archetype_id: String, battle_index: int, run_state
 
 ## S25.6: Probability weights per tier. Weights are relative (don't need to sum to 100).
 const ARCHETYPE_WEIGHTS_BY_TIER: Dictionary = {
-	1: {"standard_duel": 55, "small_swarm": 15, "large_swarm": 15, "glass_cannon_blitz": 15},  # J.1: reduce T1 small_swarm frequency (45%→25% combined swarm) — swarm-demolition fix (#314)
+	1: {"standard_duel": 40, "small_swarm": 15, "large_swarm": 10, "glass_cannon_blitz": 15, "brawler_rush": 20},  # J.2: +brawler_rush T1 archetype for chassis variety (#295)  # J.1: reduce T1 small_swarm frequency (45%→25% combined swarm) — swarm-demolition fix (#314)
 	2: {"standard_duel": 30, "small_swarm": 30, "large_swarm": 20, "counter_build_elite": 10, "glass_cannon_blitz": 10},
 	3: {"standard_duel": 20, "small_swarm": 20, "large_swarm": 20, "miniboss_escorts": 20, "counter_build_elite": 15, "glass_cannon_blitz": 5},
 	4: {"standard_duel": 15, "small_swarm": 10, "large_swarm": 15, "miniboss_escorts": 25, "counter_build_elite": 25, "glass_cannon_blitz": 10},

--- a/godot/data/opponent_loadouts.gd
+++ b/godot/data/opponent_loadouts.gd
@@ -133,7 +133,7 @@ const TEMPLATES: Array[Dictionary] = [
 		"archetype": Archetype.SKIRMISHER,
 		"tier": 1,
 		"chassis": ChassisData.ChassisType.SCOUT,
-		"weapons": [WeaponData.WeaponType.FLAK_CANNON],
+		"weapons": [WeaponData.WeaponType.MINIGUN],
 		"armor": ArmorData.ArmorType.REACTIVE_MESH,
 		"modules": [],
 		"stance": 2,

--- a/godot/tests/test_multi_target_ai.gd
+++ b/godot/tests/test_multi_target_ai.gd
@@ -123,10 +123,10 @@ func _init() -> void:
 		pass_count += 1
 
 	## ─── T8: archetype templates complete ─────────────────────────────
-	var expected_ids := ["standard_duel", "small_swarm", "large_swarm", "miniboss_escorts", "counter_build_elite", "glass_cannon_blitz", "boss"]
+	var expected_ids := ["standard_duel", "small_swarm", "large_swarm", "miniboss_escorts", "counter_build_elite", "glass_cannon_blitz", "boss", "brawler_rush"]
 	var templates := OpponentLoadouts.ARCHETYPE_TEMPLATES
 	var t8_ok := true
-	if templates.size() != 7:
+	if templates.size() != 8:
 		t8_ok = false
 	else:
 		var actual_ids := []
@@ -137,7 +137,7 @@ func _init() -> void:
 				t8_ok = false
 				break
 	if not t8_ok:
-		push_error("T8 FAIL: ARCHETYPE_TEMPLATES should have 7 records with locked IDs (got size=%d)" % templates.size())
+		push_error("T8 FAIL: ARCHETYPE_TEMPLATES should have 8 records with locked IDs (got size=%d)" % templates.size())
 		fail_count += 1
 	else:
 		pass_count += 1

--- a/godot/tests/test_runner.gd
+++ b/godot/tests/test_runner.gd
@@ -138,6 +138,8 @@ const SPRINT_TEST_FILES := [
 	"res://tests/test_s28_1_t1_hp_baseline.gd",
 	# [Arc J / sprint-28.1 SI1-003] T1 archetype weight shift — standard_duel 40→55, small_swarm 30→15 (#314).
 	"res://tests/test_s28_1_t1_weights.gd",
+	# [Arc J / sprint-28.2 SI2-003] Scrapyard variety — 200-run legacy pool + 200-run T1 archetype, ≥95% threshold (#295).
+	"res://tests/test_s28_2_scrapyard_variety.gd",
 ]
 
 # [S25.1] Arc-G-pending test files: these reference APIs removed in Arc F

--- a/godot/tests/test_s28_1_t1_weights.gd
+++ b/godot/tests/test_s28_1_t1_weights.gd
@@ -1,5 +1,6 @@
 ## test_s28_1_t1_weights.gd — verifies T1 archetype weight shift (Arc J #314 fix).
 ## Sprint-28.1 SI1-003.
+# J.2 updated: standard_duel 55→40, large_swarm 15→10 (brawler_rush added)
 extends SceneTree
 
 func _init() -> void:
@@ -8,12 +9,12 @@ func _init() -> void:
 
 	var t1: Dictionary = OpponentLoadouts.ARCHETYPE_WEIGHTS_BY_TIER.get(1, {})
 
-	# standard_duel: 40 → 55
-	if t1.get("standard_duel", -1) != 55:
-		print("FAIL: T1 standard_duel expected 55, got ", t1.get("standard_duel", "missing"))
+	# standard_duel: 55 → 40 (J.2 updated)
+	if t1.get("standard_duel", -1) != 40:
+		print("FAIL: T1 standard_duel expected 40, got ", t1.get("standard_duel", "missing"))
 		fail_count += 1
 	else:
-		print("PASS: T1 standard_duel == 55")
+		print("PASS: T1 standard_duel == 40")
 	pass_count += 1 - (fail_count if fail_count == 1 else 0)
 
 	# small_swarm: 30 → 15
@@ -24,13 +25,13 @@ func _init() -> void:
 	else:
 		print("PASS: T1 small_swarm == 15")
 
-	# large_swarm: 15 (unchanged guard)
+	# large_swarm: 15 → 10 (J.2 updated)
 	prev = fail_count
-	if t1.get("large_swarm", -1) != 15:
-		print("FAIL: T1 large_swarm expected 15, got ", t1.get("large_swarm", "missing"))
+	if t1.get("large_swarm", -1) != 10:
+		print("FAIL: T1 large_swarm expected 10, got ", t1.get("large_swarm", "missing"))
 		fail_count += 1
 	else:
-		print("PASS: T1 large_swarm == 15 (unchanged)")
+		print("PASS: T1 large_swarm == 10 (J.2 updated)")
 
 	# glass_cannon_blitz: 15 (unchanged guard)
 	prev = fail_count

--- a/godot/tests/test_s28_2_scrapyard_variety.gd
+++ b/godot/tests/test_s28_2_scrapyard_variety.gd
@@ -74,6 +74,6 @@ func _init() -> void:
 
 	print("test_s28_2_scrapyard_variety: %s" % ("ALL PASSED" if fail_count == 0 else "%d FAILED" % fail_count))
 	if fail_count > 0:
-		OS.exit(1)
+		quit(1)
 	else:
 		quit(0)

--- a/godot/tests/test_s28_2_scrapyard_variety.gd
+++ b/godot/tests/test_s28_2_scrapyard_variety.gd
@@ -1,0 +1,79 @@
+## test_s28_2_scrapyard_variety.gd — Sprint-28.2 SI2-003
+## Two variety tests for Scrapyard opponent pool and T1 archetype scheduling.
+## Test 1: Legacy TEMPLATES pool — 200-run sim, 3-battle Scrapyard runs, ≥95% get ≥2 distinct archetypes.
+## Test 2: T1 archetype_for() variety — 200-run sim, 3-battle schedule, ≥95% get ≥2 distinct archetype IDs.
+extends SceneTree
+
+func _init() -> void:
+	var fail_count := 0
+
+	# ── Test 1: Legacy TEMPLATES variety (200-run sim) ──────────────────────────
+	var t1_variety_pass := 0
+	var t1_arch_histogram: Dictionary = {}
+
+	for run_i in range(200):
+		var archetypes_seen: Dictionary = {}
+		var all_non_empty := true
+
+		for battle_idx in range(3):
+			var tier: int = OpponentLoadouts.difficulty_for("scrapyard", battle_idx)
+			var last_arch: int = -1
+			var t: Dictionary = OpponentLoadouts.pick_opponent_loadout(tier, "scrapyard", last_arch)
+
+			if t.is_empty():
+				all_non_empty = false
+				break
+
+			var arch = t.get("archetype", -1)
+			archetypes_seen[arch] = archetypes_seen.get(arch, 0) + 1
+			last_arch = arch
+
+			var arch_key := str(arch)
+			t1_arch_histogram[arch_key] = t1_arch_histogram.get(arch_key, 0) + 1
+
+		if all_non_empty and archetypes_seen.size() >= 2:
+			t1_variety_pass += 1
+
+	var t1_pass_rate: float = float(t1_variety_pass) / 200.0
+	if t1_pass_rate >= 0.95:
+		print("PASS: Test1 legacy TEMPLATES variety — pass_rate=%.3f (threshold 0.95)" % t1_pass_rate)
+	else:
+		print("FAIL: Test1 legacy TEMPLATES variety — pass_rate=%.3f < 0.95" % t1_pass_rate)
+		print("  Archetype histogram: ", t1_arch_histogram)
+		fail_count += 1
+
+	# ── Test 2: T1 archetype_for() variety (200-run sim) ────────────────────────
+	var t2_variety_pass := 0
+	var t2_arch_histogram: Dictionary = {}
+
+	for run_i in range(200):
+		var rng := RandomNumberGenerator.new()
+		rng.seed = run_i
+
+		var run_state := RunState.new()
+		# Reset the encounter schedule so each run is fresh
+		run_state.encounter_schedule = []
+
+		var arch_ids_seen: Dictionary = {}
+
+		for battle_idx in range(3):
+			var arch_id: String = OpponentLoadouts.archetype_for(battle_idx, run_state, rng)
+			arch_ids_seen[arch_id] = arch_ids_seen.get(arch_id, 0) + 1
+			t2_arch_histogram[arch_id] = t2_arch_histogram.get(arch_id, 0) + 1
+
+		if arch_ids_seen.size() >= 2:
+			t2_variety_pass += 1
+
+	var t2_pass_rate: float = float(t2_variety_pass) / 200.0
+	if t2_pass_rate >= 0.95:
+		print("PASS: Test2 T1 archetype_for variety — pass_rate=%.3f (threshold 0.95)" % t2_pass_rate)
+	else:
+		print("FAIL: Test2 T1 archetype_for variety — pass_rate=%.3f < 0.95" % t2_pass_rate)
+		print("  Archetype ID histogram: ", t2_arch_histogram)
+		fail_count += 1
+
+	print("test_s28_2_scrapyard_variety: %s" % ("ALL PASSED" if fail_count == 0 else "%d FAILED" % fail_count))
+	if fail_count > 0:
+		OS.exit(1)
+	else:
+		quit(0)


### PR DESCRIPTION
Refs #295

Sprint-28.2 fixes Scrapyard (T1) opponent variety degradation surfaced in Arc J playtest triage.

### Changes
- **[SI2-001]** 3 new legacy TEMPLATES: `glass_junksniper` (GLASS_CANNON T1), `skirmish_buzzsaw` (SKIRMISHER T1), `bruiser_scrapdog` (BRUISER T2) — all `unlock_league: "scrapyard"`
- **[SI2-002]** New `brawler_rush` archetype in ARCHETYPE_TEMPLATES; T1 weights updated (standard_duel 40, small_swarm 15, large_swarm 10, glass_cannon_blitz 15, brawler_rush 20)
- **[SI2-003]** New variety test `test_s28_2_scrapyard_variety.gd` — 200-run legacy pool test + 200-run T1 archetype test, ≥95% threshold
- **[SI2-004]** GDD §13.4 updated with brawler_rush row + sprint note

### DoD checklist
- [ ] Gate 1: ≥4 templates at Scrapyard cap — code inspection (Specc)
- [ ] Gate 2: ≥3 distinct archetypes — code inspection (Specc)
- [ ] Gate 3: ≥95% variety test — Optic post-merge
- [ ] Gate 4: No Bronze regression — Optic spot-check
- [ ] Gate 5: Specc audit at v2-sprint-28.2.md

Do NOT auto-close #295 — awaiting Optic variety test confirmation.