### PR TITLE
[sprint-28.4] Fix sim_aggregate.py JSON parse (CF-J1-001)

### DIFF
--- a/godot/tests/auto/sim_aggregate.py
+++ b/godot/tests/auto/sim_aggregate.py
@@ -33,8 +33,19 @@ def load_results(results_dir: Path) -> tuple[list[dict], dict]:
     for f in sorted(results_dir.glob("run_*.json")):
         try:
             with open(f) as fh:
-                data = json.load(fh)
-        except (json.JSONDecodeError, OSError):
+                data = None
+                for line in fh:
+                    line = line.strip()
+                    if line.startswith('{'):
+                        try:
+                            data = json.loads(line)
+                            break
+                        except json.JSONDecodeError:
+                            continue
+        except OSError:
+            error_counts["parse_errors"] += 1
+            continue
+        if data is None:
             error_counts["parse_errors"] += 1
             continue
         if data.get("schema_version") != SCHEMA_VERSION:


### PR DESCRIPTION
Fixes CF-J1-001: sim_aggregate.py fails because Godot writes engine diagnostic lines before JSON output. Update load_results() to scan for the first JSON-parseable line instead of loading the whole file.

Resolves Gate 1 of J.1 (T1 battle duration histogram).