### PR TITLE
[sprint-28.6] J.5.2: Fortress T1 HP buff + T1 weight rebalance + sim REWARD_PICK fix (#314)

### DIFF
--- a/godot/data/chassis_data.gd
+++ b/godot/data/chassis_data.gd
@@ -35,7 +35,7 @@ const CHASSIS := {
 	},
 	ChassisType.FORTRESS: {
 		"name": "Fortress",
-		"hp": 330,  # S13.3: base 220 × 1.5 pacing multiplier (GDD spec is 220; engine uses 1.5×)
+		"hp": 450,  # J.5.2: +36% HP buff for T1 survivability (was 330). Fortress is slowest chassis (60 px/s), 0 dodge, Defensive stance — cannot outrun T1 glass_cannon_blitz kite encounter. Scout/Brawler got +30-31% in J.5.1 (#314).
 		"speed": 60.0,
 		"accel": 90.0,
 		"decel": 150.0,

--- a/godot/data/opponent_loadouts.gd
+++ b/godot/data/opponent_loadouts.gd
@@ -658,7 +658,7 @@ static func compose_encounter(archetype_id: String, battle_index: int, run_state
 
 ## S25.6: Probability weights per tier. Weights are relative (don't need to sum to 100).
 const ARCHETYPE_WEIGHTS_BY_TIER: Dictionary = {
-	1: {"standard_duel": 50, "small_swarm": 15, "large_swarm": 10, "glass_cannon_blitz": 15, "brawler_rush": 10},  # J.5: brawler_rush weight halved (20→10); standard_duel raised (40→50) — T1 calibration for Brawler survivability (#314)
+	1: {"standard_duel": 60, "small_swarm": 15, "large_swarm": 10, "glass_cannon_blitz": 5, "brawler_rush": 10},  # J.5.2: glass_cannon_blitz 15→5 (Fortress can't handle 2 Railgun kiting enemies at T1 before reward picks); standard_duel 50→60 to absorb weight delta. Permanent balance decision (#314).
 	2: {"standard_duel": 30, "small_swarm": 30, "large_swarm": 20, "counter_build_elite": 10, "glass_cannon_blitz": 10},
 	3: {"standard_duel": 20, "small_swarm": 20, "large_swarm": 20, "miniboss_escorts": 20, "counter_build_elite": 15, "glass_cannon_blitz": 5},
 	4: {"standard_duel": 15, "small_swarm": 10, "large_swarm": 15, "miniboss_escorts": 25, "counter_build_elite": 25, "glass_cannon_blitz": 10},

--- a/godot/tests/auto/sim_single_run.gd
+++ b/godot/tests/auto/sim_single_run.gd
@@ -33,6 +33,7 @@ var _chosen_chassis: int = -1
 var _chassis_names := {0: "SCOUT", 1: "BRAWLER", 2: "FORTRESS"}
 var _reward_picks: Array = []
 var _battles_lost: int = 0
+var _reward_pick_retries: int = 0
 var _cumulative_arena_ticks: int = 0
 var _last_arena_ticks_seen: int = 0
 var _arena_ticks_recorded: bool = false
@@ -123,18 +124,26 @@ func _drive_flow_step() -> void:
 					var tick_count: int = sim.get("tick_count")
 					_cumulative_arena_ticks += tick_count
 					_arena_ticks_recorded = true
-				# Wait for game_main's 1s create_timer to fire and screen to transition
-				_ticks_remaining = 60
+				# Wait for game_main's 1s create_timer to fire and screen to transition.
+				# At 8x sim speed, 1s real-time ≈ 80+ Godot frames. Use 120 ticks with
+				# margin. (J.5.2: fixes REWARD_PICK no-buttons crash, #314)
+				_ticks_remaining = 120
 
 		SCREEN_REWARD_PICK:
 			var rs: Object = gf.get("run_state") if gf != null else null
 			var battle_idx: int = rs.get("current_battle_index") if rs != null else 0
 			var btn_count: int = _count_reward_buttons()
 			if btn_count <= 0:
-				_failures.append("REWARD_PICK: no reward buttons at battle %d" % battle_idx)
-				_flow_done = true
-				finish(1)
+				_reward_pick_retries += 1
+				if _reward_pick_retries >= 5:
+					_failures.append("REWARD_PICK: no reward buttons at battle %d after %d retries" % [battle_idx, _reward_pick_retries])
+					_flow_done = true
+					finish(1)
+					return
+				# Screen not ready yet — wait and retry (J.5.2: graceful retry instead of hard-fail, #314)
+				_ticks_remaining = 20
 				return
+			_reward_pick_retries = 0  # reset on success
 			var btn_idx: int = _rng.randi_range(0, btn_count - 1)
 			_reward_picks.append({"battle_index": battle_idx, "button_index": btn_idx})
 			click_reward(btn_idx)

--- a/godot/tests/test_runner.gd
+++ b/godot/tests/test_runner.gd
@@ -342,7 +342,7 @@ func _run_data_tests() -> void:
 	assert_eq(brawler["module_slots"], 2, "Brawler module slots = 2")
 	
 	var fortress := ChassisData.get_chassis(ChassisData.ChassisType.FORTRESS)
-	assert_eq(fortress["hp"], 330, "Fortress HP = 330 (S13.3: 220 × 1.5 pacing)")
+	assert_eq(fortress["hp"], 450, "Fortress HP = 450 (J.5.2: +36% T1 survivability buff, was 330)")
 	assert_near(fortress["speed"], 60.0, 0.1, "Fortress speed = 60")
 	assert_eq(fortress["weapon_slots"], 2, "Fortress weapon slots = 2")
 	assert_eq(fortress["module_slots"], 1, "Fortress module slots = 1")

--- a/godot/tests/test_s28_1_t1_weights.gd
+++ b/godot/tests/test_s28_1_t1_weights.gd
@@ -9,12 +9,12 @@ func _init() -> void:
 
 	var t1: Dictionary = OpponentLoadouts.ARCHETYPE_WEIGHTS_BY_TIER.get(1, {})
 
-	# standard_duel: 55 → 40 → 50 (J.2 updated, J.5 per-chassis T1 tuning)
-	if t1.get("standard_duel", -1) != 50:
-		print("FAIL: T1 standard_duel expected 50, got ", t1.get("standard_duel", "missing"))
+	# standard_duel: 55 → 40 → 50 → 60 (J.2 updated, J.5 per-chassis T1 tuning, J.5.2 absorbs glass_cannon_blitz delta)
+	if t1.get("standard_duel", -1) != 60:
+		print("FAIL: T1 standard_duel expected 60, got ", t1.get("standard_duel", "missing"))
 		fail_count += 1
 	else:
-		print("PASS: T1 standard_duel == 50 (J.5: weight raised 40→50)")
+		print("PASS: T1 standard_duel == 60 (J.5.2: weight raised 50→60)")
 	pass_count += 1 - (fail_count if fail_count == 1 else 0)
 
 	# small_swarm: 30 → 15
@@ -33,13 +33,13 @@ func _init() -> void:
 	else:
 		print("PASS: T1 large_swarm == 10 (J.2 updated)")
 
-	# glass_cannon_blitz: 15 (unchanged guard)
+	# glass_cannon_blitz: 15→5 (J.5.2: Fortress T1 survivability fix)
 	prev = fail_count
-	if t1.get("glass_cannon_blitz", -1) != 15:
-		print("FAIL: T1 glass_cannon_blitz expected 15, got ", t1.get("glass_cannon_blitz", "missing"))
+	if t1.get("glass_cannon_blitz", -1) != 5:
+		print("FAIL: T1 glass_cannon_blitz expected 5, got ", t1.get("glass_cannon_blitz", "missing"))
 		fail_count += 1
 	else:
-		print("PASS: T1 glass_cannon_blitz == 15 (unchanged)")
+		print("PASS: T1 glass_cannon_blitz == 5 (J.5.2: 15→5)")
 
 	# T2 spot-check: standard_duel unchanged at 30
 	var t2: Dictionary = OpponentLoadouts.ARCHETYPE_WEIGHTS_BY_TIER.get(2, {})


### PR DESCRIPTION
## Summary

Closes #314 (Fortress 0% T1 win-rate — was never addressed by J.5.1 due to name mix-up).

### Root cause
J.5.1 changed Scout + Brawler HP but left Fortress HP unchanged at 330. Fortress (60px/s, 0 dodge, Defensive stance) cannot close range vs T1 `glass_cannon_blitz` (2× Railgun+Minigun Scout kiting enemies at 12-tile range) before reward picks improve the build. Result: 0% win-rate.

### Changes
**A. Fortress HP** (`chassis_data.gd`):
- Fortress: HP 330→450 (+36%). Larger absolute bump needed vs Scout/Brawler (+30-31%) because Fortress has 0 dodge and cannot evade. Scout/Brawler unchanged.

**B. T1 encounter weights** (`opponent_loadouts.gd`):
- `glass_cannon_blitz`: 15→5 (permanent — T1 is onboarding tier; extreme kite encounters belong at T2+)
- `standard_duel`: 50→60 (absorbs delta)
- All other T1 weights unchanged

**C. Sim REWARD_PICK fix** (`sim_single_run.gd`):
- Arena match_over `_ticks_remaining`: 60→120 (covers 1s real-time timer at 8x speed)
- REWARD_PICK branch: 5-retry grace instead of immediate hard-fail (timing race fix)
- Fixes 7/20 parse errors from previous sim runs

**D. Test updates** (`test_s28_1_t1_weights.gd`):
- T1 weight assertions: glass_cannon_blitz 15→5, standard_duel 50→60
- Note: `test_sprint4.gd` Fortress HP assertion was already RETIRED (replaced with sanity `> 0` check in S16.2); no change needed.

### DoD gates (Optic validates)
- Combat sim: Fortress ≥30% WR, Scout ≥30%, Brawler ≥30%
- Parse errors: 0/20
- AutoDriver: all 4 flows green
- Issue #314 closes when all 3 chassis hit ≥30%