### PR TITLE
[sprint-29.1] Arc K: headless sim timer bypass — fix 9/20 parse errors (#314)

### DIFF
--- a/godot/game_main.gd
+++ b/godot/game_main.gd
@@ -408,7 +408,14 @@ func _on_roguelike_match_end(winner_team: int) -> void:
 				alive_per_team[b.team] = alive_per_team.get(b.team, 0) + 1
 		print("[S25.7] match_end: winner=%d alive=%s" % [winner_team, str(alive_per_team)])
 	var won := winner_team == 0
-	await get_tree().create_timer(1.0).timeout
+	## Arc K: headless-mode timer bypass.
+	## In headless sim mode, create_timer(1.0) is a real-time wall-clock delay
+	## that races against the SceneTree tick loop — the REWARD_PICK screen is
+	## set up before the timer fires, leaving btn_count=0 and crashing the sim.
+	## Production path (non-headless) is unchanged: the 1s delay still plays
+	## for the death animation in the live web build.
+	if not OS.has_feature("headless"):
+		await get_tree().create_timer(1.0).timeout
 	if won:
 		## S25.7: Boss win (battle 15 / index 14) → RUN_COMPLETE, not reward pick
 		if game_flow.current_screen == GameFlow.Screen.BOSS_ARENA:


### PR DESCRIPTION
## Summary

Fixes the root cause of the 9/20 parse error rate that blocked issue #314.

**Root cause:** `_on_roguelike_match_end` calls `await get_tree().create_timer(1.0).timeout` before routing to the reward-pick or retry screen. This is a real-time wall-clock delay. In headless sim mode, Godot's real-time timers run on the wall clock — at 8× sim speed, the sim races past the REWARD_PICK screen transition while the 1-second timer is still counting. The screen appears with `btn_count=0` and the sim hard-fails.

**Fix:** Gate the timer behind `OS.has_feature("headless")`. When headless (sim path), skip the delay entirely and call the outcome path immediately. Production path — the live web build — is completely unchanged; the 1s death-animation delay still fires for real players.

**Changes:**
- `godot/game_main.gd`: wrap `await get_tree().create_timer(1.0).timeout` with `if not OS.has_feature("headless"):` guard

**Safety:**
- `OS.has_feature("headless")` is only `true` when Godot is launched with `--headless` flag
- The live web build (HTML5 export) never uses `--headless`
- AutoDriver validation confirms production path is unchanged

Closes #314