### PR TITLE
[sprint-28.7] K.2b: Fix battle 2+ ARENA screen state — real root cause of #314 parse errors

### DIFF
--- a/godot/game_main.gd
+++ b/godot/game_main.gd
@@ -393,7 +393,11 @@ func _start_roguelike_match() -> void:
 
 	_create_arena_hud()
 
-	if game_flow.current_screen == GameFlow.Screen.RUN_START:
+	## K.2: unconditionally set ARENA on match start so any battle
+	## after battle-0 (called from REWARD_PICK or RETRY_PROMPT, not
+	## RUN_START) is visible to the AutoDriver screen-state machine.
+	## Boss arena is pre-set by _show_boss_arena(); preserve it.
+	if game_flow.current_screen != GameFlow.Screen.BOSS_ARENA:
 		game_flow.current_screen = GameFlow.Screen.ARENA
 	in_arena = true
 	speed_multiplier = 1.0

--- a/godot/game_main.gd
+++ b/godot/game_main.gd
@@ -416,6 +416,8 @@ func _on_roguelike_match_end(winner_team: int) -> void:
 	## for the death animation in the live web build.
 	if not OS.has_feature("headless"):
 		await get_tree().create_timer(1.0).timeout
+	else:
+		await get_tree().process_frame  ## K.2: one-frame settle, no wall-clock race
 	if won:
 		## S25.7: Boss win (battle 15 / index 14) → RUN_COMPLETE, not reward pick
 		if game_flow.current_screen == GameFlow.Screen.BOSS_ARENA:
@@ -813,7 +815,10 @@ func _on_match_end(winner_team: int) -> void:
 	var won := winner_team == 0
 	game_flow.finish_match(won)
 	# Show result after a brief delay (let death animation play)
-	await get_tree().create_timer(1.0).timeout
+	if not OS.has_feature("headless"):
+		await get_tree().create_timer(1.0).timeout
+	else:
+		await get_tree().process_frame  ## K.2: one-frame settle, no wall-clock race
 	_show_result()
 
 ## DEPRECATED S25.8 — league-era result screen retired.
@@ -1241,7 +1246,10 @@ func _on_brott_death(_brott) -> void:
 		_death_sfx_cooldown_active = true
 		_death_sfx_player.play()
 		# Reset cooldown after 600ms to allow future matches to play death SFX.
-		await get_tree().create_timer(0.6).timeout
+		if not OS.has_feature("headless"):
+			await get_tree().create_timer(0.6).timeout
+		else:
+			await get_tree().process_frame  ## K.2: one-frame settle, no wall-clock race
 		_death_sfx_cooldown_active = false
 
 # [S24.3] Signal handler: on_projectile_spawned — play launch SFX per projectile.


### PR DESCRIPTION
## Root cause (newly diagnosed)

The 8/20 parse errors in K.1 (and 7/20 in K.2) are caused by `_start_roguelike_match` not setting `current_screen = ARENA` for battles 2+ — only battle 0 (called from `RUN_START`) was handled.

Battles 1+ are entered from `REWARD_PICK` or `RETRY_PROMPT`. After clicking the battle 0 reward pick, `_advance_to_next_battle()` → `_start_roguelike_match()` runs with `current_screen = REWARD_PICK`. The screen transition guard only fires for `RUN_START`, so `current_screen` stays `REWARD_PICK` while battle 1's arena sim runs. AutoDriver then sees `SCREEN_REWARD_PICK`, looks for reward buttons (none — old screen was queue_freed), retries 5× and fails.

## Fix

Unconditionally set `current_screen = ARENA` in `_start_roguelike_match`, except when coming from `BOSS_ARENA` (pre-set by `_show_boss_arena()`).

This PR also includes the K.2 create_timer sweep (all three sites patched with headless guard + process_frame settle) from the already-merged K.2 commit.

Closes #314 pending sim gate pass.