### PR TITLE
[sprint-28.8] K.3: Brawler T1 balance fix (#314)

### DIFF
--- a/godot/data/chassis_data.gd
+++ b/godot/data/chassis_data.gd
@@ -22,7 +22,7 @@ const CHASSIS := {
 	},
 	ChassisType.BRAWLER: {
 		"name": "Brawler",
-		"hp": 295,  # J.5: +31% HP to survive T1 Shotgun encounters (was 225)
+		"hp": 360,  # K.3: +22% HP buff to lift T1 battle win-rate ≥30% (was 295, #314)
 		"speed": 120.0,
 		"accel": 240.0,
 		"decel": 360.0,

--- a/godot/tests/test_runner.gd
+++ b/godot/tests/test_runner.gd
@@ -336,7 +336,7 @@ func _run_data_tests() -> void:
 	assert_near(scout["dodge_chance"], 0.25, 0.001, "Scout dodge = 25%")  # Updated for J.5 per-chassis T1 tuning (sprint-28.5)
 	
 	var brawler := ChassisData.get_chassis(ChassisData.ChassisType.BRAWLER)
-	assert_eq(brawler["hp"], 295, "Brawler HP = 295 (J.5 per-chassis tuning)")  # Updated for J.5 per-chassis T1 tuning (sprint-28.5)
+	assert_eq(brawler["hp"], 360, "Brawler HP = 360 (K.3 T1 balance fix, #314)")  # Updated for J.5 per-chassis T1 tuning (sprint-28.5)
 	assert_near(brawler["speed"], 120.0, 0.1, "Brawler speed = 120")
 	assert_eq(brawler["weapon_slots"], 2, "Brawler weapon slots = 2")
 	assert_eq(brawler["module_slots"], 2, "Brawler module slots = 2")

--- a/godot/tests/test_sprint4.gd
+++ b/godot/tests/test_sprint4.gd
@@ -126,7 +126,7 @@ func _test_scout_hp_1_5x() -> void:
 func _test_brawler_hp_1_5x() -> void:
 	print("test_brawler_hp_1_5x")
 	var ch := ChassisData.get_chassis(ChassisData.ChassisType.BRAWLER)
-	assert_eq(ch["hp"], 295, "Brawler HP = 295 (J.5 per-chassis tuning)")  # Updated for J.5 per-chassis T1 tuning (sprint-28.5)
+	assert_eq(ch["hp"], 360, "Brawler HP = 360 (K.3 T1 balance fix, #314)")  # Updated for J.5 per-chassis T1 tuning (sprint-28.5)
 
 func _test_fortress_hp_1_5x() -> void:
 	print("test_fortress_hp_1_5x")


### PR DESCRIPTION
Surgical Brawler HP buff to bring T1 battle win-rate from 25% to ≥30%. Scout (69%) and Fortress (46%) unchanged.

## Change
- Brawler HP: 295 → 360 (+22%)
- No other stats modified

## Context
Sim (2026-04-29 18:21 UTC, 0/20 parse errors):
- Scout: 68.8% ✅
- Fortress: 45.5% ✅  
- Brawler: 25.0% ❌ (below 30% floor)

Closes #314 pending sim gate pass.