### PR TITLE
[sprint-28.9] K.4: Brawler T1 starting weapon → Shotgun (#314)

### DIFF
--- a/godot/game/run_state.gd
+++ b/godot/game/run_state.gd
@@ -64,9 +64,15 @@ func _init(chassis_type: int = 0, rng_seed: int = 0) -> void:
 	## least one weapon. Pre-S26.1 the player had `equipped_weapons = []`, which
 	## meant battle 1 was unwinnable (the player couldn't fire) and felt like a
 	## blank screen. GDD never specified a starter weapon, so we fill the gap
-	## here with Plasma Cutter (WeaponData.WeaponType.PLASMA_CUTTER == 4).
+	## here with a chassis-appropriate starter.
+	## [K.4] Brawler (chassis 1) starts with Shotgun (WeaponData.WeaponType.SHOTGUN == 2)
+	## to close the mobility gap vs kiting opponents at T1 (#314). Scout/Fortress
+	## keep Plasma Cutter (WeaponData.WeaponType.PLASMA_CUTTER == 4).
 	if equipped_weapons.is_empty():
-		equipped_weapons.append(4)  # WeaponData.WeaponType.PLASMA_CUTTER
+		if chassis_type == 1:  # ChassisData.ChassisType.BRAWLER
+			equipped_weapons.append(2)  # WeaponData.WeaponType.SHOTGUN
+		else:
+			equipped_weapons.append(4)  # WeaponData.WeaponType.PLASMA_CUTTER
 
 ## S25.5: Set the current encounter context (called before entering ARENA).
 func set_encounter(archetype_id: String, tier: int, arena_seed: int) -> void:

--- a/godot/tests/test_s26_1_starter_weapon.gd
+++ b/godot/tests/test_s26_1_starter_weapon.gd
@@ -5,51 +5,59 @@
 ## fire, the swarm killed them in seconds — playtest reported as "blank
 ## screen" because nothing meaningful happened on-screen.
 ##
-## Post-S26.1 behavior: RunState._init() seeds equipped_weapons with the
-## Plasma Cutter (WeaponData.WeaponType.PLASMA_CUTTER == 4) when the array
-## is empty, guaranteeing every new run enters battle 1 with at least one
-## firing weapon. These assertions all FAIL on main @ 9aa417f and PASS
-## post-fix.
+## Post-S26.1 behavior: RunState._init() seeds equipped_weapons with a
+## chassis-appropriate starter weapon when the array is empty:
+##   - Brawler (chassis 1): Shotgun (WeaponData.WeaponType.SHOTGUN == 2)
+##     [K.4: closes mobility gap vs kiting opponents at T1, #314]
+##   - Scout/Fortress (chassis 0/2): Plasma Cutter (WeaponData.WeaponType.PLASMA_CUTTER == 4)
+## These assertions all FAIL on main @ 9aa417f and PASS post-fix.
 extends SceneTree
 
 const PLASMA_CUTTER := 4  # WeaponData.WeaponType.PLASMA_CUTTER
+const SHOTGUN := 2         # WeaponData.WeaponType.SHOTGUN  [K.4: Brawler T1 starter]
 
 func _init() -> void:
 	var pass_count := 0
 	var fail_count := 0
 
-	# T1: Default-constructed RunState has at least one weapon.
+	# T1: Default-constructed RunState (Scout chassis 0) has at least one weapon.
 	var rs := RunState.new()
 	assert(rs.equipped_weapons.size() > 0, "S26.1: default RunState must start with >=1 weapon")
-	assert(PLASMA_CUTTER in rs.equipped_weapons, "S26.1: starter weapon must be Plasma Cutter (4)")
+	assert(PLASMA_CUTTER in rs.equipped_weapons, "S26.1: Scout default starter weapon must be Plasma Cutter (4)")
 	pass_count += 2
 
-	# T2: All three chassis archetypes start armed.
-	for chassis_type in [0, 1, 2]:
+	# T2: Scout (0) and Fortress (2) start with Plasma Cutter; Brawler (1) starts with Shotgun.
+	# [K.4: per-chassis starter weapon assignment]
+	for chassis_type in [0, 2]:  # Scout, Fortress
 		var rs_c := RunState.new(chassis_type)
 		assert(rs_c.equipped_weapons.size() > 0, "S26.1: chassis %d must start with >=1 weapon" % chassis_type)
 		assert(PLASMA_CUTTER in rs_c.equipped_weapons, "S26.1: chassis %d starter must be Plasma Cutter" % chassis_type)
 		pass_count += 2
 
-	# T3: build_player_brott() carries the starter weapon onto BrottState.
+	var rs_brawler := RunState.new(1)  # Brawler
+	assert(rs_brawler.equipped_weapons.size() > 0, "K.4: Brawler must start with >=1 weapon")
+	assert(SHOTGUN in rs_brawler.equipped_weapons, "K.4: Brawler starter must be Shotgun (2) to close T1 mobility gap (#314)")
+	pass_count += 2
+
+	# T3: build_player_brott() carries the Brawler Shotgun starter onto BrottState.
 	# This is the path the arena actually uses — if the BrottState has no
 	# weapons, the player can't fire, even if equipped_weapons is non-empty.
 	var rs_b := RunState.new(1)  # Brawler chassis
 	var b := rs_b.build_player_brott()
 	assert(b != null, "S26.1: build_player_brott must produce a BrottState")
 	assert(b.weapon_types.size() > 0, "S26.1: built player BrottState must carry >=1 weapon")
-	assert(PLASMA_CUTTER in b.weapon_types, "S26.1: built BrottState weapon must be Plasma Cutter")
+	assert(SHOTGUN in b.weapon_types, "K.4: built Brawler BrottState weapon must be Shotgun")
 	pass_count += 3
 
 	# T4: Adding more weapons via add_item still works (starter doesn't block growth).
-	var rs_d := RunState.new(0)
+	var rs_d := RunState.new(0)  # Scout with Plasma Cutter start
 	var added := rs_d.add_item("weapon", 0)  # MINIGUN
 	assert(added, "S26.1: add_item('weapon', MINIGUN) should succeed on a starter loadout")
 	assert(rs_d.equipped_weapons.size() == 2, "S26.1: starter + added weapon = 2")
 	pass_count += 2
 
 	# T5: Deterministic seed still produces a starter weapon.
-	var rs_seed := RunState.new(2, 12345)
+	var rs_seed := RunState.new(2, 12345)  # Fortress
 	assert(rs_seed.seed == 12345, "S26.1: seed plumbing unchanged")
 	assert(rs_seed.equipped_weapons.size() > 0, "S26.1: seeded RunState still gets a starter weapon")
 	pass_count += 2


### PR DESCRIPTION
HCD-authorized fix (2026-04-29): Brawler mobility gap at T1. HP buffs alone insufficient — Brawler at 120px/s can't close on kiting Scout-chassis enemy at 220px/s. Shotgun burst damage (3-tile range, 5 pellets, 6 dmg each) lets Brawler win close-range engagements before separation.

**Changes:**
- `run_state.gd`: per-chassis starter — Brawler → `SHOTGUN` (2), Scout/Fortress keep `PLASMA_CUTTER` (4)
- `test_s26_1_starter_weapon.gd`: updated assertions to reflect Brawler Shotgun start; added K.4 T2 per-chassis weapon checks

**Arc context:**
- K.1: T1 opponent speed 220→180px/s (reverted — changed opponent identity)
- K.2: Brawler HP 225→295
- K.3: Brawler HP 295→360 — still 16.7% win-rate after HP buffs
- K.4 (this PR): weapon is the real fix — Brawler can't outrun a kiter, but can burst it at close range

Closes #314 pending sim gate pass.