### PR TITLE
[L.3] Item description tooltip on reward screen

### DIFF
--- a/godot/tests/test_reward_pick.gd
+++ b/godot/tests/test_reward_pick.gd
@@ -73,6 +73,22 @@ func _init() -> void:
 	else:
 		pass_count += 1
 
+	## T7: Description lookup — all item types have descriptions
+	var desc_fail := false
+	for item in ItemPool.FULL_ITEM_POOL:
+		var full_data: Dictionary = {}
+		match item["category"]:
+			"weapon": full_data = WeaponData.WEAPONS[item["type"]]
+			"armor":  full_data = ArmorData.ARMORS[item["type"]]
+			"module": full_data = ModuleData.MODULES[item["type"]]
+		var description: String = full_data.get("description", "")
+		if description.is_empty() and item["type"] != 0:  # ArmorType.NONE is OK
+			push_error("T7 FAIL: %s %s has empty description" % [item["category"], item["type"]])
+			desc_fail = true
+			fail_count += 1
+	if not desc_fail:
+		pass_count += 1
+
 	print("test_reward_pick: %d passed, %d failed" % [pass_count, fail_count])
 	if fail_count > 0:
 		quit(1)

--- a/godot/ui/reward_pick_screen.gd
+++ b/godot/ui/reward_pick_screen.gd
@@ -101,6 +101,22 @@ func _build_reward_ui() -> void:
 		cat_lbl.position = Vector2(card_xs[i], 280)
 		cat_lbl.size = Vector2(220, 24)
 		add_child(cat_lbl)
+		## Description label
+		var full_data: Dictionary = {}
+		match item["category"]:
+			"weapon": full_data = WeaponData.WEAPONS[item["type"]]
+			"armor":  full_data = ArmorData.ARMORS[item["type"]]
+			"module": full_data = ModuleData.MODULES[item["type"]]
+		var description: String = full_data.get("description", "")
+		var desc_lbl := Label.new()
+		desc_lbl.text = description
+		desc_lbl.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+		desc_lbl.position = Vector2(card_xs[i], 310)
+		desc_lbl.size = Vector2(220, 60)
+		desc_lbl.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+		desc_lbl.add_theme_font_size_override("font_size", 12)
+		desc_lbl.modulate = Color(0.8, 0.8, 0.8, 1.0)
+		add_child(desc_lbl)
 
 func _is_equipped(item: Dictionary) -> bool:
 	match item["category"]:


### PR DESCRIPTION
## L.3: Item Description Tooltip

### Changes
- **reward_pick_screen.gd**: Added description label to each reward item card via WeaponData/ArmorData/ModuleData lookup
- **Tests**: Added T7 verifying description lookup works for all item categories

### Scope-gate
Stat delta deferred to backlog (#346) — field doesn't exist in data layer, >1 day to populate. Backlog issue filed.

### DoD
- [ ] Optic: reward screenshots show name + description for ≥3 items
- [ ] Optic: holistic flow (chassis-pick → battle → reward → next battle) no regressions
- [ ] Existing tests pass

Arc L.3 — UX Cleanup