### PR TITLE
[M.1] Null-guard description lookup + GDD §13.4 T1 weight sync

### DIFF
--- a/docs/gdd.md
+++ b/docs/gdd.md
@@ -825,11 +825,11 @@ Weights are relative (don't need to sum to 100). Picker excludes the immediately
 
 | Archetype | T1 | T2 | T3 | T4 |
 |---|---|---|---|---|
-| `standard_duel` | 40 | 30 | 20 | 15 |
+| `standard_duel` | 60 | 30 | 20 | 15 |
 | `small_swarm` | 15 | 30 | 20 | 10 |
 | `large_swarm` | 10 | 20 | 20 | 15 |
-| `glass_cannon_blitz` | 15 | 10 | 5 | 10 |
-| `brawler_rush` | 20 | — | — | — |
+| `glass_cannon_blitz` | 5 | 10 | 5 | 10 |
+| `brawler_rush` | 10 | — | — | — |
 | `counter_build_elite` | — | 10 | 15 | 25 |
 | `miniboss_escorts` | — | — | 20 | 25 |
 

--- a/godot/ui/reward_pick_screen.gd
+++ b/godot/ui/reward_pick_screen.gd
@@ -104,9 +104,9 @@ func _build_reward_ui() -> void:
 		## Description label
 		var full_data: Dictionary = {}
 		match item["category"]:
-			"weapon": full_data = WeaponData.WEAPONS[item["type"]]
-			"armor":  full_data = ArmorData.ARMORS[item["type"]]
-			"module": full_data = ModuleData.MODULES[item["type"]]
+			"weapon": full_data = WeaponData.WEAPONS.get(item["type"], {})
+			"armor":  full_data = ArmorData.ARMORS.get(item["type"], {})
+			"module": full_data = ModuleData.MODULES.get(item["type"], {})
 		var description: String = full_data.get("description", "")
 		var desc_lbl := Label.new()
 		desc_lbl.text = description


### PR DESCRIPTION
## M.1: Sim Triage — Defensive Fix

### Findings
- Parse errors (headless timer race) → **already fixed in K.2** (2026-04-29)
- 0% Brawler win rate → **already fixed in K.4** (2026-04-29, Brawler now uses Shotgun)
- L.3 regression → **none found** (add_item() fires before description lookup, T7 passing)

### Changes
- `reward_pick_screen.gd`: .get(key, {}) null-guard on description lookup (defensive, no behavior change for valid items)
- `docs/gdd.md §13.4`: T1 archetype weight table synced to current code values

### Acceptance gates
- [ ] 5-seed headless sim: 0 parse errors, ≥3/5 runs with battles_won ≥ 1
- [ ] Existing test suite green (incl. T7)