### PR TITLE
[M.4] T1 HP retune 150→80 — restore tier ramp for run completion

### DIFF
--- a/godot/data/opponent_loadouts.gd
+++ b/godot/data/opponent_loadouts.gd
@@ -510,7 +510,7 @@ const TEMPLATES: Array[Dictionary] = [
 ## Tier 1: battles 1-3, Tier 2: 4-7, Tier 3: 8-11, Tier 4: 12-14, Tier 5: Boss.
 static func _baseline_hp_for_tier(tier: int) -> int:
 	match tier:
-		1: return 150  # M.2: +25% HP — T1 win rates 84-87% → target 40-70% range
+		1: return 80   # M.4: T1 HP retune 150→80 — restore tier ramp, target 85-90% T1 win-rate
 		2: return 120
 		3: return 160
 		4: return 200

--- a/godot/tests/test_s28_1_t1_hp_baseline.gd
+++ b/godot/tests/test_s28_1_t1_hp_baseline.gd
@@ -1,18 +1,18 @@
-## test_s28_1_t1_hp_baseline.gd — verifies T1 baseline HP (Arc J #314 fix; updated M.2).
-## Sprint-28.1 SI1-002. M.2: HP 120→150 to correct over-soft T1 win rates.
+## test_s28_1_t1_hp_baseline.gd — verifies T1 baseline HP (Arc J #314 fix; updated M.4).
+## Sprint-28.1 SI1-002. M.4: HP 150→80 per sprint-m.4 rebalance.
 extends SceneTree
 
 func _init() -> void:
 	var pass_count := 0
 	var fail_count := 0
 
-	# T1 target: 150 (was 120 post-Arc-J; M.2 +25% to correct over-soft win rates)
+	# T1 target: 80 (was 150; M.4 rebalance)
 	var hp1 := OpponentLoadouts._baseline_hp_for_tier(1)
-	if hp1 != 150:
-		print("FAIL: _baseline_hp_for_tier(1) expected 150, got ", hp1)
+	if hp1 != 80:
+		print("FAIL: _baseline_hp_for_tier(1) expected 80, got ", hp1)
 		fail_count += 1
 	else:
-		print("PASS: _baseline_hp_for_tier(1) == 150 (M.2: 120→150)")
+		print("PASS: _baseline_hp_for_tier(1) == 80 (M.4: 150→80)")
 	pass_count += 1 - fail_count
 
 	# T2+ should be unchanged (120, 160, 200, 240)


### PR DESCRIPTION
## Arc M — Sub-sprint M.4

**Diagnosis:** T1 baseline HP was bumped 120→150 in M.2 to reduce per-battle win rates. This over-corrected: 60% of sim runs now die on battle 0 (first battle). With 60% per-battle win rate, P(15 wins) = 0.6^15 ≈ 0% — the no-retry sim cannot complete any runs.

Additionally, T2 HP (120) was lower than T1 (150), breaking the tier ramp entirely.

**Fix:** T1 HP 150 → 80. Restores proper tier progression: T1(80) < T2(120) < T3(160) < T4(200) < Boss(240). Target: 85-90% T1 per-battle win rate for starter builds, which gives ~20% run completion rate at 15 battles with no retries.

**Expected outcome:** ≥2/20 sim runs reach SCREEN_RUN_COMPLETE.