### PR TITLE
[M.4b] T2/T3/T4 HP reduction — restore difficulty ramp for equipped builds

### DIFF
--- a/godot/data/opponent_loadouts.gd
+++ b/godot/data/opponent_loadouts.gd
@@ -511,10 +511,10 @@ const TEMPLATES: Array[Dictionary] = [
 static func _baseline_hp_for_tier(tier: int) -> int:
 	match tier:
 		1: return 80   # M.4: T1 HP retune 150→80 — restore tier ramp, target 85-90% T1 win-rate
-		2: return 120
-		3: return 160
-		4: return 200
-		_: return 240  # Boss tier
+		2: return 90   # M.4b: T2 120→90 — restore ramp (≤1.3×T1), target 87%+ per-battle win-rate
+		3: return 130  # M.4b: T3 160→130
+		4: return 165  # M.4b: T4 200→165
+		_: return 240  # Boss tier (unchanged — hard boss correct at 12+ items)
 
 ## Archetype template records. enemy_specs describe the enemy composition.
 ## hp_pct is relative to _baseline_hp_for_tier(tier) at generation time.

--- a/godot/tests/test_s28_1_t1_hp_baseline.gd
+++ b/godot/tests/test_s28_1_t1_hp_baseline.gd
@@ -1,5 +1,5 @@
-## test_s28_1_t1_hp_baseline.gd — verifies T1 baseline HP (Arc J #314 fix; updated M.4).
-## Sprint-28.1 SI1-002. M.4: HP 150→80 per sprint-m.4 rebalance.
+## test_s28_1_t1_hp_baseline.gd — verifies T1 baseline HP (Arc J #314 fix; updated M.4/M.4b).
+## Sprint-28.1 SI1-002. M.4: HP 150→80 per sprint-m.4 rebalance. M.4b: T2/T3/T4 HP reduced.
 extends SceneTree
 
 func _init() -> void:
@@ -15,8 +15,8 @@ func _init() -> void:
 		print("PASS: _baseline_hp_for_tier(1) == 80 (M.4: 150→80)")
 	pass_count += 1 - fail_count
 
-	# T2+ should be unchanged (120, 160, 200, 240)
-	var expected := {2: 120, 3: 160, 4: 200}
+	# T2+ updated in M.4b: 120→90, 160→130, 200→165 (≤1.3× T1 ramp spec)
+	var expected := {2: 90, 3: 130, 4: 165}
 	for tier in expected:
 		var prev_fail := fail_count
 		var hp := OpponentLoadouts._baseline_hp_for_tier(tier)
@@ -24,7 +24,7 @@ func _init() -> void:
 			print("FAIL: _baseline_hp_for_tier(%d) expected %d, got %d" % [tier, expected[tier], hp])
 			fail_count += 1
 		else:
-			print("PASS: _baseline_hp_for_tier(%d) == %d (unchanged)" % [tier, expected[tier]])
+			print("PASS: _baseline_hp_for_tier(%d) == %d (M.4b)" % [tier, expected[tier]])
 		pass_count += 1 - (fail_count - prev_fail)
 
 	print("test_s28_1_t1_hp_baseline: %d passed, %d failed" % [pass_count, fail_count])


### PR DESCRIPTION
## Arc M — Sub-sprint M.4b

**Diagnosis:** M.5 gate sim (0/20 runs complete, max battles_won=6) shows T2 HP (120) is too high for a 2-3 item equipped build. Arc brief M.4 spec: T2 ≤ 1.3× T1 baseline. With T1=80, T2 cap=104. Current T2=120 violates spec.

**Changes:**
- T2: 120 → 90
- T3: 160 → 130
- T4: 200 → 165
- Boss: 240 (unchanged — hard boss is correct at 12+ items)

**Test updates:**
- `test_s28_1_t1_hp_baseline.gd`: updated T2/T3/T4 expected values (120/160/200 → 90/130/165)

**Expected outcome:** Per-battle win rates 87%+ in T1-T3, enabling ≥2/20 no-retry sim completions (P ≈ 0.87^15 ≈ 12%).