### PR TITLE
[M.4c] T3/T4 HP reduction — clear wall for equipped builds

### DIFF
--- a/godot/data/opponent_loadouts.gd
+++ b/godot/data/opponent_loadouts.gd
@@ -512,8 +512,8 @@ static func _baseline_hp_for_tier(tier: int) -> int:
 	match tier:
 		1: return 80   # M.4: T1 HP retune 150→80 — restore tier ramp, target 85-90% T1 win-rate
 		2: return 90   # M.4b: T2 120→90 — restore ramp (≤1.3×T1), target 87%+ per-battle win-rate
-		3: return 130  # M.4b: T3 160→130
-		4: return 165  # M.4b: T4 200→165
+		3: return 110  # M.4c: T3 130→110
+		4: return 140  # M.4c: T4 165→140
 		_: return 240  # Boss tier (unchanged — hard boss correct at 12+ items)
 
 ## Archetype template records. enemy_specs describe the enemy composition.

--- a/godot/tests/test_s28_1_t1_hp_baseline.gd
+++ b/godot/tests/test_s28_1_t1_hp_baseline.gd
@@ -1,5 +1,5 @@
-## test_s28_1_t1_hp_baseline.gd — verifies T1 baseline HP (Arc J #314 fix; updated M.4/M.4b).
-## Sprint-28.1 SI1-002. M.4: HP 150→80 per sprint-m.4 rebalance. M.4b: T2/T3/T4 HP reduced.
+## test_s28_1_t1_hp_baseline.gd — verifies T1 baseline HP (Arc J #314 fix; updated M.4/M.4b/M.4c).
+## Sprint-28.1 SI1-002. M.4: HP 150→80 per sprint-m.4 rebalance. M.4b: T2/T3/T4 HP reduced. M.4c: T3/T4 further reduced.
 extends SceneTree
 
 func _init() -> void:
@@ -15,8 +15,8 @@ func _init() -> void:
 		print("PASS: _baseline_hp_for_tier(1) == 80 (M.4: 150→80)")
 	pass_count += 1 - fail_count
 
-	# T2+ updated in M.4b: 120→90, 160→130, 200→165 (≤1.3× T1 ramp spec)
-	var expected := {2: 90, 3: 130, 4: 165}
+	# T2+ updated in M.4b: 120→90, 160→130, 200→165. M.4c: T3 130→110, T4 165→140.
+	var expected := {2: 90, 3: 110, 4: 140}
 	for tier in expected:
 		var prev_fail := fail_count
 		var hp := OpponentLoadouts._baseline_hp_for_tier(tier)
@@ -24,7 +24,7 @@ func _init() -> void:
 			print("FAIL: _baseline_hp_for_tier(%d) expected %d, got %d" % [tier, expected[tier], hp])
 			fail_count += 1
 		else:
-			print("PASS: _baseline_hp_for_tier(%d) == %d (M.4b)" % [tier, expected[tier]])
+			print("PASS: _baseline_hp_for_tier(%d) == %d (M.4c)" % [tier, expected[tier]])
 		pass_count += 1 - (fail_count - prev_fail)
 
 	print("test_s28_1_t1_hp_baseline: %d passed, %d failed" % [pass_count, fail_count])


### PR DESCRIPTION
## Arc M — Sub-sprint M.4c

M.5 gate sim R2 (0/20 wins): best run hit 7 battles with full loadout (4 weapons, 3 modules, armor) before dying at T3/T4. T1/T2 now accessible (60-70% per-battle win rate). T3=130 and T4=165 are the remaining wall.

**Changes:**
- T3: 130 → 110
- T4: 165 → 140
- T1(80), T2(90), Boss(240): unchanged

Tier ramp post-fix: T1(80) < T2(90) < T3(110) < T4(140) < Boss(240).