### PR TITLE
[M.5] T1 balance: reduce brawler_rush weight + hp_pct

### DIFF
--- a/godot/data/opponent_loadouts.gd
+++ b/godot/data/opponent_loadouts.gd
@@ -565,7 +565,7 @@ const ARCHETYPE_TEMPLATES: Array[Dictionary] = [
 		"id": "brawler_rush",
 		"display_name": "Brawler Rush",
 		"enemy_specs": [
-			{"chassis": 1, "weapons": [2], "armor": 0, "modules": [], "hp_pct": 0.75, "count": 1}
+			{"chassis": 1, "weapons": [2], "armor": 0, "modules": [], "hp_pct": 0.5, "count": 1}
 		]
 	},
 	{
@@ -658,7 +658,7 @@ static func compose_encounter(archetype_id: String, battle_index: int, run_state
 
 ## S25.6: Probability weights per tier. Weights are relative (don't need to sum to 100).
 const ARCHETYPE_WEIGHTS_BY_TIER: Dictionary = {
-	1: {"standard_duel": 45, "small_swarm": 15, "large_swarm": 10, "glass_cannon_blitz": 5, "brawler_rush": 25},  # M.2: standard_duel 60→45, brawler_rush 10→25 — reduce easy mirror duels; Shotgun burst harder for Scout/Brawler
+	1: {"standard_duel": 45, "small_swarm": 25, "large_swarm": 15, "glass_cannon_blitz": 5, "brawler_rush": 10},  # M.5: brawler_rush 25→10, small_swarm 15→25, large_swarm 10→15 — fix 80/20/20 split; brawler_rush was Scout-easy, swarms favor Brawler/Fortress area weapons
 	2: {"standard_duel": 30, "small_swarm": 30, "large_swarm": 20, "counter_build_elite": 10, "glass_cannon_blitz": 10},
 	3: {"standard_duel": 20, "small_swarm": 20, "large_swarm": 20, "miniboss_escorts": 20, "counter_build_elite": 15, "glass_cannon_blitz": 5},
 	4: {"standard_duel": 15, "small_swarm": 10, "large_swarm": 15, "miniboss_escorts": 25, "counter_build_elite": 25, "glass_cannon_blitz": 10},

--- a/godot/tests/test_s28_1_t1_weights.gd
+++ b/godot/tests/test_s28_1_t1_weights.gd
@@ -17,21 +17,21 @@ func _init() -> void:
 		print("PASS: T1 standard_duel == 45 (M.2: 60→45)")
 	pass_count += 1 - (fail_count if fail_count == 1 else 0)
 
-	# small_swarm: 30 → 15
+	# small_swarm: 15 → 25 (M.5 balance fix)
 	var prev := fail_count
-	if t1.get("small_swarm", -1) != 15:
-		print("FAIL: T1 small_swarm expected 15, got ", t1.get("small_swarm", "missing"))
+	if t1.get("small_swarm", -1) != 25:
+		print("FAIL: T1 small_swarm expected 25, got ", t1.get("small_swarm", "missing"))
 		fail_count += 1
 	else:
-		print("PASS: T1 small_swarm == 15")
+		print("PASS: T1 small_swarm == 25 (M.5: 15→25)")
 
-	# large_swarm: 15 → 10 (J.2 updated)
+	# large_swarm: 10 → 15 (M.5 balance fix)
 	prev = fail_count
-	if t1.get("large_swarm", -1) != 10:
-		print("FAIL: T1 large_swarm expected 10, got ", t1.get("large_swarm", "missing"))
+	if t1.get("large_swarm", -1) != 15:
+		print("FAIL: T1 large_swarm expected 15, got ", t1.get("large_swarm", "missing"))
 		fail_count += 1
 	else:
-		print("PASS: T1 large_swarm == 10 (J.2 updated)")
+		print("PASS: T1 large_swarm == 15 (M.5: 10→15)")
 
 	# glass_cannon_blitz: 15→5 (J.5.2: Fortress T1 survivability fix)
 	prev = fail_count
@@ -41,13 +41,13 @@ func _init() -> void:
 	else:
 		print("PASS: T1 glass_cannon_blitz == 5 (J.5.2: 15→5)")
 
-	# brawler_rush: M.2 10->25 (harder Shotgun encounter; Scout/Brawler pressure)
+	# brawler_rush: 25 → 10 (M.5 balance fix)
 	prev = fail_count
-	if t1.get("brawler_rush", -1) != 25:
-		print("FAIL: T1 brawler_rush expected 25, got ", t1.get("brawler_rush", "missing"))
+	if t1.get("brawler_rush", -1) != 10:
+		print("FAIL: T1 brawler_rush expected 10, got ", t1.get("brawler_rush", "missing"))
 		fail_count += 1
 	else:
-		print("PASS: T1 brawler_rush == 25 (M.2: 10->25)")
+		print("PASS: T1 brawler_rush == 10 (M.5: 25→10)")
 
 	# T2 spot-check: standard_duel unchanged at 30
 	var t2: Dictionary = OpponentLoadouts.ARCHETYPE_WEIGHTS_BY_TIER.get(2, {})


### PR DESCRIPTION
Gizmo-spec T1 balance fix:
- brawler_rush weight: 25→10 (was Scout-easy; 1-in-4 T1 was Scout kiting advantage)
- small_swarm weight: 15→25 (favors Brawler Shotgun spread)
- large_swarm weight: 10→15 (favors Fortress Flak AoE)
- brawler_rush hp_pct: 0.75→0.5 (drops enemy T1 HP 60→40)

Predicted: Scout 80%→~65-72%, Brawler 20%→~35-45%, Fortress 20%→~35-50%.
Part of Arc M M.5 gate — addresses 20% Brawler/Fortress T1 win-rate failure.