### PR TITLE
feat(arc-n): N.1 — single starter chassis + first_battle_intro T1 enemy

### DIFF
--- a/docs/gdd.md
+++ b/docs/gdd.md
@@ -754,6 +754,10 @@ BattleBrotts plays as a **15-battle roguelike run** rather than a persistent lea
 
 The roguelike loop replaces the league-era "build → teach → fight → analyze → iterate" loop documented in §2. BrottBrain teaching still happens — the BrottBrain editor surface is retained — but progression through tiers is now run-scoped, not account-scoped.
 
+> **Arc N note:** Player chassis is fixed to Brawler (`chassis_type=1`). `run_start_screen.gd`
+> shows a single "Start Run" button; chassis-select logic is preserved behind `#CUT:ArcN`
+> for Arc O restoration.
+
 ### 13.2 RunState
 
 A run is fully described by the `RunState` object (`godot/game/run_state.gd`), which is the **sole source of truth** for run-scoped data. Active fields:
@@ -848,6 +852,18 @@ Every run schedule is post-processed to guarantee at least one occurrence of eac
 - `miniboss_escorts` (default seed slot: battle index 11)
 
 If any required archetype is missing after the weighted draw, the schedule generator overwrites a tier-compatible later slot with the missing archetype to enforce the guarantee. *(Source: `_apply_run_guarantees()`, S25.6.)*
+
+#### Battle 0 override (`first_battle_intro`)
+
+**Battle 0 override (`first_battle_intro`):** Battle 1 (index 0) always draws the
+`first_battle_intro` archetype, bypassing the weighted schedule. Cannot be drawn for
+battles 2+. `archetype_for()` returns `"first_battle_intro"` unconditionally when
+`battle_index == 0`, before schedule lookup.
+
+Enemy spec: Scout chassis (0), Plasma Cutter (4), no armor, no modules.
+`target_hp`: 750 (direct override, bypasses `baseline_hp × hp_pct`).
+`speed_override`: 50 px/s. `fire_rate_override`: 0.4 shots/s.
+Default stance: Aggressive (0). `use_first_battle_ai`: true (enables strafe/retreat, wired in Arc N.2).
 
 ### 13.5 Run Flow
 

--- a/godot/combat/brott_state.gd
+++ b/godot/combat/brott_state.gd
@@ -66,6 +66,10 @@ var emp_disabled_timer: float = 0.0
 # Stance
 var stance: int = 0  # 0=aggressive, 1=defensive, 2=kiting, 3=ambush
 
+# Arc N: speed/fire-rate overrides (set from enemy_spec on enemy BrottStates)
+var speed_override: float = -1.0   ## -1 = disabled; >0 = absolute px/s override
+var fire_rate_override: float = -1.0  ## -1 = disabled; >0 = absolute shots/s override
+
 # S13.6: Per-match pellet modifier (additive, applied per-weapon at fire time).
 # Populated by GameState.build_brott() from _next_fight_pellet_mod and consumed
 # inside CombatSim._fire_weapon(); floor-clamped to 1 pellet per shot.
@@ -171,6 +175,9 @@ func setup() -> void:
 		module_active_timers.append(0.0)
 
 func get_effective_speed() -> float:
+	## Arc N: absolute speed override (from enemy spec; -1 = disabled)
+	if speed_override > 0.0:
+		return speed_override
 	var spd := base_speed
 	if afterburner_active:
 		spd *= 1.80

--- a/godot/combat/combat_sim.gd
+++ b/godot/combat/combat_sim.gd
@@ -1161,6 +1161,9 @@ func _fire_weapons(b: BrottState) -> void:
 		
 		b.energy -= float(wd["energy_cost"])
 		var fire_rate: float = float(wd["fire_rate"]) * b.get_fire_rate_multiplier()
+		## Arc N: absolute fire-rate override from enemy spec (bypasses multiplier)
+		if b.fire_rate_override > 0.0:
+			fire_rate = b.fire_rate_override
 		b.weapon_cooldowns[i] = float(TICKS_PER_SEC) / fire_rate
 		
 		# Instrumentation: track shots fired

--- a/godot/data/opponent_loadouts.gd
+++ b/godot/data/opponent_loadouts.gd
@@ -576,6 +576,27 @@ const ARCHETYPE_TEMPLATES: Array[Dictionary] = [
 			{"chassis": 2, "weapons": [1, 0], "armor": 3, "modules": [2, 3, 5], "hp_pct": 2.0, "count": 1}
 		]
 	},
+	## Arc N: first_battle_intro — battle index 0 always draws this archetype.
+	## NOT present in ARCHETYPE_WEIGHTS_BY_TIER — bypasses weighted schedule.
+	{
+		"id": "first_battle_intro",
+		"display_name": "First Battle",
+		"enemy_specs": [
+			{
+				"chassis": 0,               # Scout
+				"weapons": [4],              # Plasma Cutter
+				"armor": 0,
+				"modules": [],
+				"hp_pct": 1.0,              # ignored when target_hp present
+				"target_hp": 750,            # direct HP override
+				"speed_override": 50.0,      # px/s
+				"fire_rate_override": 0.4,   # shots/s
+				"stance": 0,                 # Aggressive
+				"count": 1,
+			}
+		],
+		"use_first_battle_ai": true,
+	},
 ]
 
 ## Counter-Build Elite variant selector — reads player's RunState loadout.
@@ -704,7 +725,11 @@ static func _weighted_draw(tier: int, last_archetype: String, rng: RandomNumberG
 ## Returns the archetype ID for a given battle slot.
 ## Run schedule is pre-generated on first call and cached on run_state.encounter_schedule.
 static func archetype_for(battle_index: int, run_state, rng: RandomNumberGenerator = null) -> String:
-	## Boss override FIRST — deterministic regardless of rng state (gate 3)
+	## Arc N: battle index 0 always draws first_battle_intro (bypasses weighted schedule)
+	if battle_index == 0:
+		return "first_battle_intro"
+
+	## Boss override — deterministic regardless of rng state (gate 3)
 	if battle_index >= 14:
 		return "boss"
 
@@ -813,15 +838,24 @@ static func get_archetype_enemies(archetype_id: String, tier: int, run_state) ->
 	var result: Array[Dictionary] = []
 	for spec in specs:
 		var count: int = spec.get("count", 1)
-		var hp: int = max(1, int(base_hp * float(spec["hp_pct"])))
+		## Arc N: target_hp overrides hp_pct when present (direct HP override)
+		var hp: int = int(spec["target_hp"]) if "target_hp" in spec else max(1, int(base_hp * float(spec.get("hp_pct", 1.0))))
 		for _i in range(count):
-			result.append({
+			var entry: Dictionary = {
 				"chassis": spec["chassis"],
 				"weapons": spec["weapons"].duplicate(),
 				"armor": spec["armor"],
 				"modules": spec["modules"].duplicate(),
 				"hp": hp,
-			})
+			}
+			## Arc N: forward override fields when present
+			if "speed_override" in spec:
+				entry["speed_override"] = float(spec["speed_override"])
+			if "fire_rate_override" in spec:
+				entry["fire_rate_override"] = float(spec["fire_rate_override"])
+			if "stance" in spec:
+				entry["stance"] = int(spec["stance"])
+			result.append(entry)
 	return result
 
 ## §4.1 — maps (league, index) to a difficulty tier.

--- a/godot/game_main.gd
+++ b/godot/game_main.gd
@@ -303,6 +303,13 @@ func _start_roguelike_match() -> void:
 		if spec_hp > 0:
 			ebrott.max_hp = spec_hp
 			ebrott.hp = float(spec_hp)
+		## Arc N: apply speed/fire-rate/stance overrides from first_battle_intro spec
+		if "speed_override" in spec:
+			ebrott.speed_override = float(spec["speed_override"])
+		if "fire_rate_override" in spec:
+			ebrott.fire_rate_override = float(spec["fire_rate_override"])
+		if "stance" in spec:
+			ebrott.stance = int(spec["stance"])
 		ebrott.position = positions[i] if i < positions.size() else Vector2(12 * 32.0, 8 * 32.0)
 		## Brain per enemy
 		var chassis_t: int = spec.get("chassis", 0)

--- a/godot/tests/auto/auto_driver.gd
+++ b/godot/tests/auto/auto_driver.gd
@@ -339,10 +339,10 @@ func _find_run_start_screen() -> Node:
 	var ui_scroll: Node = game_main.get("ui_scroll")
 	if ui_scroll != null:
 		for child in ui_scroll.get_children():
-			if child.get_class() == "RunStartScreen" or child is Control and child.has_method("_on_card_pressed"):
+			if child.get_class() == "RunStartScreen" or child is Control and child.has_method("_on_card_pressed") or child.has_method("_on_start_run_pressed"):
 				return child
 	var current_ui: Node = game_main.get("current_ui")
-	if current_ui != null and (current_ui.get_class() == "RunStartScreen" or current_ui.has_method("_on_card_pressed")):
+	if current_ui != null and (current_ui.get_class() == "RunStartScreen" or current_ui.has_method("_on_card_pressed") or current_ui.has_method("_on_start_run_pressed")):
 		return current_ui
 	return null
 
@@ -363,3 +363,4 @@ func _find_child_of_type(node: Node, class_name_str: String) -> Node:
 		if found != null:
 			return found
 	return null
+

--- a/godot/tests/auto/auto_driver.gd
+++ b/godot/tests/auto/auto_driver.gd
@@ -118,6 +118,30 @@ func click_chassis(index: int) -> void:
 		return
 	btn.emit_signal("pressed")
 
+# ─── Verb: click_start_run ───────────────────────────────────────────────────
+
+## Triggers the Arc N "Start Run" button on RunStartScreen.
+## Replaces click_chassis() for Arc N+ entry path.
+##
+## Signal path: StartRunBtn.pressed → RunStartScreen._on_start_run_pressed →
+##              start_run_requested.emit(default_chassis) →
+##              game_main._on_chassis_picked(default_chassis)
+func click_start_run() -> void:
+	var run_start := _find_run_start_screen()
+	if run_start == null:
+		_failures.append("click_start_run: RunStartScreen not found (current screen may not be RUN_START)")
+		return
+	var btn: Button = null
+	for child in run_start.get_children():
+		if child is Button and child.name == "StartRunBtn":
+			btn = child as Button
+			break
+	if btn == null:
+		push_error("AutoDriver.click_start_run: StartRunBtn not found")
+		_failures.append("click_start_run: StartRunBtn not found in RunStartScreen")
+		return
+	btn.emit_signal("pressed")
+
 # ─── Verb: click_reward ──────────────────────────────────────────────────────
 
 ## Click reward option at position `index` in the RewardPickScreen.

--- a/godot/tests/auto/test_first_flow_chassis_pick.gd
+++ b/godot/tests/auto/test_first_flow_chassis_pick.gd
@@ -49,14 +49,14 @@ func _drive_flow_step() -> void:
 			var screen: int = gf.get("current_screen")
 			if screen != 7:  # GameFlow.Screen.RUN_START
 				_failures.append("Expected screen RUN_START(7), got %d" % screen)
-			# Click chassis 0
-			click_chassis(0)
+			# Click Start Run (Arc N entry path — defaults to Brawler, chassis 1)
+			click_start_run()
 			_ticks_remaining = 60  # settle into arena
 			_step += 1
 		2:
-			# Assert run active, chassis 0, in_arena
+			# Assert run active, chassis 1 (Brawler), in_arena
 			assert_state("run.active", true)
-			assert_state("run.equipped_chassis", 0)
+			assert_state("run.equipped_chassis", 1)
 			assert_state("arena.in_arena", true)
 			_ticks_remaining = 60  # let sim tick
 			_step += 1

--- a/godot/tests/auto/test_reward_pick_flow.gd
+++ b/godot/tests/auto/test_reward_pick_flow.gd
@@ -46,13 +46,14 @@ func _drive_flow_step() -> void:
 			var screen: int = gf.get("current_screen")
 			if screen != 7:
 				_failures.append("Expected RUN_START(7) after new game, got %d" % screen)
-			click_chassis(0)
+			# Click Start Run (Arc N entry path — defaults to Brawler, chassis 1)
+			click_start_run()
 			_ticks_remaining = 60
 			_step += 1
 
 		2:
 			assert_state("run.active", true)
-			assert_state("run.equipped_chassis", 0)
+			assert_state("run.equipped_chassis", 1)
 			assert_state("arena.in_arena", true)
 			assert_cmp("arena.tick_count", "gte", 1)
 			force_battle_end(0)

--- a/godot/tests/auto/test_run_end_flow.gd
+++ b/godot/tests/auto/test_run_end_flow.gd
@@ -41,7 +41,8 @@ func _drive_flow_step() -> void:
 			var screen: int = gf.get("current_screen") if gf != null else -1
 			if screen != 7:
 				_failures.append("Expected RUN_START(7), got %d" % screen)
-			click_chassis(0)
+			# Click Start Run (Arc N entry path — defaults to Brawler, chassis 1)
+			click_start_run()
 			_ticks_remaining = 60
 			_step += 1
 

--- a/godot/tests/test_arc_n_1_first_battle_feel.gd
+++ b/godot/tests/test_arc_n_1_first_battle_feel.gd
@@ -1,0 +1,214 @@
+## test_arc_n_1_first_battle_feel.gd — Arc N Sub-sprint N.1 AutoDriver assertions.
+##
+## Gates:
+##   N1-1: archetype_for(0) == "first_battle_intro"; archetype_for(1..13) != "first_battle_intro"
+##   N1-2: compose_encounter("first_battle_intro", 0, null) spec: hp==750, speed_override==50.0,
+##          fire_rate_override==0.4, stance==0
+##   N1-3: BrottState created from spec has speed_override==50.0, fire_rate_override==0.4,
+##          get_effective_speed()==50.0
+##   N1-4: RunStartScreen emits chassis_type==1 (Brawler) on Start Run pressed
+##   N1-5: Fight duration: 50-seed batch Brawler+Shotgun vs first_battle_intro, median in [20, 40]s
+##   N1-6: Player win rate >= 0.80 in same 50-seed batch
+extends SceneTree
+
+func _init() -> void:
+	var pass_count := 0
+	var fail_count := 0
+
+	## ── N1-1: archetype_for(0) == "first_battle_intro" ──────────────────────────
+	var n1_1_ok := true
+	var arch_0 := OpponentLoadouts.archetype_for(0, null)
+	if arch_0 != "first_battle_intro":
+		push_error("N1-1 FAIL: archetype_for(0) expected 'first_battle_intro', got '%s'" % arch_0)
+		n1_1_ok = false
+	for idx in range(1, 14):
+		var rng := RandomNumberGenerator.new()
+		rng.seed = idx * 1000 + 7
+		var mock_state := RunState.new(1, idx * 1000 + 7)
+		var arch := OpponentLoadouts.archetype_for(idx, mock_state, rng)
+		if arch == "first_battle_intro":
+			push_error("N1-1 FAIL: archetype_for(%d) returned 'first_battle_intro' — should never appear for idx > 0" % idx)
+			n1_1_ok = false
+			break
+	if n1_1_ok:
+		print("PASS N1-1: archetype_for(0)='first_battle_intro', never appears at idx 1-13")
+		pass_count += 1
+	else:
+		print("FAIL N1-1: first_battle_intro archetype selection incorrect")
+		fail_count += 1
+
+	## ── N1-2: compose_encounter spec fields ─────────────────────────────────────
+	var n1_2_ok := true
+	var specs := OpponentLoadouts.compose_encounter("first_battle_intro", 0, null)
+	if specs.is_empty():
+		push_error("N1-2 FAIL: compose_encounter('first_battle_intro', 0, null) returned empty")
+		n1_2_ok = false
+	else:
+		var spec: Dictionary = specs[0]
+		if spec.get("hp", -1) != 750:
+			push_error("N1-2 FAIL: hp expected 750, got %d" % spec.get("hp", -1))
+			n1_2_ok = false
+		if absf(float(spec.get("speed_override", -999.0)) - 50.0) > 0.01:
+			push_error("N1-2 FAIL: speed_override expected 50.0, got %s" % str(spec.get("speed_override", "MISSING")))
+			n1_2_ok = false
+		if absf(float(spec.get("fire_rate_override", -999.0)) - 0.4) > 0.001:
+			push_error("N1-2 FAIL: fire_rate_override expected 0.4, got %s" % str(spec.get("fire_rate_override", "MISSING")))
+			n1_2_ok = false
+		if spec.get("stance", -1) != 0:
+			push_error("N1-2 FAIL: stance expected 0, got %d" % spec.get("stance", -1))
+			n1_2_ok = false
+	if n1_2_ok:
+		print("PASS N1-2: compose_encounter spec fields correct (hp=750, speed=50, fire_rate=0.4, stance=0)")
+		pass_count += 1
+	else:
+		print("FAIL N1-2: first_battle_intro spec fields incorrect")
+		fail_count += 1
+
+	## ── N1-3: BrottState overrides applied ──────────────────────────────────────
+	var n1_3_ok := true
+	if not specs.is_empty():
+		var spec: Dictionary = specs[0]
+		var ebrott := BrottState.new()
+		ebrott.team = 1
+		ebrott.chassis_type = spec.get("chassis", 0)
+		for wt in spec.get("weapons", []):
+			ebrott.weapon_types.append(wt)
+		ebrott.armor_type = spec.get("armor", 0)
+		ebrott.setup()
+		var spec_hp: int = spec.get("hp", ebrott.max_hp)
+		if spec_hp > 0:
+			ebrott.max_hp = spec_hp
+			ebrott.hp = float(spec_hp)
+		## Apply overrides (mirrors game_main.gd Arc N block)
+		if "speed_override" in spec:
+			ebrott.speed_override = float(spec["speed_override"])
+		if "fire_rate_override" in spec:
+			ebrott.fire_rate_override = float(spec["fire_rate_override"])
+		if "stance" in spec:
+			ebrott.stance = int(spec["stance"])
+
+		if absf(ebrott.speed_override - 50.0) > 0.01:
+			push_error("N1-3 FAIL: ebrott.speed_override expected 50.0, got %f" % ebrott.speed_override)
+			n1_3_ok = false
+		if absf(ebrott.fire_rate_override - 0.4) > 0.001:
+			push_error("N1-3 FAIL: ebrott.fire_rate_override expected 0.4, got %f" % ebrott.fire_rate_override)
+			n1_3_ok = false
+		if absf(ebrott.get_effective_speed() - 50.0) > 0.01:
+			push_error("N1-3 FAIL: get_effective_speed() expected 50.0 (override), got %f" % ebrott.get_effective_speed())
+			n1_3_ok = false
+	else:
+		push_error("N1-3 SKIP: specs empty (N1-2 must pass first)")
+		n1_3_ok = false
+	if n1_3_ok:
+		print("PASS N1-3: BrottState speed_override=50.0, fire_rate_override=0.4, get_effective_speed()=50.0")
+		pass_count += 1
+	else:
+		print("FAIL N1-3: BrottState override application incorrect")
+		fail_count += 1
+
+	## ── N1-4: RunStartScreen emits chassis_type==1 ──────────────────────────────
+	## (Headless unit test: instantiate RunStartScreen, connect signal, call setup, verify emission)
+	var n1_4_ok := true
+	var screen := RunStartScreen.new()
+	var emitted_chassis: int = -1
+	screen.start_run_requested.connect(func(ct: int): emitted_chassis = ct)
+	screen.setup(0)
+	## Programmatically find the StartRunBtn and simulate press
+	var btn: Button = screen.get_node_or_null("StartRunBtn")
+	if btn == null:
+		push_error("N1-4 FAIL: StartRunBtn not found on RunStartScreen after setup()")
+		n1_4_ok = false
+	else:
+		btn.emit_signal("pressed")
+		if emitted_chassis != 1:
+			push_error("N1-4 FAIL: start_run_requested emitted chassis_type=%d, expected 1" % emitted_chassis)
+			n1_4_ok = false
+	screen.queue_free()
+	if n1_4_ok:
+		print("PASS N1-4: RunStartScreen emits chassis_type=1 (Brawler)")
+		pass_count += 1
+	else:
+		print("FAIL N1-4: RunStartScreen chassis emission incorrect")
+		fail_count += 1
+
+	## ── N1-5+6: 50-seed batch: fight duration + player win rate ─────────────────
+	var durations: Array[float] = []
+	var player_wins: int = 0
+	var total_runs: int = 50
+
+	for seed_val in range(total_runs):
+		var sim := CombatSim.new(seed_val)
+		## Player: Brawler + Shotgun (chassis_type=1, WeaponType.SHOTGUN=2)
+		var player := BrottState.new()
+		player.team = 0
+		player.bot_name = "Player"
+		player.chassis_type = ChassisData.ChassisType.BRAWLER
+		player.weapon_types.append(WeaponData.WeaponType.SHOTGUN)
+		player.armor_type = ArmorData.ArmorType.NONE
+		player.setup()
+		player.position = Vector2(4 * 32.0, 8 * 32.0)
+		player.brain = BrottBrain.default_for_chassis(1)
+		sim.add_brott(player)
+
+		## Enemy: first_battle_intro spec
+		var e_specs := OpponentLoadouts.compose_encounter("first_battle_intro", 0, null)
+		var e_spec: Dictionary = e_specs[0] if not e_specs.is_empty() else {}
+		var enemy := BrottState.new()
+		enemy.team = 1
+		enemy.bot_name = "Enemy"
+		enemy.chassis_type = e_spec.get("chassis", 0)
+		for wt in e_spec.get("weapons", []):
+			enemy.weapon_types.append(wt)
+		enemy.armor_type = e_spec.get("armor", 0)
+		enemy.setup()
+		var e_hp: int = e_spec.get("hp", enemy.max_hp)
+		if e_hp > 0:
+			enemy.max_hp = e_hp
+			enemy.hp = float(e_hp)
+		if "speed_override" in e_spec:
+			enemy.speed_override = float(e_spec["speed_override"])
+		if "fire_rate_override" in e_spec:
+			enemy.fire_rate_override = float(e_spec["fire_rate_override"])
+		if "stance" in e_spec:
+			enemy.stance = int(e_spec["stance"])
+		enemy.position = Vector2(12 * 32.0, 8 * 32.0)
+		enemy.brain = BrottBrain.default_for_chassis(enemy.chassis_type)
+		sim.add_brott(enemy)
+
+		## Run until match over (cap at 1000 ticks = 100s)
+		for _tick in range(1000):
+			if sim.match_over:
+				break
+			sim.simulate_tick()
+
+		var dur_sec: float = float(sim.tick_count) / float(CombatSim.TICKS_PER_SEC)
+		durations.append(dur_sec)
+		if sim.winner_team == 0:
+			player_wins += 1
+
+	## Gate N1-5: median duration in [20, 40]s
+	durations.sort()
+	var median: float = durations[25] if durations.size() >= 50 else 0.0
+	if median >= 20.0 and median <= 40.0:
+		print("PASS N1-5: median fight duration %.1fs in [20, 40]s" % median)
+		pass_count += 1
+	else:
+		push_error("N1-5 FAIL: median fight duration %.1fs — expected in [20, 40]s" % median)
+		print("FAIL N1-5: median fight duration %.1fs not in [20, 40]s" % median)
+		fail_count += 1
+
+	## Gate N1-6: player win rate >= 0.80
+	var win_rate: float = float(player_wins) / float(total_runs)
+	if win_rate >= 0.80:
+		print("PASS N1-6: player win rate %.0f%% (>= 80%%)" % (win_rate * 100.0))
+		pass_count += 1
+	else:
+		push_error("N1-6 FAIL: player win rate %.0f%% — expected >= 80%%" % (win_rate * 100.0))
+		print("FAIL N1-6: player win rate %.0f%% < 80%%" % (win_rate * 100.0))
+		fail_count += 1
+
+	print("test_arc_n_1_first_battle_feel: %d passed, %d failed" % [pass_count, fail_count])
+	if fail_count > 0:
+		quit(1)
+	else:
+		quit(0)

--- a/godot/tests/test_multi_target_ai.gd
+++ b/godot/tests/test_multi_target_ai.gd
@@ -123,10 +123,10 @@ func _init() -> void:
 		pass_count += 1
 
 	## ─── T8: archetype templates complete ─────────────────────────────
-	var expected_ids := ["standard_duel", "small_swarm", "large_swarm", "miniboss_escorts", "counter_build_elite", "glass_cannon_blitz", "boss", "brawler_rush"]
+	var expected_ids := ["standard_duel", "small_swarm", "large_swarm", "miniboss_escorts", "counter_build_elite", "glass_cannon_blitz", "boss", "brawler_rush", "first_battle_intro"]
 	var templates := OpponentLoadouts.ARCHETYPE_TEMPLATES
 	var t8_ok := true
-	if templates.size() != 8:
+	if templates.size() != 9:
 		t8_ok = false
 	else:
 		var actual_ids := []
@@ -137,7 +137,7 @@ func _init() -> void:
 				t8_ok = false
 				break
 	if not t8_ok:
-		push_error("T8 FAIL: ARCHETYPE_TEMPLATES should have 8 records with locked IDs (got size=%d)" % templates.size())
+		push_error("T8 FAIL: ARCHETYPE_TEMPLATES should have 9 records with locked IDs (got size=%d)" % templates.size())
 		fail_count += 1
 	else:
 		pass_count += 1

--- a/godot/ui/run_start_screen.gd
+++ b/godot/ui/run_start_screen.gd
@@ -1,5 +1,6 @@
 ## Run Start screen — chassis selection for the roguelike run loop
 ## S25.1: Player picks one of 3 shuffled chassis to begin a new run.
+## Arc N: Chassis select replaced with single Brawler starter; select restored in Arc O.
 class_name RunStartScreen
 extends Control
 
@@ -9,26 +10,82 @@ var _rng: RandomNumberGenerator
 var _chassis_order: Array[int] = []
 
 func setup(rng_seed: int = 0) -> void:
-	_rng = RandomNumberGenerator.new()
-	if rng_seed == 0:
-		_rng.randomize()
-	else:
-		_rng.seed = rng_seed
-	# Shuffle-and-show-all-3: pool is exactly [Scout=0, Brawler=1, Fortress=2]
-	_chassis_order = [0, 1, 2]
-	# Fisher-Yates shuffle using seeded rng
-	for i in range(_chassis_order.size() - 1, 0, -1):
-		var j := _rng.randi_range(0, i)
-		var tmp := _chassis_order[i]
-		_chassis_order[i] = _chassis_order[j]
-		_chassis_order[j] = tmp
+	# CUT:ArcN — chassis select restored for Arc O
+	# _rng = RandomNumberGenerator.new()
+	# if rng_seed == 0:
+	# 	_rng.randomize()
+	# else:
+	# 	_rng.seed = rng_seed
+	# # Shuffle-and-show-all-3: pool is exactly [Scout=0, Brawler=1, Fortress=2]
+	# _chassis_order = [0, 1, 2]
+	# # Fisher-Yates shuffle using seeded rng
+	# for i in range(_chassis_order.size() - 1, 0, -1):
+	# 	var j := _rng.randi_range(0, i)
+	# 	var tmp := _chassis_order[i]
+	# 	_chassis_order[i] = _chassis_order[j]
+	# 	_chassis_order[j] = tmp
+	# /CUT:ArcN
 	_build_ui()
 
 func _build_ui() -> void:
 	set_anchors_preset(Control.PRESET_FULL_RECT)
 
+	# CUT:ArcN — chassis select UI restored for Arc O
+	# var title_old := Label.new()
+	# title_old.text = "⚡ CHOOSE YOUR BROTT"
+	# title_old.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	# title_old.add_theme_font_size_override("font_size", 36)
+	# title_old.position = Vector2(290, 100)
+	# title_old.size = Vector2(700, 60)
+	# add_child(title_old)
+
+	# var subtitle_old := Label.new()
+	# subtitle_old.text = "Pick a chassis to begin your run. Weapons and armor earned through battle."
+	# subtitle_old.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	# subtitle_old.add_theme_font_size_override("font_size", 16)
+	# subtitle_old.position = Vector2(290, 170)
+	# subtitle_old.size = Vector2(700, 30)
+	# add_child(subtitle_old)
+
+	# # Three chassis cards side by side
+	# var card_names := ["Scout", "Brawler", "Fortress"]
+	# var card_descs := [
+	# 	"Fast and light.\nLow HP. High speed.\nDodge-focused.",
+	# 	"Balanced fighter.\nMedium HP. 2 weapon slots.",
+	# 	"Heavy tank.\n High HP. Slow.\n3 weapon slots, 3 modules.",
+	# ]
+	# var card_x_positions := [130.0, 440.0, 750.0]
+
+	# for i in range(3):
+	# 	var chassis_type := _chassis_order[i]
+	# 	var btn_c := Button.new()
+	# 	btn_c.name = "ChassisBtn_%d" % chassis_type
+	# 	btn_c.text = "⚙ %s" % card_names[chassis_type]
+	# 	btn_c.position = Vector2(card_x_positions[i], 280)
+	# 	btn_c.size = Vector2(250, 200)
+	# 	btn_c.add_theme_font_size_override("font_size", 20)
+
+	# 	# Description label inside the button area
+	# 	var desc_c := Label.new()
+	# 	desc_c.text = card_descs[chassis_type]
+	# 	desc_c.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
+	# 	desc_c.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	# 	desc_c.add_theme_font_size_override("font_size", 13)
+	# 	desc_c.position = Vector2(card_x_positions[i], 490)
+	# 	desc_c.size = Vector2(250, 80)
+	# 	add_child(desc_c)
+
+	# 	var ct := chassis_type  # capture for closure
+	# 	# [S26.7 diagnostic] Replace lambda with bind() to sidestep any GDScript
+	# 	# closure-capture issues; emit print so we can verify the click lands.
+	# 	btn_c.pressed.connect(_on_card_pressed.bind(ct))
+	# 	add_child(btn_c)
+	# /CUT:ArcN
+
+	## Arc N: fixed Brawler starter — single "Start Run" button.
+	## chassis_type=1 (Brawler) always emitted; chassis select restored in Arc O.
 	var title := Label.new()
-	title.text = "⚡ CHOOSE YOUR BROTT"
+	title.text = "⚡ START YOUR RUN"
 	title.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
 	title.add_theme_font_size_override("font_size", 36)
 	title.position = Vector2(290, 100)
@@ -36,50 +93,28 @@ func _build_ui() -> void:
 	add_child(title)
 
 	var subtitle := Label.new()
-	subtitle.text = "Pick a chassis to begin your run. Weapons and armor earned through battle."
+	subtitle.text = "You are a Brawler. Weapons and armor earned through battle."
 	subtitle.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
 	subtitle.add_theme_font_size_override("font_size", 16)
 	subtitle.position = Vector2(290, 170)
 	subtitle.size = Vector2(700, 30)
 	add_child(subtitle)
 
-	# Three chassis cards side by side
-	var card_names := ["Scout", "Brawler", "Fortress"]
-	var card_descs := [
-		"Fast and light.\nLow HP. High speed.\nDodge-focused.",
-		"Balanced fighter.\nMedium HP. 2 weapon slots.",
-		"Heavy tank.\n High HP. Slow.\n3 weapon slots, 3 modules.",
-	]
-	var card_x_positions := [130.0, 440.0, 750.0]
+	var btn := Button.new()
+	btn.name = "StartRunBtn"
+	btn.text = "▶ Start Run"
+	btn.position = Vector2(440, 280)
+	btn.size = Vector2(400, 100)
+	btn.add_theme_font_size_override("font_size", 28)
+	btn.pressed.connect(_on_start_run_pressed)
+	add_child(btn)
 
-	for i in range(3):
-		var chassis_type := _chassis_order[i]
-		var btn := Button.new()
-		btn.name = "ChassisBtn_%d" % chassis_type
-		btn.text = "⚙ %s" % card_names[chassis_type]
-		btn.position = Vector2(card_x_positions[i], 280)
-		btn.size = Vector2(250, 200)
-		btn.add_theme_font_size_override("font_size", 20)
+# CUT:ArcN — _on_card_pressed restored for Arc O
+# func _on_card_pressed(chassis_type: int) -> void:
+# 	print("[S26.7] RunStartScreen: card pressed, ct=", chassis_type)
+# 	start_run_requested.emit(chassis_type)
 
-		# Description label inside the button area
-		var desc := Label.new()
-		desc.text = card_descs[chassis_type]
-		desc.horizontal_alignment = HORIZONTAL_ALIGNMENT_CENTER
-		desc.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
-		desc.add_theme_font_size_override("font_size", 13)
-		desc.position = Vector2(card_x_positions[i], 490)
-		desc.size = Vector2(250, 80)
-		add_child(desc)
-
-		var ct := chassis_type  # capture for closure
-		# [S26.7 diagnostic] Replace lambda with bind() to sidestep any GDScript
-		# closure-capture issues; emit print so we can verify the click lands.
-		btn.pressed.connect(_on_card_pressed.bind(ct))
-		add_child(btn)
-
-# [S26.7 diagnostic] Real method handler (instead of lambda) so chassis-type
-# binding is unambiguous. Also prints so we can confirm the button signal
-# fires through to game_main.
-func _on_card_pressed(chassis_type: int) -> void:
-	print("[S26.7] RunStartScreen: card pressed, ct=", chassis_type)
-	start_run_requested.emit(chassis_type)
+## Arc N: "Start Run" handler — always emits Brawler (chassis_type=1).
+func _on_start_run_pressed() -> void:
+	print("[ArcN] RunStartScreen: Start Run pressed — emitting Brawler (chassis_type=1)")
+	start_run_requested.emit(1)


### PR DESCRIPTION
## Arc N — Sub-sprint N.1

### What
- Replaces chassis select with single Brawler+Shotgun starter (`#CUT:ArcN` preserves old logic)
- Adds `first_battle_intro` archetype to `ARCHETYPE_TEMPLATES` with T1 enemy spec
- Battle index 0 always pulls `first_battle_intro`, bypassing weighted schedule
- Adds `speed_override`, `fire_rate_override`, `target_hp`, `stance` schema fields to enemy_spec
- `combat_sim.gd` applies `fire_rate_override` in `_fire_weapons()`
- `game_main.gd` applies `speed_override`, `fire_rate_override`, `stance` on enemy BrottState init
- `BrottState` gains `speed_override` + `fire_rate_override` fields; `get_effective_speed()` respects override
- AutoDriver assertions: chassis=Brawler, enemy spec correct, fight duration 20-40s, player win rate 80pct
- GDD updated: §13.1 Arc N note, §13.4 first_battle_intro spec

### DoD
- [ ] Brawler+Shotgun starter spawns correctly
- [ ] T1 first_battle_intro: HP=750, speed=50px/s, fire_rate=0.4 shots/s verified in AutoDriver
- [ ] Fight duration asserted 20-40s (50-seed batch)
- [ ] Player win rate 80pct+