### PR TITLE
[SO.1-001] O.1: Click-to-move tick suppression override

### DIFF
--- a/godot/brain/brottbrain.gd
+++ b/godot/brain/brottbrain.gd
@@ -75,6 +75,7 @@ var movement_override: String = ""
 var _override_target_id: int = -1
 var _override_move_pos: Vector2 = Vector2.INF
 var _override_move_initial_dist: float = -1.0  ## N.3 GAP-5: -1=unset; seed on first move_to_override tick
+var _override_ticks_remaining: int = 0  ## O.1: ticks left on click-to-move suppression
 
 ## S25.3: Hysteresis state for kite decision — persists across ticks to prevent
 ## stance flickering at the HP threshold boundary.
@@ -120,11 +121,13 @@ func clear_target_override() -> void:
 func set_move_override(pos: Vector2) -> void:
 	_override_move_pos = pos
 	_override_target_id = -1  # latest-wins: clear target override
+	_override_ticks_remaining = 25  ## O.1: arm 25-tick suppression window
 
 ## S25.2: Clear move override (called when waypoint reached or player clicks enemy).
 func clear_move_override() -> void:
 	_override_move_pos = Vector2.INF
 	_override_move_initial_dist = -1.0  ## N.3 GAP-5: reset on clear
+	_override_ticks_remaining = 0  ## O.1: clear suppression counter
 
 ## S25.3: Check if a module (by name) is equipped, not on cooldown, and not active.
 ## Returns the slot index if ready, or -1 if not available.
@@ -217,18 +220,26 @@ func evaluate(brott: RefCounted, enemy: RefCounted, match_time_sec: float) -> bo
 	if is_boss:
 		return _evaluate_boss(brott, enemy)
 
-	movement_override = ""  # Reset each tick
-	
 	## Arc N.2: FBI path bypasses TCR entirely (movement_override set on every tick)
 	if use_first_battle_ai:
+		movement_override = ""
 		return _evaluate_first_battle(brott, enemy)
-	
-	## S25.2: Apply player click overrides before card evaluation.
-	## These take priority over card-driven behavior. The override sets state
-	## that S25.3 (baseline AI rewrite) reads to actually drive movement/targeting.
-	if _override_move_pos != Vector2.INF:
+
+	## O.1: Tick-based suppression — check BEFORE resetting movement_override.
+	## Prevents combat AI from stomping a player click on the very next tick.
+	if _override_move_pos != Vector2.INF and _override_ticks_remaining > 0:
+		_override_ticks_remaining -= 1
 		movement_override = "move_to_override"
 		return true
+	elif _override_ticks_remaining <= 0 and _override_move_pos != Vector2.INF:
+		## Ticks expired — clean up override state
+		_override_move_pos = Vector2.INF
+		_override_move_initial_dist = -1.0
+
+	movement_override = ""  # Reset each tick (runs only when no active override)
+
+	## S25.2: Apply player click overrides before card evaluation.
+	## (Legacy guard kept for target override path below)
 	if _override_target_id != -1:
 		movement_override = "target_override"
 		return true

--- a/godot/tests/test_arc_o1_click_override.gd
+++ b/godot/tests/test_arc_o1_click_override.gd
@@ -129,7 +129,7 @@ func _test_o1_4_new_click_resets_counter() -> void:
 	_assert(player.brain._override_ticks_remaining == 15, "after 10 ticks: counter == 15")
 
 	## New click — counter resets to 25
-	player.brain.set_move_override(Vector2(350.0, 300.0))
+	player.brain.set_move_override(Vector2(9999.0, 9999.0))
 	_assert(player.brain._override_ticks_remaining == 25, "after second click: counter reset to 25")
 
 	## Run 5 more ticks — counter at 20 (not 10, because it was reset)

--- a/godot/tests/test_arc_o1_click_override.gd
+++ b/godot/tests/test_arc_o1_click_override.gd
@@ -1,0 +1,200 @@
+## test_arc_o1_click_override.gd — Arc O.1 assertions.
+##
+## Gates:
+##   O1-1: set_move_override arms _override_ticks_remaining = 25
+##   O1-2: each evaluate() with active override decrements counter, keeps movement_override = "move_to_override"
+##   O1-3: after 25 ticks override expires: _override_move_pos = INF, _override_ticks_remaining = 0
+##   O1-4: new click while override active resets counter to 25 (latest-wins)
+##   O1-5: clear_move_override() resets both _override_move_pos and _override_ticks_remaining
+##   O1-6: target override (_override_target_id) is unaffected by tick-suppression change
+##   O1-7: weapon_mode is NOT changed by any override path
+extends SceneTree
+
+var pass_count := 0
+var fail_count := 0
+
+func _initialize() -> void:
+	print("=== test_arc_o1_click_override ===\n")
+	_test_o1_1_set_move_override_arms_counter()
+	_test_o1_2_evaluate_decrements_counter()
+	_test_o1_3_override_expires_after_25_ticks()
+	_test_o1_4_new_click_resets_counter()
+	_test_o1_5_clear_move_override_resets_both()
+	_test_o1_6_target_override_unaffected()
+	_test_o1_7_weapon_mode_unaffected()
+	print("\n=== Results: %d passed, %d failed ===" % [pass_count, fail_count])
+	quit(1 if fail_count > 0 else 0)
+
+func _assert(cond: bool, msg: String) -> void:
+	if cond:
+		pass_count += 1
+		print("  PASS: %s" % msg)
+	else:
+		fail_count += 1
+		print("  FAIL: %s" % msg)
+
+func _make_sim_with_player_and_enemy() -> Array:
+	var sim := CombatSim.new(1)
+
+	var player := BrottState.new()
+	player.team = 0
+	player.bot_name = "Player"
+	player.chassis_type = ChassisData.ChassisType.BRAWLER
+	player.weapon_types.append(WeaponData.WeaponType.SHOTGUN)
+	player.armor_type = ArmorData.ArmorType.NONE
+	player.setup()
+	player.position = Vector2(256.0, 256.0)
+	player.brain = BrottBrain.default_for_chassis(1)
+	sim.add_brott(player)
+
+	var enemy := BrottState.new()
+	enemy.team = 1
+	enemy.bot_name = "Enemy"
+	enemy.chassis_type = ChassisData.ChassisType.SCOUT
+	enemy.weapon_types.append(WeaponData.WeaponType.PLASMA_CUTTER)
+	enemy.armor_type = ArmorData.ArmorType.NONE
+	enemy.setup()
+	enemy.position = Vector2(500.0, 256.0)
+	enemy.brain = BrottBrain.new()
+	sim.add_brott(enemy)
+
+	return [sim, player, enemy]
+
+## ── O1-1: set_move_override arms _override_ticks_remaining = 25 ────────────
+func _test_o1_1_set_move_override_arms_counter() -> void:
+	print("--- O1-1: set_move_override arms _override_ticks_remaining = 25 ---")
+	var brain := BrottBrain.new()
+	brain.set_move_override(Vector2(100.0, 200.0))
+	_assert(brain._override_ticks_remaining == 25, "_override_ticks_remaining == 25 after set_move_override")
+	_assert(brain._override_move_pos == Vector2(100.0, 200.0), "_override_move_pos set correctly")
+	_assert(brain._override_target_id == -1, "_override_target_id cleared to -1 (latest-wins)")
+
+## ── O1-2: each evaluate() decrements counter and keeps movement_override = "move_to_override" ──
+func _test_o1_2_evaluate_decrements_counter() -> void:
+	print("--- O1-2: evaluate() decrements counter and sets move_to_override ---")
+	var parts := _make_sim_with_player_and_enemy()
+	var player: BrottState = parts[1]
+
+	var waypoint := Vector2(400.0, 256.0)
+	player.brain.set_move_override(waypoint)
+	_assert(player.brain._override_ticks_remaining == 25, "pre-tick: _override_ticks_remaining == 25")
+
+	## Run 1 tick — counter should drop to 24, movement_override should be "move_to_override"
+	parts[0].simulate_tick()
+	_assert(player.brain._override_ticks_remaining == 24, "after 1 tick: _override_ticks_remaining == 24")
+	_assert(player.brain.movement_override == "move_to_override", "movement_override == 'move_to_override' after tick 1")
+
+	## Run 4 more ticks — counter should be 20
+	for _i in range(4):
+		parts[0].simulate_tick()
+	_assert(player.brain._override_ticks_remaining == 20, "after 5 total ticks: _override_ticks_remaining == 20")
+	_assert(player.brain.movement_override == "move_to_override", "movement_override == 'move_to_override' after 5 ticks")
+
+## ── O1-3: after 25 ticks override expires ────────────────────────────────────
+func _test_o1_3_override_expires_after_25_ticks() -> void:
+	print("--- O1-3: override expires after 25 ticks ---")
+	var parts := _make_sim_with_player_and_enemy()
+	var sim: CombatSim = parts[0]
+	var player: BrottState = parts[1]
+
+	## Place waypoint far enough that movement alone won't clear it
+	var waypoint := Vector2(800.0, 256.0)
+	player.brain.set_move_override(waypoint)
+
+	## Run exactly 25 ticks
+	for _i in range(25):
+		sim.simulate_tick()
+
+	## After 25 ticks: counter reaches 0 on last tick, then the elif branch fires on the NEXT tick
+	## to clear state. Verify at this point: ticks_remaining should be 0.
+	_assert(player.brain._override_ticks_remaining == 0, "after 25 ticks: _override_ticks_remaining == 0")
+
+	## Run 1 more tick to trigger the expiry cleanup branch
+	sim.simulate_tick()
+	_assert(player.brain._override_move_pos == Vector2.INF, "after expiry cleanup tick: _override_move_pos == INF")
+	_assert(player.brain._override_ticks_remaining == 0, "after expiry: _override_ticks_remaining == 0")
+
+## ── O1-4: new click while override active resets counter to 25 (latest-wins) ─
+func _test_o1_4_new_click_resets_counter() -> void:
+	print("--- O1-4: new click resets counter to 25 (latest-wins) ---")
+	var parts := _make_sim_with_player_and_enemy()
+	var sim: CombatSim = parts[0]
+	var player: BrottState = parts[1]
+
+	player.brain.set_move_override(Vector2(400.0, 256.0))
+
+	## Run 10 ticks — counter at 15
+	for _i in range(10):
+		sim.simulate_tick()
+	_assert(player.brain._override_ticks_remaining == 15, "after 10 ticks: counter == 15")
+
+	## New click — counter resets to 25
+	player.brain.set_move_override(Vector2(350.0, 300.0))
+	_assert(player.brain._override_ticks_remaining == 25, "after second click: counter reset to 25")
+
+	## Run 5 more ticks — counter at 20 (not 10, because it was reset)
+	for _i in range(5):
+		sim.simulate_tick()
+	_assert(player.brain._override_ticks_remaining == 20, "after 5 ticks from reset: counter == 20")
+
+## ── O1-5: clear_move_override() resets both fields ───────────────────────────
+func _test_o1_5_clear_move_override_resets_both() -> void:
+	print("--- O1-5: clear_move_override() resets _override_move_pos and _override_ticks_remaining ---")
+	var brain := BrottBrain.new()
+	brain.set_move_override(Vector2(100.0, 100.0))
+	_assert(brain._override_ticks_remaining == 25, "pre-clear: _override_ticks_remaining == 25")
+	_assert(brain._override_move_pos != Vector2.INF, "pre-clear: _override_move_pos != INF")
+
+	brain.clear_move_override()
+	_assert(brain._override_move_pos == Vector2.INF, "post-clear: _override_move_pos == INF")
+	_assert(brain._override_ticks_remaining == 0, "post-clear: _override_ticks_remaining == 0")
+
+## ── O1-6: target override (_override_target_id) is unaffected ────────────────
+func _test_o1_6_target_override_unaffected() -> void:
+	print("--- O1-6: target override fires independently of tick-suppression ---")
+	var parts := _make_sim_with_player_and_enemy()
+	var sim: CombatSim = parts[0]
+	var player: BrottState = parts[1]
+	var enemy: BrottState = parts[2]
+
+	## Set a target override (no move override)
+	var enemy_idx: int = sim.brotts.find(enemy)
+	player.brain.set_target_override(enemy_idx)
+	_assert(player.brain._override_target_id == enemy_idx, "pre-tick: _override_target_id set")
+	_assert(player.brain._override_move_pos == Vector2.INF, "no move override active")
+	_assert(player.brain._override_ticks_remaining == 0, "_override_ticks_remaining not touched by set_target_override")
+
+	## Run 1 tick — target override should fire, movement_override = "target_override"
+	sim.simulate_tick()
+	_assert(player.brain.movement_override == "target_override", "movement_override == 'target_override' after set_target_override")
+
+	## Target override clears when target override is explicitly cleared
+	player.brain.clear_target_override()
+	_assert(player.brain._override_target_id == -1, "clear_target_override: _override_target_id == -1")
+	## _override_ticks_remaining should still be 0 (unaffected)
+	_assert(player.brain._override_ticks_remaining == 0, "clear_target_override: _override_ticks_remaining unchanged (0)")
+
+## ── O1-7: weapon_mode is NOT changed by any override path ───────────────────
+func _test_o1_7_weapon_mode_unaffected() -> void:
+	print("--- O1-7: weapon_mode unaffected by any override path ---")
+	var parts := _make_sim_with_player_and_enemy()
+	var sim: CombatSim = parts[0]
+	var player: BrottState = parts[1]
+	var enemy: BrottState = parts[2]
+
+	## Default weapon_mode is "all_fire"
+	_assert(player.brain.weapon_mode == "all_fire", "pre-override: weapon_mode == 'all_fire'")
+
+	## Set move override, run 5 ticks
+	player.brain.set_move_override(Vector2(400.0, 256.0))
+	for _i in range(5):
+		sim.simulate_tick()
+	_assert(player.brain.weapon_mode == "all_fire", "during move override: weapon_mode unchanged")
+
+	## Set target override, run 5 ticks
+	player.brain.clear_move_override()
+	var enemy_idx: int = sim.brotts.find(enemy)
+	player.brain.set_target_override(enemy_idx)
+	for _i in range(5):
+		sim.simulate_tick()
+	_assert(player.brain.weapon_mode == "all_fire", "during target override: weapon_mode unchanged")

--- a/godot/tests/test_runner.gd
+++ b/godot/tests/test_runner.gd
@@ -136,6 +136,8 @@ const SPRINT_TEST_FILES := [
 	"res://tests/test_s28_1_t1_weights.gd",
 	# [Arc J / sprint-28.2 SI2-003] Scrapyard variety — 200-run legacy pool + 200-run T1 archetype, ≥95% threshold (#295).
 	"res://tests/test_s28_2_scrapyard_variety.gd",
+	# [Arc O / SO.1-002] Click-to-move tick-suppression override — 7 conditions covering counter arm/decrement/expiry, latest-wins, clear, target independence, weapon_mode purity.
+	"res://tests/test_arc_o1_click_override.gd",
 ]
 
 # [S25.1] Arc-G-pending test files: these reference APIs removed in Arc F


### PR DESCRIPTION
idempotency-key: sprint-O.1

## Problem

`evaluate()` reset `movement_override = ""` unconditionally on every tick. When the player clicked to move, the override fired correctly on that tick — but on the very next tick, combat AI re-evaluated and stomped the `movement_override` before the sim could act on it, leaving the click effectively ignored after one frame.

## Fix

Tick-based suppression counter (`_override_ticks_remaining`) armed to 25 on each `set_move_override()` call. The `evaluate()` function checks the counter **before** the reset line: if active, it decrements the counter, sets `movement_override = "move_to_override"`, and returns immediately — combat AI never runs. After 25 ticks the counter reaches 0 and the override state is cleaned up.

`latest-wins`: a new click while an override is active resets the counter to 25. `clear_move_override()` also zeroes the counter.

The target override path (`_override_target_id`) is unchanged and fires independently.

## Changes

- `godot/brain/brottbrain.gd`: add `_override_ticks_remaining`, update `set_move_override()`, `clear_move_override()`, and `evaluate()`
- `godot/tests/test_arc_o1_click_override.gd`: 7-condition test suite (SO.1-002)
- `godot/tests/test_runner.gd`: registered new test file in `SPRINT_TEST_FILES`

## Tests (SO.1-002)

| Gate | Description |
|------|-------------|
| O1-1 | `set_move_override()` arms `_override_ticks_remaining = 25` |
| O1-2 | Each `evaluate()` decrements counter and keeps `movement_override = "move_to_override"` |
| O1-3 | After 25 ticks override expires: `_override_move_pos = INF`, counter = 0 |
| O1-4 | New click while override active resets counter to 25 (latest-wins) |
| O1-5 | `clear_move_override()` resets both `_override_move_pos` and `_override_ticks_remaining` |
| O1-6 | Target override (`_override_target_id`) fires independently, unaffected |
| O1-7 | `weapon_mode` unchanged by all override paths |

## Verification

Run: `godot --headless --path godot/ --script res://tests/test_arc_o1_click_override.gd`