### PR TITLE
[sprint-O.2] [SO.2-001] O.2: Brawler speed 120→60 px/s with enemy speed_override

### DIFF
--- a/godot/data/chassis_data.gd
+++ b/godot/data/chassis_data.gd
@@ -23,9 +23,9 @@ const CHASSIS := {
 	ChassisType.BRAWLER: {
 		"name": "Brawler",
 		"hp": 360,  # K.3: +22% HP buff to lift T1 battle win-rate ≥30% (was 295, #314)
-		"speed": 120.0,
-		"accel": 240.0,
-		"decel": 360.0,
+		"speed": 60.0,    # O.2: 120→60 px/s (too fast to follow visually)
+		"accel": 120.0,   # O.2: halved proportionally (was 240.0)
+		"decel": 180.0,   # O.2: halved proportionally (was 360.0)
 		"turn_speed": 240.0,
 		"weight_cap": 55,
 		"weapon_slots": 2,

--- a/godot/data/opponent_loadouts.gd
+++ b/godot/data/opponent_loadouts.gd
@@ -565,7 +565,7 @@ const ARCHETYPE_TEMPLATES: Array[Dictionary] = [
 		"id": "brawler_rush",
 		"display_name": "Brawler Rush",
 		"enemy_specs": [
-			{"chassis": 1, "weapons": [2], "armor": 0, "modules": [], "hp_pct": 0.5, "count": 1}
+			{"chassis": 1, "weapons": [2], "armor": 0, "modules": [], "hp_pct": 0.5, "speed_override": 120.0, "count": 1}  # O.2: speed_override retains enemy speed at 120 px/s despite chassis_data halving player Brawler to 60 px/s
 		]
 	},
 	{

--- a/godot/tests/test_arc_o2_brawler_speed.gd
+++ b/godot/tests/test_arc_o2_brawler_speed.gd
@@ -1,0 +1,58 @@
+## test_arc_o2_brawler_speed.gd
+## [Arc O.2] SO.2-001–004: Brawler chassis speed halved (120→60 px/s) with enemy speed_override.
+## Usage: godot --headless --path godot/ --script res://tests/test_arc_o2_brawler_speed.gd
+
+extends SceneTree
+
+var pass_count := 0
+var fail_count := 0
+var test_count := 0
+
+func _initialize() -> void:
+	print("=== test_arc_o2_brawler_speed ===\n")
+	_test_o2_brawler_chassis_speed()
+	_test_o2_scout_unchanged()
+	_test_o2_fortress_unchanged()
+	_test_o2_brawler_rush_speed_override()
+	print("\n=== Results: %d passed, %d failed, %d total ===" % [pass_count, fail_count, test_count])
+	quit(1 if fail_count > 0 else 0)
+
+func _assert(cond: bool, msg: String) -> void:
+	test_count += 1
+	if cond:
+		pass_count += 1
+		print("  PASS: %s" % msg)
+	else:
+		fail_count += 1
+		print("  FAIL: %s" % msg)
+
+func _test_o2_brawler_chassis_speed() -> void:
+	print("--- SO.2-001: Brawler chassis speed/accel/decel halved ---")
+	var brawler := ChassisData.CHASSIS[ChassisData.ChassisType.BRAWLER]
+	_assert(absf(float(brawler["speed"]) - 60.0) < 0.01, "Brawler speed == 60.0 px/s (O.2: was 120.0)")
+	_assert(absf(float(brawler["accel"]) - 120.0) < 0.01, "Brawler accel == 120.0 px/s² (O.2: was 240.0)")
+	_assert(absf(float(brawler["decel"]) - 180.0) < 0.01, "Brawler decel == 180.0 px/s² (O.2: was 360.0)")
+
+func _test_o2_scout_unchanged() -> void:
+	print("--- SO.2-002: Scout speed unchanged ---")
+	var scout := ChassisData.CHASSIS[ChassisData.ChassisType.SCOUT]
+	_assert(absf(float(scout["speed"]) - 220.0) < 0.01, "Scout speed == 220.0 px/s (unchanged by O.2)")
+
+func _test_o2_fortress_unchanged() -> void:
+	print("--- SO.2-003: Fortress speed unchanged ---")
+	var fortress := ChassisData.CHASSIS[ChassisData.ChassisType.FORTRESS]
+	_assert(absf(float(fortress["speed"]) - 60.0) < 0.01, "Fortress speed == 60.0 px/s (unchanged by O.2)")
+
+func _test_o2_brawler_rush_speed_override() -> void:
+	print("--- SO.2-004: brawler_rush enemy spec has speed_override == 120.0 ---")
+	## compose_encounter resolves the enemy template and forwards override fields.
+	## We verify the composed spec carries speed_override=120.0 so the enemy Brawler
+	## keeps its original 120 px/s speed despite the chassis_data player change.
+	var specs := OpponentLoadouts.compose_encounter("brawler_rush", 1, null)
+	_assert(specs.size() > 0, "brawler_rush compose_encounter returns at least one spec")
+	if specs.size() > 0:
+		var spec: Dictionary = specs[0]
+		_assert("speed_override" in spec, "brawler_rush spec has 'speed_override' field")
+		if "speed_override" in spec:
+			_assert(absf(float(spec["speed_override"]) - 120.0) < 0.01,
+				"brawler_rush speed_override == 120.0 (enemy retains pre-O.2 speed)")

--- a/godot/tests/test_runner.gd
+++ b/godot/tests/test_runner.gd
@@ -138,6 +138,8 @@ const SPRINT_TEST_FILES := [
 	"res://tests/test_s28_2_scrapyard_variety.gd",
 	# [Arc O / SO.1-002] Click-to-move tick-suppression override — 7 conditions covering counter arm/decrement/expiry, latest-wins, clear, target independence, weapon_mode purity.
 	"res://tests/test_arc_o1_click_override.gd",
+	# [Arc O / SO.2-001–004] Brawler speed 120→60 px/s; enemy brawler_rush retains 120 px/s via speed_override.
+	"res://tests/test_arc_o2_brawler_speed.gd",
 ]
 
 # [S25.1] Arc-G-pending test files: these reference APIs removed in Arc F

--- a/godot/tests/test_runner.gd
+++ b/godot/tests/test_runner.gd
@@ -337,7 +337,7 @@ func _run_data_tests() -> void:
 	
 	var brawler := ChassisData.get_chassis(ChassisData.ChassisType.BRAWLER)
 	assert_eq(brawler["hp"], 360, "Brawler HP = 360 (K.3 T1 balance fix, #314)")  # Updated for J.5 per-chassis T1 tuning (sprint-28.5)
-	assert_near(brawler["speed"], 120.0, 0.1, "Brawler speed = 120")
+	assert_near(brawler["speed"], 60.0, 0.1, "Brawler speed = 60 (O.2: was 120.0)")
 	assert_eq(brawler["weapon_slots"], 2, "Brawler weapon slots = 2")
 	assert_eq(brawler["module_slots"], 2, "Brawler module slots = 2")
 	

--- a/godot/tests/test_sprint12_1.gd
+++ b/godot/tests/test_sprint12_1.gd
@@ -50,8 +50,8 @@ func test_chassis_accel_decel_values() -> void:
 	_assert(scout["turn_speed"] == 360.0, "Scout turn_speed = 360")
 
 	var brawler := ChassisData.get_chassis(ChassisData.ChassisType.BRAWLER)
-	_assert(brawler["accel"] == 240.0, "Brawler accel = 240")
-	_assert(brawler["decel"] == 360.0, "Brawler decel = 360")
+	_assert(brawler["accel"] == 120.0, "Brawler accel = 120 (O.2: was 240.0)")
+	_assert(brawler["decel"] == 180.0, "Brawler decel = 180 (O.2: was 360.0)")
 	_assert(brawler["turn_speed"] == 240.0, "Brawler turn_speed = 240")
 
 	var fortress := ChassisData.get_chassis(ChassisData.ChassisType.FORTRESS)


### PR DESCRIPTION
idempotency-key: sprint-O.2

## Problem (SO.2-001)

At 120 px/s the player Brawler moves too fast to follow visually — players lose spatial tracking of their own unit during combat, which undermines the Brawler's identity as a sturdy, deliberate fighter. HCD flagged this in Arc O.2 playtest feedback.

## Fix

**SO.2-001 — `godot/data/chassis_data.gd`**
Halve the Brawler's movement stats:
- speed: 120.0 → 60.0 px/s
- accel: 240.0 → 120.0 px/s² (proportional)
- decel: 360.0 → 180.0 px/s² (proportional)

This brings Brawler to parity with Fortress on raw speed (both 60 px/s), reinforcing the \slow-and-tough\ T2 chassis tier, while Scout stays at 220 px/s as the nimble contrast.

**SO.2-002 (Option B) — `godot/data/opponent_loadouts.gd`**
Added `speed_override: 120.0` to the `brawler_rush` enemy spec. The chassis_data change applies to both player and enemy Brawlers, which would inadvertently slow the enemy encounter and make it trivial. `speed_override` (already supported by `BrottState.get_effective_speed()` and forwarded by `compose_encounter()`) pins the enemy at its original 120 px/s. This mirrors exactly how `first_battle_intro` uses `speed_override: 50.0` to tune the tutorial enemy independently of chassis defaults.

## Tests (SO.2-003 + SO.2-004)

`godot/tests/test_arc_o2_brawler_speed.gd` — 7 assertions across 4 test functions:
1. `_test_o2_brawler_chassis_speed` — speed==60.0, accel==120.0, decel==180.0
2. `_test_o2_scout_unchanged` — Scout speed==220.0 (no regression)
3. `_test_o2_fortress_unchanged` — Fortress speed==60.0 (no regression)
4. `_test_o2_brawler_rush_speed_override` — composed brawler_rush spec carries speed_override==120.0

Registered in `SPRINT_TEST_FILES` in `test_runner.gd`.

## How to verify

```
godot --headless --path godot/ --script res://tests/test_arc_o2_brawler_speed.gd
```

Expected: 7 passed, 0 failed.